### PR TITLE
Titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@material-ui/core": "^4.9.9",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.48",
+    "constate": "^2.0.0",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-app-rewired": "^2.1.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { CssBaseline, ThemeProvider } from '@material-ui/core';
 import React, { cloneElement, FC, ReactElement } from 'react';
 import { BrowserRouter } from 'react-router-dom';
+import { TitleProvider } from './components/title';
 import { createTheme } from './theme';
 
 const theme = createTheme();
@@ -12,6 +13,7 @@ const theme = createTheme();
 const providers = [
   <ThemeProvider theme={theme} children={<></>} />,
   <BrowserRouter />,
+  <TitleProvider title="CORD Field" />,
 ];
 
 export const App = () => (

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -1,0 +1,69 @@
+import createContainer from 'constate';
+import { unionBy } from 'lodash';
+import { useEffect, useState } from 'react';
+
+export const Title = ({ title }: { title: string }) => {
+  useTitle(title);
+  return null;
+};
+
+export const useTitle = (title?: string) => {
+  const context = useTitleContext();
+  const [id] = useState(uniqid);
+  // Ignore context changes which change when the title changes
+  // which creates an infinite loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => context.register(id, title), [id, title]);
+};
+
+interface TitleState {
+  string?: string;
+  id?: string;
+}
+
+const useTitles = ({ title = '', divider = ' - ', append = false }) => {
+  const [titles, setTitles] = useState<TitleState[]>([]);
+
+  // Reset old title on unmount
+  useEffect(() => {
+    const oldTitle = document.title;
+    return () => {
+      document.title = oldTitle;
+    };
+  }, []);
+
+  useEffect(() => {
+    const allTitles = [{ string: title }, ...titles];
+    if (!append) {
+      allTitles.reverse();
+    }
+    document.title = joinTitles(allTitles, divider);
+  }, [titles, divider, append, title]);
+
+  function register(id: string, string?: string) {
+    const object = { id, string };
+    setTitles((state) => unionBy(state, [object], 'id'));
+    return function unregister() {
+      const id = object.id;
+      setTitles((state) => state.filter((item) => item.id !== id));
+    };
+  }
+
+  return { register, titles };
+};
+
+const [TitleProvider, useTitleContext] = createContainer(useTitles);
+export { TitleProvider };
+
+const joinTitles = (titles: TitleState[], divider: string) =>
+  titles
+    .map((item) => item.string)
+    .filter((item) => item)
+    .join(divider);
+
+const uniqid = () => {
+  const time = Date.now();
+  const last = uniqid.last || time;
+  return (uniqid.last = time > last ? time : last + 1).toString(36);
+};
+uniqid.last = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4348,6 +4348,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"constate@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "constate@npm:2.0.0"
+  peerDependencies:
+    react: ^16.8.0
+  checksum: 2/f508ff6705fa393434af3495f86812ad23afc186f88c140600cd4ddea02dc98cb12278b939748297475bed78bda9553d39eaaef282b82e1883c3141204f4b016
+  languageName: node
+  linkType: hard
+
 "contains-path@npm:^0.1.0":
   version: 0.1.0
   resolution: "contains-path@npm:0.1.0"
@@ -4443,6 +4452,7 @@ __metadata:
     "@types/react-dom": ^16.9.0
     babel-plugin-import: ^1.13.0
     babel-plugin-mui-make-styles: ^0.1.1
+    constate: ^2.0.0
     customize-cra: ^0.9.1
     eslint: ^6.8.0
     husky: ^4.2.5


### PR DESCRIPTION
Adds `useTitle` hook and `Title` component to set pieces of the page title in a tree structure

Simple example with routing omitted:
Page title is `Notifications - Profile - CORD Field`
```tsx
const App = () => (
  <TitleProvider title="CORD Field">
    <Profile />
  </TitleProvider>
);

const Profile = () => (
  <div>
    <Title title="Profile" />
    <Notifications />
    ....
  </div>
);

const Notifications = () => {
  useTitle('Notifications');
  return <div>...</div>;
};
```

Also updates automatically with dynamic labels that need to be fetched from API