### PR TITLE
Move help icon

### DIFF
--- a/src/app/internships/internship-engagements/internship-engagements.component.scss
+++ b/src/app/internships/internship-engagements/internship-engagements.component.scss
@@ -12,6 +12,7 @@
   @include mat-elevation(3);
   z-index: 1;
   background: mat-background($theme, card);
+  padding-bottom: 60px;
 
   .active {
     color: mat-color($accent);

--- a/src/app/projects/project-engagements/project-engagements.component.scss
+++ b/src/app/projects/project-engagements/project-engagements.component.scss
@@ -12,6 +12,7 @@
   @include mat-elevation(3);
   z-index: 1;
   background: mat-background($theme, card);
+  padding-bottom: 60px;
 
   .active {
     color: mat-color($accent);

--- a/src/environments/environment.sqa.ts
+++ b/src/environments/environment.sqa.ts
@@ -10,7 +10,7 @@ export const environment = {
   },
   services: {
     'domain': 'field',
-    'plo.cord.bible': 'https://sqa-api.cordfield.com/api',
+    'plo.cord.bible': 'https://api.alpha.seedcompany.com',
   },
   googleAnalytics: 'UA-108415468-9',
 };


### PR DESCRIPTION
My only concern is that it might not be immediately apparent that you need to scroll down to see the rest of the languages in the list on Plan. If you do scroll all the way down now though, the help icon won't block the last one. 