### PR TITLE
Form field tweaks

### DIFF
--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -51,7 +51,6 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
         labelPlacement={labelPlacement}
         control={
           <Checkbox
-            color="primary"
             {...rest}
             inputRef={ref}
             checked={input.value}

--- a/src/components/form/SubmitButton.stories.tsx
+++ b/src/components/form/SubmitButton.stories.tsx
@@ -1,28 +1,30 @@
-import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
 import { Form } from 'react-final-form';
+import { sleep } from '../../util';
 import { SubmitButton as SB } from './SubmitButton';
 
 export default { title: 'Components/Forms' };
 
 export const SubmitButton = () => (
-  <Form onSubmit={action('onSubmit')}>
+  <Form onSubmit={() => sleep(2000)}>
     {({ handleSubmit }) => (
       <form onSubmit={handleSubmit}>
         <SB
-          name="submit"
-          spinner={boolean('Progress', true)}
           size={select('Size', ['small', 'medium', 'large'], 'large')}
           fullWidth={boolean('Full Width', true)}
           color={select(
             'Color',
             ['inherit', 'primary', 'secondary', 'default', 'error'],
-            'secondary'
+            'error'
           )}
-          onClick={action('click')}
+          variant={select(
+            'Variant',
+            ['contained', 'outlined', 'text'],
+            'contained'
+          )}
         >
-          {text('Label', 'SubmitButton')}
+          {text('Label', 'Submit')}
         </SB>
       </form>
     )}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -94,6 +94,14 @@ const overrides = ({ palette }: { palette: Palette }): Overrides => {
         },
       },
     },
+    MuiFormControlLabel: {
+      label: {
+        // Disallow user selection on labels as they are often clicked to change
+        // boolean states. An accidental double click selects the label which
+        // isn't what the user is trying to do.
+        userSelect: 'none',
+      },
+    },
     MuiFilledInput: {
       input: {
         '&:-webkit-autofill': {


### PR DESCRIPTION
- Fix SubmitButton story (regression from #140)
- Disallow form label selection to prevent accidental highlighting on double clicks
- Let theme determine default color of checkbox
