### PR TITLE
Require Auth & Logout

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,8 +4,6 @@ plugins:
 extends:
   - plugin:@seedcompany/react
 rules:
-  # Makes refactoring harder
-  import/no-default-export: warn
   no-restricted-imports:
     - error
     - paths:
@@ -25,10 +23,3 @@ rules:
         - '@material-ui/core/*'
         - '@material-ui/icons/*'
         - lodash/*
-
-overrides:
-  # Allow default export on storybook files
-  - files:
-      - ./**/*.stories.tsx
-    rules:
-      import/no-default-export: off

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@graphql-codegen/typescript": "^1.13.2",
     "@graphql-codegen/typescript-operations": "^1.13.2",
     "@graphql-codegen/typescript-react-apollo": "^1.13.2",
-    "@seedcompany/eslint-plugin": "~0.0.4",
+    "@seedcompany/eslint-plugin": "~0.0.6",
     "@storybook/addon-actions": "^5.3.18",
     "@storybook/addon-info": "^5.3.18",
     "@storybook/addon-knobs": "^5.3.18",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { App } from './App';
 
 test('renders HOME', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/Welcome/i);
-  expect(linkElement).toBeInTheDocument();
+  const { getByRole } = render(<App />);
+  const spinner = getByRole('progressbar');
+  expect(spinner).toBeInTheDocument();
 });

--- a/src/api/graphql.generated.tsx
+++ b/src/api/graphql.generated.tsx
@@ -3422,6 +3422,13 @@ export type LoginMutation = { __typename?: 'Mutation' } & {
   };
 };
 
+export interface LogoutMutationVariables {}
+
+export type LogoutMutation = { __typename?: 'Mutation' } & Pick<
+  Mutation,
+  'logout'
+>;
+
 export interface ResetPasswordMutationVariables {
   input: ResetPasswordInput;
 }
@@ -3682,6 +3689,51 @@ export type LoginMutationResult = ApolloReactCommon.MutationResult<
 export type LoginMutationOptions = ApolloReactCommon.BaseMutationOptions<
   LoginMutation,
   LoginMutationVariables
+>;
+export const LogoutDocument = gql`
+  mutation Logout {
+    logout
+  }
+`;
+export type LogoutMutationFn = ApolloReactCommon.MutationFunction<
+  LogoutMutation,
+  LogoutMutationVariables
+>;
+
+/**
+ * __useLogoutMutation__
+ *
+ * To run a mutation, you first call `useLogoutMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLogoutMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [logoutMutation, { data, loading, error }] = useLogoutMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useLogoutMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    LogoutMutation,
+    LogoutMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<LogoutMutation, LogoutMutationVariables>(
+    LogoutDocument,
+    baseOptions
+  );
+}
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
+export type LogoutMutationResult = ApolloReactCommon.MutationResult<
+  LogoutMutation
+>;
+export type LogoutMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  LogoutMutation,
+  LogoutMutationVariables
 >;
 export const ResetPasswordDocument = gql`
   mutation ResetPassword($input: ResetPasswordInput!) {

--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -10,7 +10,7 @@ export type SessionUser = LoggedInUserFragment;
 
 function Session() {
   const { loading, data, client } = useSessionQuery();
-  const setSession = (user: LoggedInUserFragment) =>
+  const setSession = (user: SessionUser | null) =>
     client.writeQuery<SessionQuery>({
       query: SessionDocument,
       data: {

--- a/src/scenes/Authentication/Authentication.tsx
+++ b/src/scenes/Authentication/Authentication.tsx
@@ -41,7 +41,11 @@ export const Authentication: FC = ({ children }) => {
 
   useEffect(() => {
     if (!session && !sessionLoading && !matched) {
-      navigate('/login', { replace: true });
+      const current = location.pathname + location.search + location.hash;
+      const returnTo =
+        current !== '/' ? encodeURIComponent(current) : undefined;
+      const search = returnTo ? `?returnTo=${returnTo}` : undefined;
+      navigate({ pathname: '/login', search }, { replace: true });
     }
   }, [session, sessionLoading, navigate, matched, location]);
 

--- a/src/scenes/Authentication/Authentication.tsx
+++ b/src/scenes/Authentication/Authentication.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useRoutes } from 'react-router-dom';
 import { ForgotPassword } from './ForgotPassword';
 import { Login } from './Login/Login';
+import { Logout } from './Logout';
 import { ResetPassword } from './ResetPassword';
 
 const useStyles = makeStyles(() => ({
@@ -23,6 +24,7 @@ export const Authentication = () => {
 
   const matched = useRoutes([
     { path: '/', element: <Login className={classes.card} /> },
+    { path: '/logout', element: <Logout /> },
     {
       path: '/forgot-password',
       element: <ForgotPassword className={classes.card} />,

--- a/src/scenes/Authentication/Logout/Logout.tsx
+++ b/src/scenes/Authentication/Logout/Logout.tsx
@@ -1,0 +1,21 @@
+import { CircularProgress } from '@material-ui/core';
+import * as React from 'react';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLogoutMutation } from '../../../api';
+import { useSession } from '../../../components/Session';
+
+export const Logout = () => {
+  const navigate = useNavigate();
+  const [logout] = useLogoutMutation();
+  const [, , setCurrentUser] = useSession();
+
+  useEffect(() => {
+    logout().then(() => {
+      setCurrentUser(null);
+      navigate('/login', { replace: true });
+    });
+  }, [logout, setCurrentUser, navigate]);
+
+  return <CircularProgress />;
+};

--- a/src/scenes/Authentication/Logout/index.ts
+++ b/src/scenes/Authentication/Logout/index.ts
@@ -1,0 +1,1 @@
+export * from './Logout';

--- a/src/scenes/Authentication/Logout/logout.graphql
+++ b/src/scenes/Authentication/Logout/logout.graphql
@@ -1,0 +1,3 @@
+mutation Logout {
+  logout
+}

--- a/src/scenes/Organizations/Create/CreateOrganization.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganization.tsx
@@ -1,9 +1,7 @@
 import { useSnackbar } from 'notistack';
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 import { Except } from 'type-fest';
 import { handleFormError, useCreateOrganizationMutation } from '../../../api';
-import { useSession } from '../../../components/Session';
 import {
   CreateOrganizationForm,
   CreateOrganizationFormProps as Props,
@@ -12,14 +10,6 @@ import {
 export const CreateOrganization = (props: Except<Props, 'onSubmit'>) => {
   const [createOrg] = useCreateOrganizationMutation();
   const { enqueueSnackbar } = useSnackbar();
-  const navigate = useNavigate();
-  const [session, sessionLoading] = useSession();
-
-  useEffect(() => {
-    if (!sessionLoading && !session) {
-      navigate('/login');
-    }
-  }, [navigate, session, sessionLoading]);
 
   const submit: Props['onSubmit'] = async (input) => {
     try {

--- a/src/scenes/Root.tsx
+++ b/src/scenes/Root.tsx
@@ -19,12 +19,13 @@ const useStyles = makeStyles(() => ({
 
 export const Root = () => {
   useStyles();
-  return (
+  const routes = (
     <Routes>
       <Route path="/" element={<Home />} />
-      <Route path="/login/*" element={<Authentication />} />
       <Route path="/devtest" element={<DevTest />} />
       <Route path="/organizations/*" element={<Organizations />} />
     </Routes>
   );
+
+  return <Authentication>{routes}</Authentication>;
 };

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -2,7 +2,7 @@ import { ThemeOptions } from '@material-ui/core';
 import { pickBy } from 'lodash';
 
 export const typography: ThemeOptions['typography'] = (_palette) => ({
-  fontFamily: 'sofia-pro',
+  fontFamily: 'sofia-pro, sans-serif',
 
   allVariants: {
     fontWeight: 500,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2649,9 +2649,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@seedcompany/eslint-plugin@npm:~0.0.4":
-  version: 0.0.4
-  resolution: "@seedcompany/eslint-plugin@npm:0.0.4"
+"@seedcompany/eslint-plugin@npm:~0.0.6":
+  version: 0.0.6
+  resolution: "@seedcompany/eslint-plugin@npm:0.0.6"
   dependencies:
     "@typescript-eslint/eslint-plugin": ^2.27.0
     "@typescript-eslint/experimental-utils": ^2.27.0
@@ -2667,7 +2667,7 @@ __metadata:
   peerDependencies:
     eslint: ^6.8.0
     prettier: ^2.0.0
-  checksum: 2/90fe404aa645381e0f0b3ccf7fa9276dc8acde3f5323212122ae91f55b66f7486cc9fefe61a42976b711bee5d120c8ad10d171e85cee89e875c171e22e979b02
+  checksum: 2/a76b3725eacb9fcb3f8e6a106d1c33390e84efb9669545eeb9c36326f81b415aaac0d80a01e256232f02620663ea936a5807c859e86a496da8f5cde4aa8c79c3
   languageName: node
   linkType: hard
 
@@ -6962,7 +6962,7 @@ __metadata:
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.48
     "@material-ui/pickers": next
-    "@seedcompany/eslint-plugin": ~0.0.4
+    "@seedcompany/eslint-plugin": ~0.0.6
     "@storybook/addon-actions": ^5.3.18
     "@storybook/addon-info": ^5.3.18
     "@storybook/addon-knobs": ^5.3.18


### PR DESCRIPTION
Main changes:
- Added logout route. Closes #110 
- Enforcing logged in user for all routes (except auth ones)
- Moved auth routes to root path (`/login/forgot-password` -> `/forgot-password`)
- Implemented "return to" logic after logging in.
  `/organizations/create` -> `/login` -> `/organizations/create`

Snuck in:
- Updated our eslint plugin
- Fallback to sans-serif font while sofia is loading