### PR TITLE
MUI Routing Components

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,10 +12,14 @@ rules:
         # As noted in https://github.com/mui-org/material-ui/releases/tag/v4.5.1
         - name: '@material-ui/styles'
           message: Use '@material-ui/core' instead
-            # As noted in https://github.com/mui-org/material-ui/releases/tag/v4.5.1
+        # Enforce SVG Icons as recommended
         - name: '@material-ui/core'
           importNames: [Icon]
           message: Use specific SVG Icons from '@material-ui/icons' instead
+        # Enforce our Link component
+        - name: '@material-ui/core'
+          importNames: [Link]
+          message: Use Link in components/Routing instead which has routing integrated
       patterns:
         # Enforce single import. Leave code splitting to webpack.
         - '@material-ui/core/*'

--- a/src/components/Routing/ButtonLink.stories.tsx
+++ b/src/components/Routing/ButtonLink.stories.tsx
@@ -1,0 +1,34 @@
+import { select, text } from '@storybook/addon-knobs';
+import React, { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ButtonLink, ButtonLinkProps } from './ButtonLink';
+
+export default {
+  title: 'Components/Routing/ButtonLink',
+  decorators: [(fn: () => ReactElement) => <MemoryRouter>{fn()}</MemoryRouter>],
+};
+
+export const Internal = () => <Story to="/">Homepage</Story>;
+
+export const External = () => (
+  <Story external to="https://google.com" target="_blank">
+    Google
+  </Story>
+);
+
+const Story = (defaults: ButtonLinkProps) => (
+  <ButtonLink
+    {...defaults}
+    to={text('To', defaults.to as string)}
+    target={text('Target', defaults.target || '')}
+    color={select(
+      'Color',
+      ['inherit', 'primary', 'secondary', 'default'],
+      'primary'
+    )}
+    variant={select('Variant', ['contained', 'text', 'outlined'], 'contained')}
+    size={select('Size', ['small', 'medium', 'large'], 'medium')}
+  >
+    {text('Label', defaults.children ? `${defaults.children}` : '')}
+  </ButtonLink>
+);

--- a/src/components/Routing/ButtonLink.tsx
+++ b/src/components/Routing/ButtonLink.tsx
@@ -1,0 +1,39 @@
+import { Button, ButtonProps } from '@material-ui/core';
+import React, { forwardRef } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { Merge } from 'type-fest';
+
+export type ButtonLinkProps = InternalProps | ExternalProps;
+
+type BaseProps = Omit<ButtonProps<'a'>, 'component' | 'href'>;
+
+interface InternalProps
+  extends Merge<BaseProps, Omit<LinkProps, 'as' | 'href'>> {
+  external?: false;
+}
+
+interface ExternalProps extends BaseProps {
+  external: true;
+  to: string;
+}
+
+/**
+ * A Link to somewhere.
+ *
+ * Combines MUI Link with react router for internal routing
+ * and <a> for external routing.
+ */
+export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  ({ external, to, children, ...props }, ref) => {
+    const other: any = {
+      ref,
+      component: external ? 'a' : Link,
+      ...(external ? { href: to } : { to }),
+    };
+    return (
+      <Button {...props} {...other}>
+        {children}
+      </Button>
+    );
+  }
+);

--- a/src/components/Routing/Link.stories.tsx
+++ b/src/components/Routing/Link.stories.tsx
@@ -1,0 +1,32 @@
+import { select, text } from '@storybook/addon-knobs';
+import React, { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { Link, LinkProps } from './Link';
+
+export default {
+  title: 'Components/Routing/Link',
+  decorators: [(fn: () => ReactElement) => <MemoryRouter>{fn()}</MemoryRouter>],
+};
+
+export const Internal = () => <LinkStory to="/">Homepage</LinkStory>;
+
+export const External = () => (
+  <LinkStory external to="https://google.com" target="_blank">
+    Google
+  </LinkStory>
+);
+
+const LinkStory = (defaults: LinkProps) => (
+  <Link
+    {...defaults}
+    to={text('To', defaults.to as string)}
+    underline={select(
+      'Underline',
+      ['none', 'hover', 'always'],
+      defaults.underline ?? 'hover'
+    )}
+    target={text('Target', defaults.target || '')}
+  >
+    {text('Label', defaults.children ? `${defaults.children}` : '')}
+  </Link>
+);

--- a/src/components/Routing/Link.tsx
+++ b/src/components/Routing/Link.tsx
@@ -1,0 +1,41 @@
+// eslint-disable-next-line no-restricted-imports
+import { Link as MUILink, LinkProps as MUILinkProps } from '@material-ui/core';
+import React, { forwardRef } from 'react';
+import { Link as RRLink, LinkProps as RRLinkProps } from 'react-router-dom';
+import { Merge } from 'type-fest';
+
+export type LinkProps = InternalProps | ExternalProps;
+
+type BaseProps = Omit<MUILinkProps, 'component' | 'href'>;
+
+interface InternalProps
+  extends Merge<BaseProps, Omit<RRLinkProps, 'as' | 'href'>> {
+  external?: false;
+}
+
+interface ExternalProps extends BaseProps {
+  external: true;
+  to: string;
+}
+
+/**
+ * A Link to somewhere.
+ *
+ * Combines MUI Link with react router for internal routing
+ * and <a> for external routing.
+ */
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ external, to, children, ...props }, ref) => {
+    const other: any = {
+      ref,
+      component: external ? 'a' : RRLink,
+      ...(external ? { href: to } : { to }),
+    };
+
+    return (
+      <MUILink {...props} {...other}>
+        {children}
+      </MUILink>
+    );
+  }
+);

--- a/src/components/Routing/ListItemLink.stories.tsx
+++ b/src/components/Routing/ListItemLink.stories.tsx
@@ -1,0 +1,38 @@
+import { List, ListItemIcon, ListItemText } from '@material-ui/core';
+import { Home as HomeIcon, Launch, Lock } from '@material-ui/icons';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ListItemLink as LIL } from './ListItemLink';
+
+export default { title: 'Components/Routing' };
+
+export const ListItemLink = () => (
+  <MemoryRouter>
+    <List>
+      <LIL to="/">
+        <ListItemIcon>
+          <HomeIcon />
+        </ListItemIcon>
+        <ListItemText>Home</ListItemText>
+      </LIL>
+      <LIL selected={false} to="/">
+        <ListItemIcon>
+          <HomeIcon />
+        </ListItemIcon>
+        <ListItemText>Home - but I'm never "selected/active"</ListItemText>
+      </LIL>
+      <LIL to="/login">
+        <ListItemIcon>
+          <Lock />
+        </ListItemIcon>
+        <ListItemText>Login</ListItemText>
+      </LIL>
+      <LIL external to="https://google.com" target="_blank">
+        <ListItemText>Google</ListItemText>
+        <ListItemIcon>
+          <Launch />
+        </ListItemIcon>
+      </LIL>
+    </List>
+  </MemoryRouter>
+);

--- a/src/components/Routing/ListItemLink.tsx
+++ b/src/components/Routing/ListItemLink.tsx
@@ -1,0 +1,61 @@
+import { ListItem, ListItemProps } from '@material-ui/core';
+import clsx from 'clsx';
+import React, { forwardRef, Ref } from 'react';
+import { Link, NavLinkProps, useMatch } from 'react-router-dom';
+import { assert } from 'ts-essentials';
+import { Merge } from 'type-fest';
+
+export type ListItemLinkProps = InternalProps | ExternalProps;
+
+type BaseProps = Omit<ListItemProps<'a'>, 'button' | 'component' | 'href'>;
+
+interface InternalProps
+  extends Merge<BaseProps, Omit<NavLinkProps, 'as' | 'href'>> {
+  external?: false;
+}
+
+interface ExternalProps extends BaseProps {
+  external: true;
+  to: string;
+}
+
+/**
+ * A ListItem linking to somewhere.
+ *
+ * Uses react-router `Link` for internal routing and `<a>` for external routing.
+ *
+ * Instead of using `NavLink` here we just set `selected={true}` if current path
+ * matches since that's more idiomatic with the component. This can be disabled
+ * by passing in `selected={false}`.
+ */
+export const ListItemLink = forwardRef<HTMLAnchorElement, ListItemLinkProps>(
+  ({ external, to, children, ...props }, ref) => {
+    const active = useMatch(to);
+
+    if (external) {
+      assert(typeof to === 'string');
+      return (
+        <ListItem {...props} href={to} button ref={ref} component="a">
+          {children}
+        </ListItem>
+      );
+    }
+
+    const { activeStyle, activeClassName } = props as InternalProps;
+    return (
+      <ListItem
+        selected={active}
+        {...props}
+        to={to}
+        button
+        ref={ref as Ref<HTMLDivElement>}
+        component={Link as any}
+        aria-current={active ? props['aria-current'] ?? 'page' : undefined}
+        style={{ ...props.style, ...(active ? activeStyle : null) }}
+        className={clsx(props.className, active && activeClassName)}
+      >
+        {children}
+      </ListItem>
+    );
+  }
+);

--- a/src/components/Routing/MenuItemLink.stories.tsx
+++ b/src/components/Routing/MenuItemLink.stories.tsx
@@ -1,0 +1,22 @@
+import { MenuList, Paper } from '@material-ui/core';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { MenuItemLink as MIL } from './MenuItemLink';
+
+export default { title: 'Components/Routing' };
+
+export const MenuItemLink = () => (
+  <MemoryRouter>
+    <div style={{ display: 'flex' }}>
+      <Paper>
+        <MenuList>
+          <MIL to="/">Home</MIL>
+          <MIL to="/login">Login</MIL>
+          <MIL external to="https://google.com" target="_blank">
+            Google
+          </MIL>
+        </MenuList>
+      </Paper>
+    </div>
+  </MemoryRouter>
+);

--- a/src/components/Routing/MenuItemLink.tsx
+++ b/src/components/Routing/MenuItemLink.tsx
@@ -1,0 +1,49 @@
+import { MenuItem, MenuItemProps } from '@material-ui/core';
+import React, { forwardRef, Ref } from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+import { assert } from 'ts-essentials';
+import { Merge } from 'type-fest';
+
+export type MenuItemLinkProps = InternalProps | ExternalProps;
+
+type BaseProps = Omit<MenuItemProps<'a'>, 'button' | 'component' | 'href'>;
+
+interface InternalProps
+  extends Merge<BaseProps, Omit<LinkProps, 'as' | 'href'>> {
+  external?: false;
+}
+
+interface ExternalProps extends BaseProps {
+  external: true;
+  to: string;
+}
+
+/**
+ * A MenuItem linking to somewhere.
+ *
+ * Uses `Link` for internal routing and `<a>` for external routing.
+ */
+export const MenuItemLink = forwardRef<HTMLAnchorElement, MenuItemLinkProps>(
+  ({ external, to, children, ...props }, ref) => {
+    if (external) {
+      assert(typeof to === 'string');
+      return (
+        <MenuItem {...props} href={to} button ref={ref} component="a">
+          {children}
+        </MenuItem>
+      );
+    }
+
+    return (
+      <MenuItem
+        {...props}
+        to={to}
+        button
+        ref={ref as Ref<HTMLLIElement>}
+        component={Link as any}
+      >
+        {children}
+      </MenuItem>
+    );
+  }
+);

--- a/src/components/Routing/index.ts
+++ b/src/components/Routing/index.ts
@@ -1,0 +1,1 @@
+export * from './Link';

--- a/src/components/Routing/index.ts
+++ b/src/components/Routing/index.ts
@@ -1,2 +1,3 @@
 export * from './Link';
 export * from './ListItemLink';
+export * from './MenuItemLink';

--- a/src/components/Routing/index.ts
+++ b/src/components/Routing/index.ts
@@ -1,1 +1,2 @@
 export * from './Link';
+export * from './ListItemLink';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -19,6 +19,7 @@ const palette = createPalette({
   },
   error: {
     main: '#e87967',
+    contrastText: '#ffffff',
   },
 });
 

--- a/typings/react-router-dom/index.d.ts
+++ b/typings/react-router-dom/index.d.ts
@@ -78,7 +78,7 @@ export function useHref<S = unknown>(to: LocationDescriptor<S>): Href;
 
 export function useLocation<S = unknown>(): Location<S>;
 
-export function useMatch(to: Location): boolean;
+export function useMatch<S = unknown>(to: LocationDescriptor<S>): boolean;
 
 export interface NavigateOptions<S = unknown> {
   replace?: boolean;


### PR DESCRIPTION
Created `Link`, `ButtonLink`, `ListItemLink`, `MenuItemLink` components which represent their MUI counterparts but they are integrated to `react-router` for internal links or plain `<a>` tags for external links.

I have storybook examples for each one.

----

I cast to `any` a lot in these components, which I frown upon. However, MUI component types can't quite seem to figure out how to make these truly dynamic (it is a hard problem). Part of the reason for my component abstractions is to hide this pain point. Also, because the components define their props correctly all usage will be enforced. Therefore, the `any` escape hatch is very narrow as it should always be.