### PR TITLE
session & login

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -8,8 +8,8 @@ hooks:
 generates:
   ./src/api/graphql.generated.tsx:
     plugins:
-      # Until hooks & common can be merged into one import
-      - { add: /* eslint-disable import/no-duplicates */ }
+      # import/no-duplicates is here until hooks & common can be merged into one import
+      - add: /* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
       - typescript
       - typescript-operations
       - typescript-react-apollo

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,6 @@ import { App } from './App';
 
 test('renders HOME', () => {
   const { getByText } = render(<App />);
-  const linkElement = getByText(/HOME/i);
+  const linkElement = getByText(/Welcome/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { LocalizationProvider } from '@material-ui/pickers';
 import React, { cloneElement, FC, ReactElement } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { apolloClient } from './api';
+import { SessionProvider } from './components/Session';
 import { TitleProvider } from './components/title';
 import { Root } from './scenes/Root';
 import { createTheme } from './theme';
@@ -19,6 +20,7 @@ const providers = [
   <ApolloProvider client={apolloClient} children={<></>} />,
   <ThemeProvider theme={theme} children={<></>} />,
   <LocalizationProvider dateAdapter={LuxonUtils} children={<></>} />,
+  <SessionProvider />,
   <BrowserRouter />,
   <TitleProvider title="CORD Field" />,
 ];

--- a/src/api/apolloClient.ts
+++ b/src/api/apolloClient.ts
@@ -6,5 +6,6 @@ export const apolloClient = new ApolloClient({
   cache: new InMemoryCache(),
   link: new HttpLink({
     uri: `${serverHost}/graphql`,
+    credentials: 'include',
   }),
 });

--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -1,26 +1,26 @@
 import constate from 'constate';
-import { useEffect, useState } from 'react';
-import { LoggedInUserFragment, useSessionQuery } from '../../api';
+import {
+  LoggedInUserFragment,
+  SessionDocument,
+  SessionQuery,
+  useSessionQuery,
+} from '../../api';
 
 export type SessionUser = LoggedInUserFragment;
 
 function Session() {
-  const [userSession, setUserSession] = useState<SessionUser | null>(null);
-  const [loading, setLoading] = useState(true);
-  const { loading: loadingSession, error, data } = useSessionQuery();
+  const { loading, data, client } = useSessionQuery();
+  const setSession = (user: LoggedInUserFragment) =>
+    client.writeQuery<SessionQuery>({
+      query: SessionDocument,
+      data: {
+        session: {
+          user,
+        },
+      },
+    });
 
-  useEffect(() => {
-    if (!loadingSession || error) {
-      if (data?.session.user) {
-        setUserSession(data?.session.user);
-      }
-
-      setLoading(false);
-    }
-    setUserSession(data?.session.user || null);
-  }, [loadingSession, error, data, setUserSession, setLoading]);
-
-  return [userSession, loading, setUserSession] as const;
+  return [data?.session.user, loading, setSession] as const;
 }
 
 export const [SessionProvider, useSession] = constate(Session);

--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -1,0 +1,26 @@
+import constate from 'constate';
+import { useEffect, useState } from 'react';
+import { LoggedInUserFragment, useSessionQuery } from '../../api';
+
+export type SessionUser = LoggedInUserFragment;
+
+function Session() {
+  const [userSession, setUserSession] = useState<SessionUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const { loading: loadingSession, error, data } = useSessionQuery();
+
+  useEffect(() => {
+    if (!loadingSession || error) {
+      if (data?.session.user) {
+        setUserSession(data?.session.user);
+      }
+
+      setLoading(false);
+    }
+    setUserSession(data?.session.user || null);
+  }, [loadingSession, error, data, setUserSession, setLoading]);
+
+  return [userSession, loading, setUserSession] as const;
+}
+
+export const [SessionProvider, useSession] = constate(Session);

--- a/src/components/Session/index.ts
+++ b/src/components/Session/index.ts
@@ -1,0 +1,1 @@
+export * from './Session';

--- a/src/components/Session/session.graphql
+++ b/src/components/Session/session.graphql
@@ -1,0 +1,29 @@
+query Session {
+  session(browser: true) {
+    user {
+      ...LoggedInUser
+    }
+  }
+}
+
+fragment LoggedInUser on User {
+  id
+  email {
+    value
+  }
+  timezone {
+    value
+  }
+  realFirstName {
+    value
+  }
+  realLastName {
+    value
+  }
+  displayFirstName {
+    value
+  }
+  displayLastName {
+    value
+  }
+}

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -1,28 +1,36 @@
 import { ApolloError } from '@apollo/client';
 import { FORM_ERROR } from 'final-form';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Except } from 'type-fest';
 import { useLoginMutation } from '../../../api';
+import { useSession } from '../../../components/Session';
 import { LoginForm, LoginFormProps as Props } from './LoginForm';
 
 export const Login = (props: Except<Props, 'onSubmit'>) => {
   const [login] = useLoginMutation();
+  const navigate = useNavigate();
+  const [session, sessionLoading, setUserSession] = useSession();
+
+  useEffect(() => {
+    if (!sessionLoading && session) {
+      navigate('/');
+    }
+  }, [navigate, session, sessionLoading]);
 
   const submit: Props['onSubmit'] = async (input) => {
     const invalidCreds = {
       [FORM_ERROR]: `Something wasn't right. Try again, or reset password.`,
     };
     try {
-      const res = await login({
+      const { data } = await login({
         variables: { input },
       });
 
-      // TODO: post-login authentication (session storage, etc)
-      if (res?.login.success) {
-        alert(`Welcome ${res.login.user?.realFirstName.value}`);
-      } else {
-        return invalidCreds;
-      }
+      // TODO: Navigate to a returnTo place if it exists.
+      navigate('/');
+
+      setUserSession(data.login.user);
     } catch (e) {
       if (
         e instanceof ApolloError &&

--- a/src/scenes/Authentication/Login/queries.graphql
+++ b/src/scenes/Authentication/Login/queries.graphql
@@ -1,14 +1,7 @@
 mutation Login($input: LoginInput!) {
   login(input: $input) {
-    success
     user {
-      id
-      realFirstName {
-        value
-      }
-      realLastName {
-        value
-      }
+      ...LoggedInUser
     }
   }
 }

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { useSession } from '../../components/Session';
 import { useTitle } from '../../components/title';
 
 export const Home = () => {
   useTitle('Home');
-  return <div>HOME</div>;
+  const [session] = useSession();
+
+  return <div>Welcome, {session?.displayFirstName.value ?? 'Friend'}</div>;
 };


### PR DESCRIPTION
1. Enable `credentials: include` in apolloClient
2. Created `UserSession` context for looking up existing session and hydrating the user session post-login
3. Implemented app bootstrapping in `Root.tsx` - not sure if this is the best place to put this, need feedback here
4. Hydrate `UserSession` context state after successful login and route to the home scene
