### PR TITLE
RadioField label closer to designs

### DIFF
--- a/src/components/form/RadioField.stories.tsx
+++ b/src/components/form/RadioField.stories.tsx
@@ -30,6 +30,7 @@ export const Radio = () => {
           >
             {['red', 'blue', 'green'].map((color) => (
               <RadioOption
+                key={color}
                 label={startCase(color)}
                 value={color}
                 disabled={disabled}

--- a/src/components/form/RadioField.tsx
+++ b/src/components/form/RadioField.tsx
@@ -5,6 +5,7 @@ import {
   FormControlProps,
   FormHelperText,
   FormLabel,
+  makeStyles,
   Radio,
   RadioGroup,
 } from '@material-ui/core';
@@ -24,6 +25,12 @@ interface RadioOptionProps<T = string>
   extends Pick<FormControlLabelProps, 'label' | 'labelPlacement' | 'disabled'> {
   value: T;
 }
+
+const useStyles = makeStyles(({ typography }) => ({
+  fieldLabel: {
+    fontWeight: typography.weight.bold,
+  },
+}));
 
 export const RadioOption = <FieldValue extends any = string>({
   label,
@@ -59,15 +66,21 @@ export const RadioField = <FieldValue extends any = string>({
     required: true,
     ...props,
   });
+  const classes = useStyles();
   return (
     <FormControl
+      color="primary"
       {...rest}
       component="fieldset"
       error={showError(meta)}
       required
       disabled={props.disabled ?? meta.submitting}
     >
-      {label && <FormLabel component="legend">{label}</FormLabel>}
+      {label && (
+        <FormLabel component="legend" className={classes.fieldLabel}>
+          {label}
+        </FormLabel>
+      )}
       <RadioGroup {...input}>{children}</RadioGroup>
       <FormHelperText>{getHelperText(meta, helperText)}</FormHelperText>
     </FormControl>

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -9,9 +9,11 @@ export const appProps: ThemeOptions['props'] = (_theme) => ({
     fullWidth: true,
     margin: 'dense',
   },
+  MuiFormLabel: {
+    required: false, // no asterisk
+  },
   MuiInputLabel: {
     shrink: true,
-    required: false, // no asterisk
   },
   MuiOutlinedInput: {
     // because we always shrink label we always want notch applied
@@ -37,7 +39,7 @@ export const appOverrides: ThemeOptions['overrides'] = ({
         padding: '16px 40px',
       },
     },
-    MuiFormLabel: {
+    MuiInputLabel: {
       root: {
         textTransform: 'uppercase',
         fontWeight: typography.weight.medium,


### PR DESCRIPTION
- no asterisk on all labels not just input ones
- uppercase, etc. only one input labels not all labels
- Radio labels are bold
- Label is green (primary color) when field is active (not designs, but I think it looks good)