### PR TITLE
Theme Fixes / Tweaks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
-    "@babel/plugin-proposal-export-namespace-from"
+    "@babel/plugin-proposal-export-namespace-from",
+    "mui-make-styles"
   ]
 }

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -2,7 +2,6 @@
 const {
   useBabelRc,
   addBundleVisualizer,
-  addBabelPlugin,
   fixBabelImports,
   override,
 } = require('customize-cra');
@@ -13,6 +12,5 @@ module.exports = override(
     libraryDirectory: '',
     camel2DashComponentName: false,
   }),
-  addBabelPlugin('mui-make-styles'),
   addBundleVisualizer({}, true)
 );

--- a/src/theme/createTheme.ts
+++ b/src/theme/createTheme.ts
@@ -33,6 +33,9 @@ export const createTheme = ({
   });
   const theme = createMuiTheme(
     {
+      shape: {
+        borderRadius: 6,
+      },
       ...options,
       palette,
       typography,

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -13,6 +13,10 @@ export const appProps: ThemeOptions['props'] = (_theme) => ({
     shrink: true,
     required: false, // no asterisk
   },
+  MuiOutlinedInput: {
+    // because we always shrink label we always want notch applied
+    notched: true,
+  },
 });
 
 export const appOverrides: ThemeOptions['overrides'] = ({

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -15,7 +15,10 @@ export const appProps: ThemeOptions['props'] = (_theme) => ({
   },
 });
 
-export const appOverrides: ThemeOptions['overrides'] = ({ palette }) => {
+export const appOverrides: ThemeOptions['overrides'] = ({
+  palette,
+  typography,
+}) => {
   const primaryColorForText = palette.dark
     ? palette.primary.light
     : palette.primary.main;
@@ -26,14 +29,14 @@ export const appOverrides: ThemeOptions['overrides'] = ({ palette }) => {
       },
       containedSizeLarge: {
         fontSize: '1rem',
-        fontWeight: 400,
+        fontWeight: typography.weight.regular,
         padding: '16px 40px',
       },
     },
     MuiFormLabel: {
       root: {
         textTransform: 'uppercase',
-        fontWeight: 500,
+        fontWeight: typography.weight.medium,
         '&$focused': {
           color: primaryColorForText,
         },

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -6,7 +6,7 @@ export const typography: ThemeOptions['typography'] = (palette) => {
     light: 300, // default
     regular: 400, // default
     medium: 500, // default
-    bold: 700, // default
+    bold: 600,
   };
   return {
     fontFamily: 'sofia-pro, sans-serif',

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,29 +1,43 @@
 import { pickBy } from 'lodash';
 import { ThemeOptions } from './createTheme';
 
-export const typography: ThemeOptions['typography'] = (palette) => ({
-  fontFamily: 'sofia-pro, sans-serif',
+export const typography: ThemeOptions['typography'] = (palette) => {
+  const weight: FontWeights = {
+    light: 300, // default
+    regular: 400, // default
+    medium: 500, // default
+    bold: 700, // default
+  };
+  return {
+    fontFamily: 'sofia-pro, sans-serif',
 
-  allVariants: {
-    fontWeight: 500,
-    color: palette.text.primary,
-  },
+    weight,
+    fontWeightLight: weight.light,
+    fontWeightRegular: weight.regular,
+    fontWeightMedium: weight.medium,
+    fontWeightBold: weight.bold,
 
-  // Header 1
-  h1: variant(44, 55),
-  // Header 2
-  h2: variant(32, 36),
-  // Header 3
-  h3: variant(24, 28),
-  // Header 4
-  h4: variant(18, 24),
-  // Body Copy
-  body1: variant(16, 20, 400),
-  // Small Copy
-  body2: variant(14, 18),
-  // X-Small / Legal Copy
-  caption: variant(12, 14),
-});
+    allVariants: {
+      fontWeight: weight.medium,
+      color: palette.text.primary,
+    },
+
+    // Header 1
+    h1: variant(44, 55),
+    // Header 2
+    h2: variant(32, 36),
+    // Header 3
+    h3: variant(24, 28),
+    // Header 4
+    h4: variant(18, 24),
+    // Body Copy
+    body1: variant(16, 20, weight.regular),
+    // Small Copy
+    body2: variant(14, 18),
+    // X-Small / Legal Copy
+    caption: variant(12, 14),
+  };
+};
 
 const variant = (size: number, lineHeightPx: number, weight?: number) =>
   pickBy({
@@ -31,3 +45,16 @@ const variant = (size: number, lineHeightPx: number, weight?: number) =>
     fontWeight: weight,
     lineHeight: lineHeightPx / size,
   });
+
+interface FontWeights {
+  light: number;
+  regular: number;
+  medium: number;
+  bold: number;
+}
+
+declare module '@material-ui/core/styles/createTypography' {
+  interface FontStyle {
+    weight: FontWeights;
+  }
+}


### PR DESCRIPTION
- Fix regression in border radius from b41444e
- Further define font weights within theme with possibility to augment
- Change bold from 700 to 600
- Move our babel mui-make-styles plugin to .babelrc so it's also picked up by storybook
- Fix OutlinedInput notch since we always shrink label
