### PR TITLE
FieldGroup

### DIFF
--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -8,6 +8,7 @@ import {
   FormHelperText,
 } from '@material-ui/core';
 import React, { FC, ReactNode } from 'react';
+import { useFieldName } from './FieldGroup';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError, useFocusOnEnabled } from './util';
 
@@ -19,7 +20,7 @@ export type CheckboxFieldProps = FieldConfig<boolean> & {
   Pick<FormControlProps, 'fullWidth' | 'margin' | 'variant'>;
 
 export const CheckboxField: FC<CheckboxFieldProps> = ({
-  name,
+  name: nameProp,
   label,
   labelPlacement,
   helperText,
@@ -30,6 +31,7 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
   variant,
   ...props
 }) => {
+  const name = useFieldName(nameProp);
   const { input, meta, rest } = useField(name, { defaultValue, ...props });
   const disabled = disabledProp ?? meta.submitting;
   const ref = useFocusOnEnabled<HTMLInputElement>(meta, disabled);

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -6,7 +6,7 @@ import {
 import { DateTime } from 'luxon';
 import React, { ComponentProps, useMemo } from 'react';
 import { Except } from 'type-fest';
-import { validators } from '.';
+import { useFieldName, validators } from '.';
 import { CalendarDate } from '../../util';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError, useFocusOnEnabled } from './util';
@@ -22,7 +22,7 @@ export interface DateFieldProps
 }
 
 export const DateField = ({
-  name,
+  name: nameProp,
   helperText,
   disabled: disabledProp,
   children,
@@ -53,6 +53,7 @@ export const DateField = ({
     [initialValueProp]
   );
 
+  const name = useFieldName(nameProp);
   const { input, meta, rest } = useField<DateTime | null>(name, {
     isEqual: isDateEqual,
     ...props,

--- a/src/components/form/FieldGroup.tsx
+++ b/src/components/form/FieldGroup.tsx
@@ -1,0 +1,16 @@
+import { compact } from 'lodash';
+import React, { createContext, FC, useContext } from 'react';
+
+export const FieldGroupContext = createContext('');
+FieldGroupContext.displayName = 'FieldGroupContext';
+
+export const FieldGroup: FC<{ prefix: string }> = ({ prefix, children }) => (
+  <FieldGroupContext.Provider value={useFieldName(prefix)}>
+    {children}
+  </FieldGroupContext.Provider>
+);
+
+export const useFieldName = (name: string) => {
+  const prefix = useContext(FieldGroupContext);
+  return compact([prefix, name]).join('.');
+};

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -4,6 +4,7 @@ import {
 } from '@material-ui/core';
 import * as React from 'react';
 import { Except } from 'type-fest';
+import { useFieldName } from './FieldGroup';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError, useFocusOnEnabled } from './util';
 
@@ -16,23 +17,24 @@ export type TextFieldProps<FieldValue = string> = FieldConfig<FieldValue> & {
 
 /** Combines final form field and MUI text field */
 export function TextField<FieldValue = string>({
-  name,
+  name: nameProp,
   InputProps,
   helperText,
   disabled: disabledProp,
   children,
   ...props
 }: TextFieldProps<FieldValue>) {
+  const name = useFieldName(nameProp);
   const { input, meta, rest } = useField(name, props);
   const disabled = disabledProp ?? meta.submitting;
   const ref = useFocusOnEnabled(meta, disabled);
 
   return (
     <MuiTextField
-      name={name}
       disabled={disabled}
       required={props.required}
       {...rest}
+      name={name}
       inputRef={ref}
       InputProps={{ ...InputProps, ...input }}
       helperText={getHelperText(meta, helperText)}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -2,6 +2,7 @@ export * from './CheckboxField';
 export * from './decorators';
 export * from './DateField';
 export * from './EmailField';
+export * from './FieldGroup';
 export * from './PasswordField';
 export * from './SubmitButton';
 export * from './SubmitError';


### PR DESCRIPTION
This allows fields to be nested, without having to duplicate the `a.b` syntax for each field.

```tsx
// Defined by API
interface CreateUserInput {
  user: {
    firstName: string;
    lastName: string;
    email: string;
  }
}

const [create] = useCreateUserMutation();
<Form<CreateUserInput> onSubmit={create}>
  {({ handleSubmit }) => (
    <form onSubmit={handleSubmit}>
      <FieldGroup prefix="user">
        <TextField name="firstName" />
        <TextField name="lastName" />
        <TextField name="email" />
      </FieldGroup>
    </form>
  )}
</Form>
```
Making these fields names the same as what's passed into the API allows _Validation_ errors to be mapped back correctly.
i.e. gets connected automatically with form (assuming `handleFormError` is used)
```
{
  'user.firstName': {
    minLength: 'first name must be more than 2 characters'
  }
}
```