### PR TITLE
Fix status being disabled on first render

### DIFF
--- a/src/app/internships/internship-overview/internship-overview-sidebar/internship-overview-sidebar.component.ts
+++ b/src/app/internships/internship-overview/internship-overview-sidebar/internship-overview-sidebar.component.ts
@@ -4,9 +4,9 @@ import { Sensitivity } from '@app/core/models/sensitivity';
 import { InternshipService } from '@app/core/services/internship.service';
 import { skipEmptyViewState, TypedFormGroup } from '@app/core/util';
 import { InternshipViewStateService } from '@app/internships/internship-view-state.service';
-import { emptyOptions } from '@app/shared/components/status-select-workflow/status-select-workflow.component';
 import { SubscriptionComponent } from '@app/shared/components/subscription.component';
-import { takeUntil } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map, takeUntil } from 'rxjs/operators';
 
 interface Form {
   sensitivity: Sensitivity;
@@ -23,6 +23,7 @@ export class InternshipOverviewSidebarComponent extends SubscriptionComponent im
   readonly Sensitivity = Sensitivity;
 
   form: TypedFormGroup<Form>;
+  internship$: Observable<Internship>;
   internship: Internship | null;
 
   constructor(
@@ -32,11 +33,14 @@ export class InternshipOverviewSidebarComponent extends SubscriptionComponent im
     super();
   }
 
-  findAvailableStatuses = () => this.internship ? this.internships.getAvailableStatuses(this.internship) : emptyOptions;
+  findAvailableStatuses = () => this.internship$.pipe(
+    map(internship => this.internships.getAvailableStatuses(internship)),
+  );
 
   ngOnInit(): void {
-    this.viewState.subject
-      .pipe(skipEmptyViewState(), takeUntil(this.unsubscribe))
+    this.internship$ = this.viewState.subject.pipe(skipEmptyViewState());
+    this.internship$
+      .pipe(takeUntil(this.unsubscribe))
       .subscribe(i => this.internship = i);
 
     this.form = this.viewState.fb.group<Form>(this.unsubscribe, {


### PR DESCRIPTION
The problem was `Project/InternshipService.getAvailableStatus` was getting called before the internship/project property had been set.
I fixed this by allowing `findAvailableStatuses` input to return a promise or observable so the implementor can wait for their objects to be set.