### PR TITLE
Picture Abstraction (Responsive, Placeholders, Lazy-Loading)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-intersection-observer": "^8.25.1",
     "react-router": "^6.0.0-alpha.3",
     "react-router-dom": "^6.0.0-alpha.3",
-    "react-scripts": "^3.4.1"
+    "react-scripts": "^3.4.1",
+    "react-use": "^14.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@material-ui/core": "^4.9.9",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.48",
+    "clsx": "^1.1.0",
     "constate": "^2.0.0",
     "lodash": "^4.17.15",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^16.13.1",
     "react-app-rewired": "^2.1.5",
     "react-dom": "^16.13.1",
+    "react-intersection-observer": "^8.25.1",
     "react-router": "^6.0.0-alpha.3",
     "react-router-dom": "^6.0.0-alpha.3",
     "react-scripts": "^3.4.1"

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
 
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script crossorigin="anonymous" src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserverEntry%2CIntersectionObserver%2CResizeObserver%2CAbortController"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -41,14 +41,14 @@ export interface LayoutProps {
   /** The image's natural height */
   height?: number;
   /**
-   * How does the image size itself in regards to its parent?
+   * How does the image fit itself in regards to its parent?
    * - auto     - image will grow proportionally as large as it can (default)
    * - contain  - image will not go beyond its natural size
    *              and will center itself within its parent
    * - cover    - image WILL go beyond its natural size to completely cover the
    *              parent. This could result in parts of the image being hidden.
    */
-  size?: 'auto' | 'contain' | 'cover';
+  fit?: 'auto' | 'contain' | 'cover';
   /**
    * Image is to be used as a background
    * This will absolutely position the element to fill the parent.
@@ -167,7 +167,7 @@ const PictureImpl = ({
   // Layout Props
   width,
   height,
-  size = 'auto',
+  fit = 'auto',
   background,
   // Lazy Props
   lazy: lazyProp,
@@ -327,11 +327,11 @@ const PictureImpl = ({
     img
   );
 
-  if (size === 'auto' && background) {
+  if (fit === 'auto' && background) {
     return <div className={classes.background}>{held}</div>;
   }
 
-  if (size === 'contain') {
+  if (fit === 'contain') {
     return (
       <div
         className={clsx({
@@ -345,8 +345,8 @@ const PictureImpl = ({
     );
   }
 
-  if (size === 'cover') {
-    throw new Error('<Picture size="cover"> is not yet implemented');
+  if (fit === 'cover') {
+    throw new Error('<Picture fit="cover"> is not yet implemented');
   }
 
   return held;

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -102,9 +102,16 @@ export interface PlaceholderStyles {
   filter?: string;
 }
 
+export interface EffectsProps {
+  /**
+   * Darken the image by a percentage (0-100)
+   */
+  darken?: number;
+}
+
 export type PictureProps = Merge<
   Omit<JSX.IntrinsicElements['img'], 'ref' | 'src' | 'srcSet'>,
-  SourceProps & LayoutProps & LazyProps & PlaceholderProps
+  SourceProps & LayoutProps & LazyProps & PlaceholderProps & EffectsProps
 >;
 
 const useStyles = makeStyles(() => ({
@@ -123,6 +130,17 @@ const useStyles = makeStyles(() => ({
     left: 0,
     width: '100%',
     height: '100%',
+  },
+  darkener: {
+    background: 'black',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    opacity: 0,
+    overflow: 'hidden',
+    pointerEvents: 'none',
   },
 }));
 
@@ -150,6 +168,8 @@ const PictureImpl = ({
   errorStyles = {},
   transitionTime = undefined,
   timingFunction = 'ease',
+  // Effects Props
+  darken,
   // HTML Image Props
   className: classNameProp,
   style: styleProp,
@@ -174,7 +194,7 @@ const PictureImpl = ({
     triggerOnce: true,
   });
   const hideImg = !placeholder && lazyObserve && !inView && !isBot;
-  const needsHolder = aspectRatio || hideImg;
+  const needsHolder = aspectRatio || hideImg || darken;
 
   const isMounted = useMountedState();
   // We use the DOM callbacks to determine state as this is closest to what
@@ -281,6 +301,16 @@ const PictureImpl = ({
       }}
     >
       {img}
+      {darken && (
+        <div
+          className={classes.darkener}
+          style={{
+            ...styles,
+            opacity: darken / 100,
+          }}
+          aria-hidden="true"
+        />
+      )}
     </div>
   ) : (
     img

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -124,6 +124,9 @@ export type PictureProps = Merge<
 >;
 
 const useStyles = makeStyles(() => ({
+  root: {
+    borderRadius: 0,
+  },
   contain: {
     margin: 'auto',
   },
@@ -147,6 +150,7 @@ const useStyles = makeStyles(() => ({
   },
   img: {
     maxWidth: '100%',
+    borderRadius: 'inherit',
   },
   aspectRatio: {
     position: 'absolute',
@@ -286,6 +290,7 @@ const PictureImpl = ({
         [classes.img]: true,
         [classes.aspectRatio]: aspectRatio,
         [classes.coverImg]: fitCover,
+        [classes.root]: !needsHolder,
         [classNameProp ?? '']: !needsHolder && classNameProp,
       })}
       style={!needsHolder ? { ...styles, ...styleProp } : styles}
@@ -320,6 +325,7 @@ const PictureImpl = ({
       className={clsx({
         [classes.holder]: true,
         [classes.coverHolder]: fitCover,
+        [classes.root]: true,
         [classNameProp ?? '']: classNameProp,
       })}
       style={{

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,0 +1,95 @@
+import { makeStyles } from '@material-ui/core';
+import clsx from 'clsx';
+import { toFinite } from 'lodash';
+import React from 'react';
+import { Merge } from 'type-fest';
+import { many } from '../util';
+
+export interface SourceProps {
+  /**
+   * An image url or set of image urls with sizes
+   *
+   * @example
+   *   source="https://via.placeholder.com/150x150"
+   * @example
+   *   source={[
+   *     ['https://via.placeholder.com/150x150', 150],
+   *     ['https://via.placeholder.com/300x300', 300],
+   *   ]}
+   * @example
+   *   source={[
+   *     ['https://via.placeholder.com/small.jpg', '1x'],
+   *     ['https://via.placeholder.com/large.jpg', '2x'],
+   *   ]}
+   */
+  source: ImageSourceSet;
+  /** Sizes attribute to be used with src for determine best image for user's viewport. */
+  sizes?: string | string[];
+}
+
+export type ImageSourceSet = string | ImageSource[];
+
+export type ImageSource = string | [string, string | number];
+
+export interface LayoutProps {
+  /** Whether the image should stretch to the full width of its parent */
+  fullWidth?: boolean;
+}
+
+export type PictureProps = Merge<
+  Omit<JSX.IntrinsicElements['img'], 'src' | 'srcSet'>,
+  SourceProps & LayoutProps
+>;
+
+const useStyles = makeStyles(() => ({
+  fullWidth: {
+    width: '100%',
+  },
+}));
+
+/**
+ * An Image/Picture wrapper.
+ *
+ * Named picture to not conflict with global DOM Image class.
+ * Auto imports will not work with `Image` because editor thinks
+ * you are referencing the global class.
+ */
+export const Picture = ({
+  // Source Props
+  source,
+  sizes: sizesProp,
+  // Layout Props
+  fullWidth,
+  // HTML Image Props
+  ...rest
+}: PictureProps) => {
+  const classes = useStyles();
+  const sizes = sizesProp ? many(sizesProp).join(', ') : undefined;
+  const srcSet = formatSrcSet(source);
+
+  return (
+    <img
+      alt=""
+      {...rest}
+      srcSet={srcSet}
+      sizes={sizes}
+      className={clsx({
+        [classes.fullWidth]: fullWidth,
+        [rest.className ?? '']: rest.className,
+      })}
+    />
+  );
+};
+
+const formatSrcSet = (source: ImageSourceSet) =>
+  many(source)
+    .map((src) => {
+      const [url, size] = many(src);
+      const sizeStr = !size
+        ? undefined
+        : toFinite(size) === 0
+        ? size
+        : `${size}w`;
+      return sizeStr ? `${url} ${sizeStr}` : url;
+    })
+    .join(', ');

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { toFinite } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import { IntersectionOptions, useInView } from 'react-intersection-observer';
 import { useMountedState } from 'react-use';
 import { Merge } from 'type-fest';
@@ -95,7 +95,7 @@ export interface PlaceholderStyles {
 }
 
 export type PictureProps = Merge<
-  Omit<JSX.IntrinsicElements['img'], 'src' | 'srcSet'>,
+  Omit<JSX.IntrinsicElements['img'], 'ref' | 'src' | 'srcSet'>,
   SourceProps & LayoutProps & LazyProps & PlaceholderProps
 >;
 
@@ -119,7 +119,7 @@ const useStyles = makeStyles(() => ({
  * Auto imports will not work with `Image` because editor thinks
  * you are referencing the global class.
  */
-export const Picture = ({
+const PictureImpl = ({
   // Source Props
   source,
   sizes: sizesProp,
@@ -274,6 +274,8 @@ export const Picture = ({
     img
   );
 };
+PictureImpl.displayName = 'Picture';
+export const Picture = memo(PictureImpl);
 
 const formatSrcSet = (source: ImageSourceSet) =>
   many(source)

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -268,7 +268,7 @@ const PictureImpl = ({
       {...rest}
       ref={lazyObserve && !inView ? ref : undefined}
       srcSet={renderPlaceholder ? placeholder : srcSet}
-      sizes={renderPlaceholder ? undefined : sizes}
+      sizes={sizes}
       width={width}
       height={height}
       className={clsx({

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -7,6 +7,7 @@ import { useMountedState } from 'react-use';
 import { Merge } from 'type-fest';
 import { useIsBot } from '../hooks';
 import { many } from '../util';
+import { usePictureSizes } from './PictureSizes';
 
 export interface SourceProps {
   /**
@@ -176,7 +177,8 @@ const PictureImpl = ({
   ...rest
 }: PictureProps) => {
   const classes = useStyles();
-  const sizes = sizesProp ? many(sizesProp).join(', ') : undefined;
+  const sizesContext = usePictureSizes();
+  const sizes = sizesProp ? many(sizesProp).join(', ') : sizesContext;
   const srcSet = formatSrcSet(source);
   const aspectRatio = width && height ? width / height : 0;
 

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -50,7 +50,9 @@ export interface LayoutProps {
 export interface LazyProps {
   /**
    * Whether to load the image lazily (while in / just before in view).
-   * - `native` or `true` just uses the native lazy loading functionality, no JS.
+   *
+   * Optionally specify the lazy loading implementation:
+   * - `native` just uses the native lazy loading functionality, no JS.
    *    If native is not supported we fallback to `observe`.
    *    This should generally be the option specified.
    *    @see https://web.dev/native-lazy-loading/
@@ -58,7 +60,7 @@ export interface LazyProps {
    *    in view / close to in view. This can be useful when images are hidden
    *    out of view, but still positioned in the viewport. i.e. carousels
    */
-  lazy?: 'native' | 'observe' | true;
+  lazy?: boolean | 'native' | 'observe';
   /**
    * Options for `IntersectionObserver` when using `lazy=observe`.
    * These should probably also be specified for `lazy=native`
@@ -150,10 +152,11 @@ export const Picture = ({
   const [supportsNativeLazyLoading] = useState(
     () => 'loading' in HTMLImageElement.prototype
   );
-  const lazyNative =
-    (lazyProp === true || lazyProp === 'native') && supportsNativeLazyLoading;
+  const lazyNative = lazyProp === 'native' && supportsNativeLazyLoading;
   const lazyObserve =
-    lazyProp === 'observe' || (lazyProp && !supportsNativeLazyLoading);
+    lazyProp === true ||
+    lazyProp === 'observe' ||
+    (lazyProp && !supportsNativeLazyLoading);
   const [ref, inView] = useInView({
     rootMargin: '200px 0px',
     ...lazyOptions,

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -42,15 +42,15 @@ export interface LayoutProps {
   height?: number;
   /**
    * How does the image fit itself in regards to its parent?
-   * - `auto`     - image will grow proportionally as large as it can
+   * - `scale`    - image will grow proportionally as large as it can
    * - `contain`  - image will not go beyond its natural size
    *                and will center itself within its parent
    * - `cover`    - image WILL go beyond its natural size to completely cover the
    *                parent. This could result in parts of the image being hidden.
    *
-   * If `background` is true, then the default will be `cover`, else `auto`.
+   * If `background` is true, then the default will be `cover`, else `scale`.
    */
-  fit?: 'auto' | 'contain' | 'cover';
+  fit?: 'scale' | 'contain' | 'cover';
   /**
    * Image is to be used as a background
    * This will absolutely position the element to fill the parent.
@@ -198,7 +198,7 @@ const PictureImpl = ({
   const sizes = sizesProp ? many(sizesProp).join(', ') : sizesContext;
   const srcSet = formatSrcSet(source);
   const aspectRatio = width && height ? width / height : 0;
-  const fit = fitProp ? fitProp : background ? 'cover' : 'auto';
+  const fit = fitProp ? fitProp : background ? 'cover' : 'scale';
   const fitCover = fit === 'cover';
   const fitContain = fit === 'contain';
 

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -2,7 +2,7 @@ import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { toFinite } from 'lodash';
 import React, { memo, useEffect, useState } from 'react';
-import { IntersectionOptions, useInView } from 'react-intersection-observer';
+import { useInView } from 'react-intersection-observer';
 import { useMountedState } from 'react-use';
 import { Merge } from 'type-fest';
 import { useIsBot } from '../hooks';
@@ -65,11 +65,12 @@ export interface LazyProps {
    */
   lazy?: boolean | 'native' | 'observe';
   /**
-   * Options for `IntersectionObserver` when using `lazy=observe`.
-   * These should probably also be specified for `lazy=native`
-   * because it still falls back to observe when native is not supported.
+   * Margin around the image in which to trigger loading.
+   *
+   * Can have values similar to the CSS margin property,
+   * e.g. "10px 20px 30px 40px" (top, right, bottom, left).
    */
-  lazyOptions?: IntersectionOptions;
+  lazyMargin?: string;
 }
 
 export interface PlaceholderProps {
@@ -142,7 +143,7 @@ const PictureImpl = ({
   size = 'auto',
   // Lazy Props
   lazy: lazyProp,
-  lazyOptions,
+  lazyMargin,
   // Placeholder Props
   placeholder,
   placeholderStyles = {},
@@ -169,8 +170,7 @@ const PictureImpl = ({
     lazyProp === 'observe' ||
     (lazyProp && !supportsNativeLazyLoading);
   const [ref, inView] = useInView({
-    rootMargin: '200px 0px',
-    ...lazyOptions,
+    rootMargin: lazyMargin || '200px 0px',
     triggerOnce: true,
   });
   const hideImg = !placeholder && lazyObserve && !inView && !isBot;

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -49,6 +49,12 @@ export interface LayoutProps {
    *              parent. This could result in parts of the image being hidden.
    */
   size?: 'auto' | 'contain' | 'cover';
+  /**
+   * Image is to be used as a background
+   * This will absolutely position the element to fill the parent.
+   * Note: This requires the parent element to be styled `position: relative`
+   */
+  background?: boolean;
 }
 
 export interface LazyProps {
@@ -122,6 +128,15 @@ const useStyles = makeStyles(() => ({
   holder: {
     position: 'relative',
   },
+  background: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    overflow: 'hidden',
+    pointerEvents: 'none',
+  },
   img: {
     maxWidth: '100%',
   },
@@ -134,14 +149,7 @@ const useStyles = makeStyles(() => ({
   },
   darkener: {
     background: 'black',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
     opacity: 0,
-    overflow: 'hidden',
-    pointerEvents: 'none',
   },
 }));
 
@@ -160,6 +168,7 @@ const PictureImpl = ({
   width,
   height,
   size = 'auto',
+  background,
   // Lazy Props
   lazy: lazyProp,
   lazyMargin,
@@ -305,7 +314,7 @@ const PictureImpl = ({
       {img}
       {darken && (
         <div
-          className={classes.darkener}
+          className={clsx(classes.background, classes.darkener)}
           style={{
             ...styles,
             opacity: darken / 100,
@@ -318,10 +327,17 @@ const PictureImpl = ({
     img
   );
 
+  if (size === 'auto' && background) {
+    return <div className={classes.background}>{held}</div>;
+  }
+
   if (size === 'contain') {
     return (
       <div
-        className={classes.contain}
+        className={clsx({
+          [classes.contain]: true,
+          [classes.background]: background,
+        })}
         style={{ maxWidth: width, maxHeight: height }}
       >
         {held}

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -35,14 +35,10 @@ export type ImageSourceSet = string | ImageSource[];
 export type ImageSource = string | [string, string | number];
 
 export interface LayoutProps {
-  /**
-   * Image's aspect ratio
-   *
-   * Used to correctly allocate layout height before image is loaded.
-   * This isn't the image's actual size, which most of the time is dynamic
-   * anyways. It's the natural width divided by the natural height.
-   */
-  aspectRatio?: number;
+  /** The image's natural width */
+  width?: number;
+  /** The image's natural height */
+  height?: number;
   /** Whether the image should stretch to the full width of its parent */
   fullWidth?: boolean;
 }
@@ -128,7 +124,8 @@ export const Picture = ({
   source,
   sizes: sizesProp,
   // Layout Props
-  aspectRatio,
+  width,
+  height,
   fullWidth,
   // Lazy Props
   lazy: lazyProp,
@@ -147,6 +144,7 @@ export const Picture = ({
   const classes = useStyles();
   const sizes = sizesProp ? many(sizesProp).join(', ') : undefined;
   const srcSet = formatSrcSet(source);
+  const aspectRatio = width && height ? width / height : 0;
 
   const isBot = useIsBot();
   const [supportsNativeLazyLoading] = useState(
@@ -227,6 +225,8 @@ export const Picture = ({
       ref={lazyObserve && !inView ? ref : undefined}
       srcSet={renderPlaceholder ? placeholder : srcSet}
       sizes={renderPlaceholder ? undefined : sizes}
+      width={width}
+      height={height}
       className={clsx({
         [classes.aspectRatio]: aspectRatio,
         [classes.fullWidth]: fullWidth,

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -1,8 +1,10 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { toFinite } from 'lodash';
-import React from 'react';
+import React, { useState } from 'react';
+import { IntersectionOptions, useInView } from 'react-intersection-observer';
 import { Merge } from 'type-fest';
+import { useIsBot } from '../hooks';
 import { many } from '../util';
 
 export interface SourceProps {
@@ -44,9 +46,29 @@ export interface LayoutProps {
   fullWidth?: boolean;
 }
 
+export interface LazyProps {
+  /**
+   * Whether to load the image lazily (while in / just before in view).
+   * - `native` or `true` just uses the native lazy loading functionality, no JS.
+   *    If native is not supported we fallback to `observe`.
+   *    This should generally be the option specified.
+   *    @see https://web.dev/native-lazy-loading/
+   * - `observe` uses `IntersectionObserver` to determine when image is first
+   *    in view / close to in view. This can be useful when images are hidden
+   *    out of view, but still positioned in the viewport. i.e. carousels
+   */
+  lazy?: 'native' | 'observe' | true;
+  /**
+   * Options for `IntersectionObserver` when using `lazy=observe`.
+   * These should probably also be specified for `lazy=native`
+   * because it still falls back to observe when native is not supported.
+   */
+  lazyOptions?: IntersectionOptions;
+}
+
 export type PictureProps = Merge<
   Omit<JSX.IntrinsicElements['img'], 'src' | 'srcSet'>,
-  SourceProps & LayoutProps
+  SourceProps & LayoutProps & LazyProps
 >;
 
 const useStyles = makeStyles(() => ({
@@ -76,14 +98,35 @@ export const Picture = ({
   // Layout Props
   aspectRatio,
   fullWidth,
+  // Lazy Props
+  lazy: lazyProp,
+  lazyOptions,
   // HTML Image Props
+  className: classNameProp,
+  style: styleProp,
   ...rest
 }: PictureProps) => {
   const classes = useStyles();
   const sizes = sizesProp ? many(sizesProp).join(', ') : undefined;
   const srcSet = formatSrcSet(source);
 
-  const img = (
+  const isBot = useIsBot();
+  const [supportsNativeLazyLoading] = useState(
+    () => 'loading' in HTMLImageElement.prototype
+  );
+  const lazyNative =
+    (lazyProp === true || lazyProp === 'native') && supportsNativeLazyLoading;
+  const lazyObserve =
+    lazyProp === 'observe' || (lazyProp && !supportsNativeLazyLoading);
+  const [ref, inView] = useInView({
+    rootMargin: '200px 0px',
+    ...lazyOptions,
+    triggerOnce: true,
+  });
+  const hideImg = lazyObserve && !inView && !isBot;
+  const needsWrapper = aspectRatio || hideImg;
+
+  const img = hideImg ? null : (
     <img
       alt=""
       {...rest}
@@ -92,16 +135,21 @@ export const Picture = ({
       className={clsx({
         [classes.aspectRatio]: aspectRatio,
         [classes.fullWidth]: fullWidth,
-        [rest.className ?? '']: rest.className,
+        [classNameProp ?? '']: !needsWrapper && classNameProp,
       })}
+      style={!needsWrapper && styleProp ? styleProp : undefined}
+      {...(lazyNative ? { loading: 'lazy' } : {})}
     />
   );
 
-  return aspectRatio ? (
+  return needsWrapper ? (
     <div
+      ref={lazyObserve && !inView ? ref : undefined}
+      className={classNameProp}
       style={{
         position: 'relative',
-        paddingBottom: `${(1 / aspectRatio) * 100}%`,
+        paddingBottom: aspectRatio ? `${(1 / aspectRatio) * 100}%` : undefined,
+        ...styleProp,
       }}
     >
       {img}

--- a/src/components/Picture.tsx
+++ b/src/components/Picture.tsx
@@ -32,6 +32,14 @@ export type ImageSourceSet = string | ImageSource[];
 export type ImageSource = string | [string, string | number];
 
 export interface LayoutProps {
+  /**
+   * Image's aspect ratio
+   *
+   * Used to correctly allocate layout height before image is loaded.
+   * This isn't the image's actual size, which most of the time is dynamic
+   * anyways. It's the natural width divided by the natural height.
+   */
+  aspectRatio?: number;
   /** Whether the image should stretch to the full width of its parent */
   fullWidth?: boolean;
 }
@@ -42,6 +50,13 @@ export type PictureProps = Merge<
 >;
 
 const useStyles = makeStyles(() => ({
+  aspectRatio: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
   fullWidth: {
     width: '100%',
   },
@@ -59,6 +74,7 @@ export const Picture = ({
   source,
   sizes: sizesProp,
   // Layout Props
+  aspectRatio,
   fullWidth,
   // HTML Image Props
   ...rest
@@ -67,17 +83,31 @@ export const Picture = ({
   const sizes = sizesProp ? many(sizesProp).join(', ') : undefined;
   const srcSet = formatSrcSet(source);
 
-  return (
+  const img = (
     <img
       alt=""
       {...rest}
       srcSet={srcSet}
       sizes={sizes}
       className={clsx({
+        [classes.aspectRatio]: aspectRatio,
         [classes.fullWidth]: fullWidth,
         [rest.className ?? '']: rest.className,
       })}
     />
+  );
+
+  return aspectRatio ? (
+    <div
+      style={{
+        position: 'relative',
+        paddingBottom: `${(1 / aspectRatio) * 100}%`,
+      }}
+    >
+      {img}
+    </div>
+  ) : (
+    img
   );
 };
 

--- a/src/components/PictureSizes.tsx
+++ b/src/components/PictureSizes.tsx
@@ -1,0 +1,29 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useDebugValue,
+} from 'react';
+
+const PictureSizesContext = createContext('100vw');
+
+export interface PictureSizesProviderProps {
+  /** Give raw sizes value */
+  sizes: string;
+  children: ReactNode;
+}
+
+export const PictureSizesProvider = ({
+  sizes,
+  children,
+}: PictureSizesProviderProps) => (
+  <PictureSizesContext.Provider value={sizes}>
+    {children}
+  </PictureSizesContext.Provider>
+);
+
+export const usePictureSizes = () => {
+  const sizes = useContext(PictureSizesContext);
+  useDebugValue(sizes);
+  return sizes;
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useUserAgent';

--- a/src/hooks/useUserAgent.tsx
+++ b/src/hooks/useUserAgent.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext, useDebugValue, useState } from 'react';
+
+// Allows user agent to be overridden/defined during SSR
+export const UserAgentContext = createContext(
+  typeof window !== 'undefined' ? window.navigator.userAgent : undefined
+);
+
+// Use sparingly. Doing things based on User Agent is unreliable and not recommended.
+export const useUserAgent = () => {
+  const ua = useContext(UserAgentContext);
+  useDebugValue(ua);
+  return ua;
+};
+
+// Use sparingly. This is an imperfect check.
+export const useIsBot = () => {
+  const agent = useUserAgent();
+  if (!agent) {
+    throw new Error('Cannot check if bot when user agent is not defined');
+  }
+  const [isBot] = useState(
+    () =>
+      (typeof window !== 'undefined' && !('onscroll' in window)) ||
+      /(gle|ing|ro)bot|crawl|spider/i.test(agent)
+  );
+  useDebugValue(isBot);
+
+  return isBot;
+};

--- a/src/util/array-helpers.ts
+++ b/src/util/array-helpers.ts
@@ -1,0 +1,4 @@
+export type Many<T> = T | readonly T[];
+
+export const many = <T>(items: Many<T>): readonly T[] =>
+  Array.isArray(items) ? items : [items];

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from './array-helpers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6341,7 +6341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.0.2, clsx@npm:^1.0.4":
+"clsx@npm:^1.0.2, clsx@npm:^1.0.4, clsx@npm:^1.1.0":
   version: 1.1.0
   resolution: "clsx@npm:1.1.0"
   checksum: 2/aebac019d24b4f40d28490fa31abdb7791d50242d928f27faa3aef44150f410600eb3c64ab6af01c66c3a022313d1c578a3e57c26bd6040bc15d30699824456c
@@ -6731,6 +6731,7 @@ __metadata:
     "@types/react-dom": ^16.9.0
     babel-plugin-import: ^1.13.0
     babel-plugin-mui-make-styles: ^0.1.1
+    clsx: ^1.1.0
     constate: ^2.0.0
     customize-cra: ^0.9.1
     eslint: ^6.8.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6744,6 +6744,7 @@ __metadata:
     react: ^16.13.1
     react-app-rewired: ^2.1.5
     react-dom: ^16.13.1
+    react-intersection-observer: ^8.25.1
     react-router: ^6.0.0-alpha.3
     react-router-dom: ^6.0.0-alpha.3
     react-scripts: ^3.4.1
@@ -16140,6 +16141,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-intersection-observer@npm:^8.25.1":
+  version: 8.26.1
+  resolution: "react-intersection-observer@npm:8.26.1"
+  dependencies:
+    tiny-invariant: ^1.1.0
+  peerDependencies:
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 2/03a266c54d875d4c5e013473f8a8c60f0b32a2b2f9256171646bb4725477bf98b28bfbbc0f47babcd6c7441e734fff8219a590e8aad34d227753a23cf2c02290
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.12.0, react-is@npm:^16.7.0, react-is@npm:^16.8.0, react-is@npm:^16.8.1, react-is@npm:^16.8.4":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -18473,6 +18485,13 @@ __metadata:
   version: 2.1.0
   resolution: "tiny-emitter@npm:2.1.0"
   checksum: 2/0055509c72e5fe35d6ab66fa6339342e0f29129e77ed2086e475fdf80be43a8651f2517be76513b46a042c8356396f4da5a35e2e23457252176808d5a892036a
+  languageName: node
+  linkType: hard
+
+"tiny-invariant@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "tiny-invariant@npm:1.1.0"
+  checksum: 2/64318fbd77c451cfff23b57b9f3aef56594d9cea051a87dc538c9b371f97e8d474eaa2a7cbd60b8aa23f852393152495e8651b197607465fdf9c8ff134043b1b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3306,6 +3306,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/js-cookie@npm:2.2.6":
+  version: 2.2.6
+  resolution: "@types/js-cookie@npm:2.2.6"
+  checksum: 2/08d3a2a014d2b7fd97070b5e5039f2ca387f07b9ecc13cfa85040479e7adbd62087901bd8adf94b2afad96457652996d1f051282ad3d4677a7ae1b6bf87a640f
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.3":
   version: 7.0.4
   resolution: "@types/json-schema@npm:7.0.4"
@@ -4009,6 +4016,13 @@ __metadata:
   dependencies:
     tslib: ^1.9.3
   checksum: 2/3d1da5799967fc272ae53f698514c169c85a04c11c1db3e4641a21edc82af75bfb4db9221c4f87aa333f14c7b43b72311fa66dae1ae981fa6f24c2bc5863d92b
+  languageName: node
+  linkType: hard
+
+"@xobotyi/scrollbar-width@npm:1.9.5":
+  version: 1.9.5
+  resolution: "@xobotyi/scrollbar-width@npm:1.9.5"
+  checksum: 2/ed2f287c3b3d5012d04c3052f0b6f8582bf92e6669b84e226690f0ae3b8c42c158f46fb21c1b4651e5896553211ed537369cd4f9de31660241c0235c8964f208
   languageName: node
   linkType: hard
 
@@ -5604,6 +5618,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bowser@npm:^1.7.3":
+  version: 1.9.4
+  resolution: "bowser@npm:1.9.4"
+  checksum: 2/6550d42547b878da87c6d2c1b0a0e4aeed894c914fd7052e950a03c78d6d97bc62d4e9d98a8073150ed7723eccf5499a24640d5a79828d48011df08b8c0237bd
+  languageName: node
+  linkType: hard
+
 "boxen@npm:^4.1.0":
   version: 4.2.0
   resolution: "boxen@npm:4.2.0"
@@ -6688,7 +6709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-to-clipboard@npm:^3.0.8":
+"copy-to-clipboard@npm:^3.0.8, copy-to-clipboard@npm:^3.2.0":
   version: 3.3.1
   resolution: "copy-to-clipboard@npm:3.3.1"
   dependencies:
@@ -6748,6 +6769,7 @@ __metadata:
     react-router: ^6.0.0-alpha.3
     react-router-dom: ^6.0.0-alpha.3
     react-scripts: ^3.4.1
+    react-use: ^14.1.1
     ts-node: ^8.8.2
     typescript: ^3.8.3
     webpack: 4.42.0
@@ -6992,6 +7014,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-in-js-utils@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "css-in-js-utils@npm:2.0.1"
+  dependencies:
+    hyphenate-style-name: ^1.0.2
+    isobject: ^3.0.1
+  checksum: 2/85ea5c716f3a9f95148cbf4a9cabe46fb08c6c034b015f9e3c6b7abadb384b5833ab348697f2327ce4c3181c951d7a339c118f05e9e3ba8b680f84857c039c6d
+  languageName: node
+  linkType: hard
+
 "css-loader@npm:3.4.2, css-loader@npm:^3.0.0":
   version: 3.4.2
   resolution: "css-loader@npm:3.4.2"
@@ -7073,6 +7105,15 @@ __metadata:
     mdn-data: 2.0.6
     source-map: ^0.6.1
   checksum: 2/2b3b48563f07d1636153a439f076565b125f5b64690736266c1833d5274c55f68b467ac5d648a5387121f7b1ff1f6e709a80f89824e345a17417994a34749403
+  languageName: node
+  linkType: hard
+
+"css-tree@npm:^1.0.0-alpha.28":
+  version: 1.0.0-alpha9
+  resolution: "css-tree@npm:1.0.0-alpha9"
+  dependencies:
+    source-map: ^0.5.3
+  checksum: 2/f390cf4bcff70ae53ae81711efe566155b637d7f482705ce33c5d5bf2ded24cf9ef5764a0deb1226eb80feada3817e48edc393fdd3e10265e7a24f2e23fbe052
   languageName: node
   linkType: hard
 
@@ -7249,7 +7290,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^2.2.0, csstype@npm:^2.5.2, csstype@npm:^2.5.7, csstype@npm:^2.6.5, csstype@npm:^2.6.7":
+"csstype@npm:^2.2.0, csstype@npm:^2.5.2, csstype@npm:^2.5.5, csstype@npm:^2.5.7, csstype@npm:^2.6.5, csstype@npm:^2.6.7":
   version: 2.6.10
   resolution: "csstype@npm:2.6.10"
   checksum: 2/b48260010e9bdc28ab80554375c14e2aec3f7fd46806a9206c0a15f99a0b559049bc4d75f91676183b76baf03708d10c1308b94be89870958797eced54cfe661
@@ -8096,6 +8137,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"error-stack-parser@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "error-stack-parser@npm:2.0.6"
+  dependencies:
+    stackframe: ^1.1.1
+  checksum: 2/7abf762c20054310d33f0c0a34a2ea38f93a1b0169f5289feb96cf94d7b30d277a0df09567469be79ccfcfa49df37cddc8c59e0bc5b682a1e7e3c234e67b25c8
+  languageName: node
+  linkType: hard
+
 "es-abstract@npm:^1.17.0, es-abstract@npm:^1.17.0-next.0, es-abstract@npm:^1.17.0-next.1, es-abstract@npm:^1.17.4, es-abstract@npm:^1.17.5":
   version: 1.17.5
   resolution: "es-abstract@npm:1.17.5"
@@ -8903,6 +8953,20 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 2/a2d03af3088b0397633e007fb3010ecfa4f91cae2116d2385653c59396a1b31467641afa672a79e6f82218518670dc144128378124e711e35dbf90bc82846f22
+  languageName: node
+  linkType: hard
+
+"fast-shallow-equal@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-shallow-equal@npm:1.0.0"
+  checksum: 2/c027a424ea3f2c653745e930bfd3f366c99118dc90d56e68beb034b7fa9c37fe5643bda89338abe19df274d1fa5170b02ffadac97343632403f7294eb2f26f9f
+  languageName: node
+  linkType: hard
+
+"fastest-stable-stringify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "fastest-stable-stringify@npm:1.0.1"
+  checksum: 2/c4a0e044930798ce7750062cbd851c6844873f086a822c3e87bf68c587291bd375e77d06fa25e713f440736f4f5fdcc8499d1d7d4c4488ce75b25213204fbf29
   languageName: node
   linkType: hard
 
@@ -10321,7 +10385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hyphenate-style-name@npm:^1.0.3":
+"hyphenate-style-name@npm:^1.0.2, hyphenate-style-name@npm:^1.0.3":
   version: 1.0.3
   resolution: "hyphenate-style-name@npm:1.0.3"
   checksum: 2/3ec167a398a992183dad59a73a0379d057799a56811469ef6e15aaf68313e80c173ed4d504f8f5babf089846136c9c1ea5ac42c25bf38b269f5c361430f062bc
@@ -10542,6 +10606,16 @@ __metadata:
   version: 1.3.5
   resolution: "ini@npm:1.3.5"
   checksum: 2/304a78d1e0ec49c6dc316b6a21bee5340ba85159c6581235b26a4cf27e2bac5f66f2c8f0e074ceaf3c48085f89fb974691cbf812df2128d2d74c5ef726d1b19a
+  languageName: node
+  linkType: hard
+
+"inline-style-prefixer@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "inline-style-prefixer@npm:4.0.2"
+  dependencies:
+    bowser: ^1.7.3
+    css-in-js-utils: ^2.0.0
+  checksum: 2/bf5b923274f164999f89458adfb267a37f3c12394665a6d5bead1219a7460564b7edbbb97e66407c4092a002913c1f0cbeef5d3e674297e4400b3e4d532f6eee
   languageName: node
   linkType: hard
 
@@ -11844,6 +11918,13 @@ __metadata:
   bin:
     jest: ./bin/jest.js
   checksum: 2/d5cc3c0b51ec59b6bd7ec0755e821b62b9e2e4ed0d94c255ceef11ad7d481c5232350bd8acf87d87b2a57e78b08dfab507aa91cf5d6e6ab4f964d4913c64488e
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "js-cookie@npm:2.2.1"
+  checksum: 2/c110f78427cb7715f67c69df0b3430f7cf9dafb5ddb13014df171d4fb61ccda0b1caf9767412cde63cab4bad697a5d4ce83b0c2e7ec650ec9929ed70750d20ae
   languageName: node
   linkType: hard
 
@@ -13345,6 +13426,25 @@ __metadata:
   dependencies:
     node-gyp: latest
   checksum: 2/988248a5f141b9ff728d00927607af857564707fb480de7dca775126af3ea5d7fe231958139fb866931742525ef0c0ca9c8d161188df81e1fa5fd79de1e2adc6
+  languageName: node
+  linkType: hard
+
+"nano-css@npm:^5.2.1":
+  version: 5.3.0
+  resolution: "nano-css@npm:5.3.0"
+  dependencies:
+    css-tree: ^1.0.0-alpha.28
+    csstype: ^2.5.5
+    fastest-stable-stringify: ^1.0.1
+    inline-style-prefixer: ^4.0.0
+    rtl-css-js: ^1.9.0
+    sourcemap-codec: ^1.4.1
+    stacktrace-js: ^2.0.0
+    stylis: 3.5.0
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 2/977665c4554abcf5573c6d21ec443ac090907b26b4ecb917ce2a4fdd86e7300720831ed2c4fef5a6a391cfc20b8af32207e3979803def1fc1c4b45f5361a13a8
   languageName: node
   linkType: hard
 
@@ -16350,6 +16450,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-use@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "react-use@npm:14.1.1"
+  dependencies:
+    "@types/js-cookie": 2.2.6
+    "@xobotyi/scrollbar-width": 1.9.5
+    copy-to-clipboard: ^3.2.0
+    fast-deep-equal: ^3.1.1
+    fast-shallow-equal: ^1.0.0
+    js-cookie: ^2.2.1
+    nano-css: ^5.2.1
+    resize-observer-polyfill: ^1.5.1
+    screenfull: ^5.0.0
+    set-harmonic-interval: ^1.0.1
+    throttle-debounce: ^2.1.0
+    ts-easing: ^0.2.0
+    tslib: ^1.10.0
+  peerDependencies:
+    react: ^16.8.0
+    react-dom: ^16.8.0
+  checksum: 2/a72b970111d78c18df44471eb9e3e96c84e382fdd5e3a9e081f2bd7c4f935582feacb767847f011a94c82d67a0673b4438470bf9dba24a614438bf1ac88ce819
+  languageName: node
+  linkType: hard
+
 "react@npm:^16.13.1, react@npm:^16.8.3":
   version: 16.13.1
   resolution: "react@npm:16.13.1"
@@ -17000,6 +17124,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rtl-css-js@npm:^1.9.0":
+  version: 1.14.0
+  resolution: "rtl-css-js@npm:1.14.0"
+  dependencies:
+    "@babel/runtime": ^7.1.2
+  checksum: 2/cedcc6142c98e6d4d05383e0f96d5724d42c79e355e6beea45c1c66d1e8b96aace4cba21c550f6bbb92dc1f340b2694cb9b70e66a15d22f5b7c7b904b8208f19
+  languageName: node
+  linkType: hard
+
 "run-async@npm:^2.2.0, run-async@npm:^2.4.0":
   version: 2.4.0
   resolution: "run-async@npm:2.4.0"
@@ -17169,6 +17302,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"screenfull@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "screenfull@npm:5.0.2"
+  checksum: 2/b87aa9170e54ea3a8920d02bc554a14b5addec701f32dfcaa2e8686f4f3e135fd1d2f0a94f100b5969e58a49c2ee340c1bd860346950b2004d63dff68148373c
+  languageName: node
+  linkType: hard
+
 "scuid@npm:^1.0.2":
   version: 1.1.0
   resolution: "scuid@npm:1.1.0"
@@ -17321,6 +17461,13 @@ __metadata:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 2/0ac2403b0c2d39bf452f6d5d17dfd3cb952b9113098e1231cc0614c436e2f465637e39d27cf3b93556f5c59795e9790fd7e98da784c5f9919edeba4295ffeb29
+  languageName: node
+  linkType: hard
+
+"set-harmonic-interval@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "set-harmonic-interval@npm:1.0.1"
+  checksum: 2/62a5bc2a0067e81b12e8b795bc5726fc9d48afe27e14517b8eda9de3444068ab45c87292e818e74491ed15d70c13bb58a4470a570ef13622f1db89bb1b2cc96d
   languageName: node
   linkType: hard
 
@@ -17684,6 +17831,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.5.6":
+  version: 0.5.6
+  resolution: "source-map@npm:0.5.6"
+  checksum: 2/288edf6dcb7148554ca4b4a989322051c6536724af890f1d4a30009155acaede29d1c14c6c58a53c23d04d80b455b032eda5c83704de0aef9a21cfe429ad8fe2
+  languageName: node
+  linkType: hard
+
 "source-map@npm:0.6.1, source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -17691,10 +17845,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.5.0, source-map@npm:^0.5.6, source-map@npm:^0.5.7":
+"source-map@npm:^0.5.0, source-map@npm:^0.5.3, source-map@npm:^0.5.6, source-map@npm:^0.5.7":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
   checksum: 2/737face96577a2184a42f141607fcc2c9db5620cb8517ae8ab3924476defa138fc26b0bab31e98cbd6f19211ecbf78400b59f801ff7a0f87aa9faa79f7433e10
+  languageName: node
+  linkType: hard
+
+"sourcemap-codec@npm:^1.4.1":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: 2/4d56d1232a45af813606d1755f11e7ae6b3542c615a7e3f904382f0134a9412ba8d090e83749254d78449eafdfcc62d5158b8f35e6241480b51b74b5c46b99f9
   languageName: node
   linkType: hard
 
@@ -17829,10 +17990,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-generator@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "stack-generator@npm:2.0.5"
+  dependencies:
+    stackframe: ^1.1.1
+  checksum: 2/3755840159707d4e3126b707d16cd0e9c847b7cf617d10db19bca1d7d6b0ae63eb52b3abdf730858b412b22dd238715d924b1219af8c92dc82584ca10bb71e1c
+  languageName: node
+  linkType: hard
+
 "stack-utils@npm:^1.0.1":
   version: 1.0.2
   resolution: "stack-utils@npm:1.0.2"
   checksum: 2/593a8bc5ca6d4bc0f97a5eb9b4d5739614a1037ccbeb05989de7e24c9352e2744c779611fa30a441ab40a97a1cc770d6cd4acdbc621fd80ea8d309c3d8068c49
+  languageName: node
+  linkType: hard
+
+"stackframe@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "stackframe@npm:1.1.1"
+  checksum: 2/cc6360418f8edbf2428b8ecd5866bd2caf6cf7a9fc6eb80ec86a7d4e0c4a89d1f9aa84b30069ac24700692cc747da867972df2468df19ffb09ec3bb3a53d3f58
+  languageName: node
+  linkType: hard
+
+"stacktrace-gps@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "stacktrace-gps@npm:3.0.4"
+  dependencies:
+    source-map: 0.5.6
+    stackframe: ^1.1.1
+  checksum: 2/18896e8b12d049b3d883334bb553d56ae7b38ac4f53cddf5637f8c6842c21a2c53d194ea9778eadd2034ca4029a28dff8cb2da22cc52a8bebe019a1576bac307
+  languageName: node
+  linkType: hard
+
+"stacktrace-js@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "stacktrace-js@npm:2.0.2"
+  dependencies:
+    error-stack-parser: ^2.0.6
+    stack-generator: ^2.0.5
+    stacktrace-gps: ^3.0.4
+  checksum: 2/0b7280113ca0a59aa1137b576dd66dad90a378e07982ba75627d4e86c7424b0ea8b4af269f5d3de7923be938b463f8f430de2b2e5b283ec6cf9c9f7757aba724
   languageName: node
   linkType: hard
 
@@ -18209,6 +18407,13 @@ __metadata:
     postcss: ^7.0.0
     postcss-selector-parser: ^3.0.0
   checksum: 2/1345ad348db3c98f7d0423762e13e816a8c1ba0b1d90d79f3528513be429f1cf68b7fa9c9d379870208586e7ff4cfb68b4121bbd904df03b17e84d62efcff288
+  languageName: node
+  linkType: hard
+
+"stylis@npm:3.5.0":
+  version: 3.5.0
+  resolution: "stylis@npm:3.5.0"
+  checksum: 2/7d916cd3020fef1d26f363284e22aebd62aacf2def82bf10a3b7771c06b0fb0edcab9df1219b7ef27efc8e814ba212ec73d09a123611c02b54a2762168470f41
   languageName: node
   linkType: hard
 
@@ -18616,6 +18821,13 @@ __metadata:
   version: 1.1.1
   resolution: "ts-dedent@npm:1.1.1"
   checksum: 2/262038f5f5337c890dae8d28b784d698c5c1c99c014a48abf046caa3d9d055ec1fa83b3205bd85dbf7fe910f864931577c350fcf90db92c90fd574e142a13b24
+  languageName: node
+  linkType: hard
+
+"ts-easing@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "ts-easing@npm:0.2.0"
+  checksum: 2/6f8c21c18411d3acadd15b7245fbea9d9b9320b8d0644e67bee78d17ad0a7604b7e4a4128a69d9c5fdd26bc52fe68c98ed8c0fa7dd9bf9049e6fb349bf94234f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## `Picture`
All of the props are optional (other than `source`), so this component should be used for all images. If something isn't working/supported we should talk about it.

### Supports [responsive][responsive-images] options
  - Specify one or more `sources` which will be formatted into `img` `srcset`
  - Specify one or more `sizes` which will be joined into `img` `sizes`
### Placeholder Images
  - A placeholder image url can be specified to load first before the main image. This reduces perceived loading time.
  - Styles (blur, opacity, grayscale) and transitions can be customized for placeholder. Sane values are used by default.
  - Separate error styles can also be given in case main image fails to load.
  - Placeholder is ignored for robots since we want to give them the real image
### Lazy Loading
  - Image will wait to load until it is "close to" (customizable via `lazyMargin`) in view
  - Strategy defaults to IntersectionObserver API which is performant (no on scroll listeners)
  - Native lazy loading strategy is also supported, but still very new and only supported by Chrome. If chosen, we fall back to the `observe` strategy if not supported.
  - Can be used with or without a placeholder
  - Lazy is ignored for robots since we want to give them the real image
### Layout & Effects
  - Specify `width` & `height` properties to create space in layout before image loads. This 
  prevents the image from "push content below it down" when it loads.
  - `background` image is to be used as a background.
      Positions the image absolutely to fill the parent, similar to what CSS `background-image` would do.
  - `fit` option to control image fits in layout
    - `fit="scale"` (default) image scale proportionally to its parent's width
    - `fit="contain"` Same as `scale`, but will not go beyond its natural size and will center itself within its parent
    - `fit="cover"` (default if background is true) image WILL go beyond its natural size to completely cover the parent (parts of image could be hidden).
  - `darken` darken the image by a percentage (0-100)


## `PictureSizesProvider`
Use to provide the default value of [`sizes`][responsive-images] to `Picture` components.
For example, in our `Root` component we could state that the page content will have a will have a max width of 1440px. We can inform all `Picture` components of this:
```tsx
<PictureSizesProvider sizes="(min-width: 1440px) 1440px, 100vw"> 
```
They will use this value by default, unless overridden with another `PictureSizesProvider`.
As described in link, this isn't the actual picture size in layout; it just helps inform the browser which source it should choose from our given list.

[responsive-images]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images