### PR TITLE
Form Validation & Focusing

### DIFF
--- a/src/api/graphql.generated.tsx
+++ b/src/api/graphql.generated.tsx
@@ -547,9 +547,10 @@ export interface CreateSessionOutput {
   __typename?: 'CreateSessionOutput';
   /**
    * Use this token in future requests in the Authorization header.
-   * Authorization: Bearer {token}
+   * Authorization: Bearer {token}.
+   * This token is only returned when the `browser` argument is not set to `true`.
    */
-  token: Scalars['String'];
+  token?: Maybe<Scalars['String']>;
 }
 
 export interface CreateUnavailability {
@@ -1400,6 +1401,10 @@ export interface MutationDeleteSecurityGroupArgs {
 
 export interface MutationUpdateSecurityGroupNameArgs {
   input: UpdateSecurityGroupNameInput;
+}
+
+export interface MutationCreateSessionArgs {
+  browser?: Maybe<Scalars['Boolean']>;
 }
 
 export interface MutationLoginArgs {

--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -9,12 +9,12 @@ import {
 } from '@material-ui/core';
 import React, { FC, ReactNode } from 'react';
 import { FieldConfig, useField } from './useField';
-import { getHelperText, showError } from './util';
+import { getHelperText, showError, useFocusOnEnabled } from './util';
 
 export type CheckboxFieldProps = FieldConfig<boolean> & {
   name: string;
   helperText?: ReactNode;
-} & Omit<CheckboxProps, 'defaultValue' | 'value'> &
+} & Omit<CheckboxProps, 'defaultValue' | 'value' | 'inputRef'> &
   Pick<FormControlLabelProps, 'label' | 'labelPlacement'> &
   Pick<FormControlProps, 'fullWidth' | 'margin' | 'variant'>;
 
@@ -24,18 +24,21 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
   labelPlacement,
   helperText,
   defaultValue = false,
-  disabled,
+  disabled: disabledProp,
   fullWidth,
   margin,
   variant,
   ...props
 }) => {
   const { input, meta, rest } = useField(name, { defaultValue, ...props });
+  const disabled = disabledProp ?? meta.submitting;
+  const ref = useFocusOnEnabled<HTMLInputElement>(meta, disabled);
+
   return (
     <FormControl
       required={props.required}
       error={showError(meta)}
-      disabled={disabled || meta.submitting}
+      disabled={disabled}
       fullWidth={fullWidth}
       margin={margin}
       variant={variant}
@@ -48,6 +51,7 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
           <Checkbox
             color="primary"
             {...rest}
+            inputRef={ref}
             checked={input.value}
             value={name}
             onChange={(e) => input.onChange(e.target.checked)}

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -9,7 +9,7 @@ import { Except } from 'type-fest';
 import { validators } from '.';
 import { CalendarDate } from '../../util';
 import { FieldConfig, useField } from './useField';
-import { getHelperText, showError } from './util';
+import { getHelperText, showError, useFocusOnEnabled } from './util';
 import { Validator } from './validators';
 
 type DatePickerProps = ComponentProps<typeof DatePicker>;
@@ -24,6 +24,7 @@ export interface DateFieldProps
 export const DateField = ({
   name,
   helperText,
+  disabled: disabledProp,
   children,
   initialValue: initialValueProp,
   ...props
@@ -58,11 +59,13 @@ export const DateField = ({
     initialValue,
     validate: [validator, props.required ? validators.required : null],
   });
+  const disabled = disabledProp ?? meta.submitting;
+  const ref = useFocusOnEnabled(meta, disabled);
 
   return (
     <DatePicker
       views={['year', 'month', 'date']}
-      disabled={meta.submitting}
+      disabled={disabled}
       clearable={!props.required}
       // default luxon value does not work with masked inputs
       // since there's no zero padding
@@ -71,6 +74,7 @@ export const DateField = ({
       autoComplete="off"
       {...rest}
       {...input}
+      inputRef={ref}
       onChange={(d) => input.onChange(d ? CalendarDate.fromDateTime(d) : d)}
       name={name}
       helperText={getHelperText(meta, helperText)}

--- a/src/components/form/PasswordField.tsx
+++ b/src/components/form/PasswordField.tsx
@@ -52,6 +52,7 @@ export const PasswordIconToggle = ({ show, onClick, ...rest }: ToggleProps) => (
     {...rest}
     edge="end"
     onClick={onClick}
+    onMouseDown={(e) => e.preventDefault()}
   >
     {show ? <VisibilityOff /> : <Visibility />}
   </IconButton>

--- a/src/components/form/SubmitButton.tsx
+++ b/src/components/form/SubmitButton.tsx
@@ -1,3 +1,5 @@
+import { FORM_ERROR } from 'final-form';
+import { difference } from 'lodash';
 import { FC } from 'react';
 import * as React from 'react';
 import { useForm, useFormState } from 'react-final-form';
@@ -18,16 +20,28 @@ export const SubmitButton: FC<SubmitButtonProps> = ({
   ...rest
 }) => {
   const form = useForm('SubmitButton');
-  const { hasValidationErrors, submitting, touched, validating } = useFormState(
-    {
-      subscription: {
-        hasValidationErrors: true,
-        submitting: true,
-        touched: true,
-        validating: true,
-      },
-    }
-  );
+  const {
+    hasValidationErrors,
+    submitting,
+    touched,
+    validating,
+    submitErrors,
+    dirtyFieldsSinceLastSubmit,
+  } = useFormState({
+    subscription: {
+      submitErrors: true,
+      dirtyFieldsSinceLastSubmit: true,
+      hasValidationErrors: true,
+      submitting: true,
+      touched: true,
+      validating: true,
+    },
+  });
+  // Ignore FORM_ERROR since it doesn't count as it doesn't go to a field.
+  // We'll assume that the form _can_ be re-submitted with these errors.
+  // It could be a server error, connection error, etc.
+  const { [FORM_ERROR]: _, ...fieldSubmitErrors } = submitErrors ?? {};
+
   const allFieldsTouched = touched
     ? Object.values(touched).every((field) => field)
     : false;
@@ -48,7 +62,16 @@ export const SubmitButton: FC<SubmitButtonProps> = ({
       }}
       type="submit"
       disabled={
-        submitting || validating || (allFieldsTouched && hasValidationErrors)
+        submitting ||
+        validating ||
+        (allFieldsTouched && hasValidationErrors) ||
+        // disable if there are submit/server errors for specific fields
+        // and they have not been changed since last submit
+        (submitErrors &&
+          difference(
+            Object.keys(fieldSubmitErrors),
+            Object.keys(dirtyFieldsSinceLastSubmit)
+          ).length > 0)
       }
       progress={spinner && submitting}
     >

--- a/src/components/form/SubmitError.tsx
+++ b/src/components/form/SubmitError.tsx
@@ -8,17 +8,17 @@ import { useFormState } from 'react-final-form';
  * if it is a string.
  */
 export const SubmitError = ({ children, ...rest }: TypographyProps) => {
-  const { submitErrors } = useFormState({
+  const { submitError } = useFormState({
     subscription: {
-      submitErrors: true,
+      submitError: true,
     },
   });
-  if (!children && (!submitErrors || typeof submitErrors !== 'string')) {
+  if (!children && !submitError) {
     return null;
   }
   return (
     <Typography color="error" {...rest}>
-      {children || submitErrors}
+      {children || submitError}
     </Typography>
   );
 };

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -5,28 +5,35 @@ import {
 import * as React from 'react';
 import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';
-import { getHelperText, showError } from './util';
+import { getHelperText, showError, useFocusOnEnabled } from './util';
 
 export type TextFieldProps<FieldValue = string> = FieldConfig<FieldValue> & {
   name: string;
-} & Except<MuiTextFieldProps, 'defaultValue' | 'error' | 'value' | 'name'>;
+} & Except<
+    MuiTextFieldProps,
+    'defaultValue' | 'error' | 'value' | 'name' | 'inputRef'
+  >;
 
 /** Combines final form field and MUI text field */
 export function TextField<FieldValue = string>({
   name,
   InputProps,
   helperText,
+  disabled: disabledProp,
   children,
   ...props
 }: TextFieldProps<FieldValue>) {
   const { input, meta, rest } = useField(name, props);
+  const disabled = disabledProp ?? meta.submitting;
+  const ref = useFocusOnEnabled(meta, disabled);
 
   return (
     <MuiTextField
       name={name}
-      disabled={meta.submitting}
+      disabled={disabled}
       required={props.required}
       {...rest}
+      inputRef={ref}
       InputProps={{ ...InputProps, ...input }}
       helperText={getHelperText(meta, helperText)}
       error={showError(meta)}

--- a/src/components/form/decorators.ts
+++ b/src/components/form/decorators.ts
@@ -1,6 +1,37 @@
 import { FormApi, Unsubscribe } from 'final-form';
 
 /**
+ * Focuses the first field to have a submit error.
+ * Be sure to use blurOnSubmit decorator with this one.
+ */
+export function focusFirstFieldWithSubmitError<T>(
+  form: FormApi<T>
+): Unsubscribe {
+  let wasSubmitting = false;
+  return form.subscribe(
+    ({ submitting, submitFailed, submitErrors }) => {
+      if (wasSubmitting && !submitting && submitFailed) {
+        wasSubmitting = false;
+        for (const field of form.getRegisteredFields()) {
+          if (submitErrors?.[field]) {
+            form.focus(field);
+            break;
+          }
+        }
+      }
+      if (submitting) {
+        wasSubmitting = true;
+      }
+    },
+    {
+      submitting: true,
+      submitFailed: true,
+      submitErrors: true,
+    }
+  );
+}
+
+/**
  * Focuses the last active field after a submit error.
  * Be sure to use blurOnSubmit decorator with this one.
  */

--- a/src/components/form/decorators.ts
+++ b/src/components/form/decorators.ts
@@ -1,0 +1,63 @@
+import { FormApi, Unsubscribe } from 'final-form';
+
+/**
+ * Focuses the last active field after a submit error.
+ * Be sure to use blurOnSubmit decorator with this one.
+ */
+export function focusLastActiveFieldOnSubmitError<T>(
+  form: FormApi<T>
+): Unsubscribe {
+  let lastActive: string | undefined;
+  let wasSubmitting = false;
+  return form.subscribe(
+    ({ active, submitting, submitFailed }) => {
+      if (
+        wasSubmitting &&
+        !submitting &&
+        submitFailed &&
+        !active &&
+        lastActive
+      ) {
+        wasSubmitting = false;
+        form.focus(lastActive);
+      }
+      if (submitting) {
+        wasSubmitting = true;
+      }
+      if (active) {
+        lastActive = active;
+      }
+    },
+    {
+      active: true,
+      submitting: true,
+      submitFailed: true,
+    }
+  );
+}
+
+/**
+ * Since we disable our fields on submit, the field that FF thinks is active
+ * is actually not active anymore. This informs FF of that.
+ * This really only matters when we are trying to automatically focus fields.
+ * Without this a field could become re-active after submission and compete
+ * with another to try and focus. Since it's an imperative call one could
+ * clobber the other.
+ * This seems to be an issue when submitting via enter key since the lack of
+ * blur event creates the stale state. Clicking off the field, even to click
+ * the submit button, triggers the field to blur which informs FF to remove
+ * the active property.
+ */
+export function blurOnSubmit<T>(form: FormApi<T>): Unsubscribe {
+  return form.subscribe(
+    ({ submitting, active }) => {
+      if (submitting && active) {
+        form.blur(active);
+      }
+    },
+    {
+      submitting: true,
+      active: true,
+    }
+  );
+}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,4 +1,5 @@
 export * from './CheckboxField';
+export * from './decorators';
 export * from './DateField';
 export * from './EmailField';
 export * from './PasswordField';

--- a/src/components/form/util.ts
+++ b/src/components/form/util.ts
@@ -1,4 +1,10 @@
-import { ReactNode } from 'react';
+import {
+  MutableRefObject,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import { FieldMetaState, useFormState } from 'react-final-form';
 
 export const useIsSubmitting = () => {
@@ -18,4 +24,38 @@ export const getHelperText = (
   // always pass a truthy value, aka ' ', so layout doesn't adjust
   // when an error is shown. This is per Material Design.
   return text || ' ';
+};
+
+/**
+ * Helper hook to focus element attached to ref
+ */
+export const useFocus = <T extends HTMLElement = HTMLElement>(): [
+  () => void,
+  MutableRefObject<T | null>
+] => {
+  const ref = useRef<T | null>(null);
+  const focus = useCallback(() => {
+    if (ref.current) {
+      setTimeout(() => ref.current?.focus(), 100);
+    }
+  }, [ref]);
+  return [focus, ref];
+};
+
+/**
+ * Focus field if it is enabled and is active.
+ * When fields are disabled they lose focus so this fixes that.
+ */
+export const useFocusOnEnabled = <T extends HTMLElement = HTMLElement>(
+  meta: FieldMetaState<unknown>,
+  disabled: boolean
+) => {
+  // Refocus field if it has become re-enabled and is active
+  const [focus, ref] = useFocus<T>();
+  useEffect(() => {
+    if (!disabled && meta.active) {
+      focus();
+    }
+  }, [meta.active, disabled, focus]);
+  return ref;
 };

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -1,3 +1,5 @@
+import { ApolloError } from '@apollo/client';
+import { FORM_ERROR } from 'final-form';
 import React from 'react';
 import { Except } from 'type-fest';
 import { useLoginMutation } from '../../../api';
@@ -7,6 +9,9 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
   const [login] = useLoginMutation();
 
   const submit: Props['onSubmit'] = async (input) => {
+    const invalidCreds = {
+      [FORM_ERROR]: `Something wasn't right. Try again, or reset password.`,
+    };
     try {
       const res = await login({
         variables: { input },
@@ -16,9 +21,15 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
       if (res?.login.success) {
         alert(`Welcome ${res.login.user?.realFirstName.value}`);
       } else {
-        alert('Login failed. Please check your email or password.');
+        return invalidCreds;
       }
     } catch (e) {
+      if (
+        e instanceof ApolloError &&
+        e.graphQLErrors?.[0]?.extensions?.exception.status === 401
+      ) {
+        return invalidCreds;
+      }
       alert('Login failed. Please contact support.');
       console.log(e);
     }

--- a/src/scenes/Authentication/Login/LoginForm.tsx
+++ b/src/scenes/Authentication/Login/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent } from '@material-ui/core';
+import { Decorator, Mutator } from 'final-form';
 import React from 'react';
 import { Form, FormProps } from 'react-final-form';
 import { LoginInput } from '../../../api';
@@ -6,6 +7,7 @@ import {
   EmailField,
   PasswordField,
   SubmitButton,
+  SubmitError,
 } from '../../../components/form';
 
 export type LoginFormProps = Pick<
@@ -14,10 +16,26 @@ export type LoginFormProps = Pick<
 > & { className?: string };
 
 export const LoginForm = ({ className, ...props }: LoginFormProps) => (
-  <Form {...props}>
+  <Form
+    {...props}
+    onSubmit={async (...args) => {
+      const res = await props.onSubmit(...args);
+      return res
+        ? {
+            ...res,
+            // Add errors to fields so they show invalid
+            email: ' ',
+            password: ' ',
+          }
+        : undefined;
+    }}
+    decorators={[clearSubmitErrorsOnChange]}
+    mutators={{ clearSubmitErrors }}
+  >
     {({ handleSubmit }) => (
       <Card component="form" onSubmit={handleSubmit} className={className}>
         <CardContent>
+          <SubmitError />
           <EmailField placeholder="Enter Email Address" />
           <PasswordField placeholder="Enter Password" />
           <SubmitButton />
@@ -26,3 +44,23 @@ export const LoginForm = ({ className, ...props }: LoginFormProps) => (
     )}
   </Form>
 );
+
+// Since email and password are invalid as a pair we need to clear
+// both errors from both fields when either of them change.
+const clearSubmitErrorsOnChange: Decorator<LoginInput> = (form) =>
+  form.subscribe(
+    ({ dirtySinceLastSubmit }) => {
+      if (dirtySinceLastSubmit) {
+        form.mutators.clearSubmitErrors();
+      }
+    },
+    { dirtySinceLastSubmit: true }
+  );
+
+const clearSubmitErrors: Mutator<LoginInput> = (args, state) => {
+  state.formState = {
+    ...state.formState,
+    submitError: undefined,
+    submitErrors: undefined,
+  };
+};

--- a/src/scenes/Authentication/Login/LoginForm.tsx
+++ b/src/scenes/Authentication/Login/LoginForm.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { Form, FormProps } from 'react-final-form';
 import { LoginInput } from '../../../api';
 import {
+  blurOnSubmit,
   EmailField,
+  focusLastActiveFieldOnSubmitError,
   PasswordField,
   SubmitButton,
   SubmitError,
@@ -29,14 +31,14 @@ export const LoginForm = ({ className, ...props }: LoginFormProps) => (
           }
         : undefined;
     }}
-    decorators={[clearSubmitErrorsOnChange]}
+    decorators={decorators}
     mutators={{ clearSubmitErrors }}
   >
     {({ handleSubmit }) => (
       <Card component="form" onSubmit={handleSubmit} className={className}>
         <CardContent>
           <SubmitError />
-          <EmailField placeholder="Enter Email Address" />
+          <EmailField autoFocus placeholder="Enter Email Address" />
           <PasswordField placeholder="Enter Password" />
           <SubmitButton />
         </CardContent>
@@ -64,3 +66,11 @@ const clearSubmitErrors: Mutator<LoginInput> = (args, state) => {
     submitErrors: undefined,
   };
 };
+
+// decorators get re-created if array identity changes
+// so make constant outside of render function
+const decorators = [
+  clearSubmitErrorsOnChange,
+  blurOnSubmit,
+  focusLastActiveFieldOnSubmitError,
+];


### PR DESCRIPTION
# Form Foundation Changes
- Change `SubmitError` component to use `submitError` form state instead of `submitErrors` and check if it's a string. This comes filled by special `FORM_ERROR` key.
- Disable `SubmitButton` if there are fields with submit errors that have not been changed.
  The special `FORM_ERROR` key doesn't count as it doesn't go to a field.
  We'll assume that the form _can_ be re-submitted in this case.
- Fix password field losing focus on visibility toggle

## Field Focus Fixes / Tweaks
Focus is really hard to manage because there's not a declarative API and it changes all the time due to side effects.
- One issue is disabling fields, which we do this while submitting. When fields are disabled they lose focus, but this isn't necessarily communicated out. Final Form as an `active` state which basically follows which field is in focus. So now we explicitly call `focus()` on the input element when the field is enabled and Final Form says it is active. This should help make things work as expected and allows `form.focus(fieldName)` to work as expected.
- Along these lines we have a `blurOnSubmit` decorator which should pretty much be used in every form. This fixes the inconsistent active state when a form is submitted via enter key while a field is focused. Since the field is not blurred (normally, disabling doesn't count), Final Form doesn't get the callback to to remove set that field as inactive.
- I added a decorator to focus first field that has a submit error (`focusFirstFieldWithSubmitError`).
  This seems like a common pattern that we'll use.

# Login Form Changes
- Return form submission error object on invalid credentials.
  The `ApolloError` statement really highlights how poor our errors are. We need to address this soon.
- Login fields are special because we validate them as a pair, and we don't known which one is actually wrong. So for this form we give a general error but we also want to mark those fields as invalid so they show red and disable the submit button. But because of this we also need to clear those errors whenever one of the two fields is changed since it could just be the password or email that's incorrect. So I've added a decorator to do that.
- I've created and used a decorator that focuses the last active field after a submit error (`focusLastActiveFieldOnSubmitError`).
  This is focusing logic is better here instead of focusing the first field that has an error. Since
  we mark both fields as invalid, but it's probably the password that's wrong or at least the last one you've changed.