### PR TITLE
Search and Profile Toolbar

### DIFF
--- a/src/components/Picture/Picture.tsx
+++ b/src/components/Picture/Picture.tsx
@@ -308,14 +308,15 @@ const PictureImpl = ({
       }}
       onError={(e) => {
         const url = e.currentTarget.srcset;
-        // eslint-disable-next-line no-console
-        console.error('Image failed to load\n', url);
         if (!isMounted()) {
           return;
         }
         setErrored(url);
         if (rest.onError) {
           rest.onError(e);
+        } else {
+          // eslint-disable-next-line no-console
+          console.error('Image failed to load\n', url);
         }
       }}
     />

--- a/src/scenes/Projects/ProjectList.tsx
+++ b/src/scenes/Projects/ProjectList.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles(({ spacing }) => ({
   root: {
     flex: 1,
     overflowY: 'scroll',
-    padding: spacing(5),
+    padding: spacing(4),
   },
   options: {
     margin: spacing(3, 0),

--- a/src/scenes/Root/Header/Header.tsx
+++ b/src/scenes/Root/Header/Header.tsx
@@ -1,0 +1,26 @@
+import { makeStyles } from '@material-ui/core';
+import { FC } from 'react';
+import * as React from 'react';
+import { HeaderSearch } from './HeaderSearch';
+import { ProfileToolbar } from './ProfileToolbar';
+
+const useStyles = makeStyles(({ spacing }) => ({
+  header: {
+    padding: spacing(4),
+    width: '100%',
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+  },
+}));
+
+export const Header: FC = () => {
+  const classes = useStyles();
+
+  return (
+    <header className={classes.header}>
+      <HeaderSearch />
+      <ProfileToolbar />
+    </header>
+  );
+};

--- a/src/scenes/Root/Header/Header.tsx
+++ b/src/scenes/Root/Header/Header.tsx
@@ -5,9 +5,8 @@ import { HeaderSearch } from './HeaderSearch';
 import { ProfileToolbar } from './ProfileToolbar';
 
 const useStyles = makeStyles(({ spacing }) => ({
-  header: {
-    padding: spacing(4),
-    width: '100%',
+  root: {
+    padding: spacing(4, 4, 0, 4),
     display: 'flex',
     alignItems: 'baseline',
     justifyContent: 'space-between',
@@ -18,7 +17,7 @@ export const Header: FC = () => {
   const classes = useStyles();
 
   return (
-    <header className={classes.header}>
+    <header className={classes.root}>
       <HeaderSearch />
       <ProfileToolbar />
     </header>

--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.stories.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.stories.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { HeaderSearch as HS } from './HeaderSearch';
+
+export default { title: 'Scenes/Root/Header' };
+
+export const HeaderSearch = () => <HS />;

--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
@@ -1,14 +1,12 @@
-import { InputAdornment, makeStyles, OutlinedInput } from '@material-ui/core';
+import { InputAdornment, makeStyles, TextField } from '@material-ui/core';
 import { Search } from '@material-ui/icons';
 import { FC } from 'react';
 import * as React from 'react';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ spacing }) => ({
   root: {
-    minWidth: '550px',
-  },
-  input: {
-    padding: '12px',
+    maxWidth: 500,
+    marginRight: spacing(3),
   },
 }));
 
@@ -16,18 +14,18 @@ export const HeaderSearch: FC = () => {
   const classes = useStyles();
 
   return (
-    <OutlinedInput
-      classes={{
-        root: classes.root,
-        input: classes.input,
-      }}
-      id="input-search"
+    <TextField
+      variant="outlined"
+      className={classes.root}
       placeholder="Projects, Languages, Regions, People"
-      startAdornment={
-        <InputAdornment position="start">
-          <Search />
-        </InputAdornment>
-      }
+      size="small"
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <Search />
+          </InputAdornment>
+        ),
+      }}
     />
   );
 };

--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
@@ -1,0 +1,33 @@
+import { InputAdornment, makeStyles, OutlinedInput } from '@material-ui/core';
+import { Search } from '@material-ui/icons';
+import { FC } from 'react';
+import * as React from 'react';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    minWidth: '550px',
+  },
+  input: {
+    padding: '12px',
+  },
+}));
+
+export const HeaderSearch: FC = () => {
+  const classes = useStyles();
+
+  return (
+    <OutlinedInput
+      classes={{
+        root: classes.root,
+        input: classes.input,
+      }}
+      id="input-search"
+      placeholder="Projects, Languages, Regions, People"
+      startAdornment={
+        <InputAdornment position="start">
+          <Search />
+        </InputAdornment>
+      }
+    />
+  );
+};

--- a/src/scenes/Root/Header/HeaderSearch/index.ts
+++ b/src/scenes/Root/Header/HeaderSearch/index.ts
@@ -1,0 +1,1 @@
+export * from './HeaderSearch';

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.stories.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.stories.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ProfileMenu as PM } from './ProfileMenu';
+
+export default { title: 'Scenes/Root/Header' };
+
+export const ProfileMenu = () => (
+  <PM anchorEl={null} handleClose={() => false} />
+);

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.stories.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.stories.tsx
@@ -3,6 +3,4 @@ import { ProfileMenu as PM } from './ProfileMenu';
 
 export default { title: 'Scenes/Root/Header' };
 
-export const ProfileMenu = () => (
-  <PM anchorEl={null} handleClose={() => false} />
-);
+export const ProfileMenu = () => <PM open />;

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
@@ -1,61 +1,51 @@
-import { makeStyles, Menu, MenuItem } from '@material-ui/core';
-import { FC } from 'react';
+import {
+  Divider,
+  makeStyles,
+  Menu,
+  MenuProps,
+  Typography,
+  useTheme,
+} from '@material-ui/core';
 import * as React from 'react';
-import { Link } from '../../../../components/Routing';
+import { MenuItemLink } from '../../../../components/Routing';
 
-const useStyles = makeStyles(({ typography }) => ({
+const useStyles = makeStyles(({ spacing }) => ({
   menu: {
-    width: '230px',
-    position: 'absolute',
-    top: '100px !important',
-    right: '100px !important',
-    left: 'auto !important',
+    minWidth: 200,
   },
   menuHeading: {
-    fontWeight: typography.fontWeightMedium,
-    padding: '8px 0',
-    fontSize: 16,
-  },
-  signOut: {
-    padding: '14px 0 6px 0',
-    borderTop: '1px solid #E5E5E5',
-    display: 'block',
-  },
-  paper: {
-    position: 'static',
-    padding: '16px',
+    padding: spacing(1, 2, 2, 2),
   },
 }));
 
-export interface ProfileMenuProps {
-  anchorEl: Element | null | undefined;
-  handleClose: (type: any) => void;
-}
+// Menu looks for disabled prop to skip over when choosing
+// which item to auto focus first.
+const skipAutoFocus: any = { disabled: true };
 
-export const ProfileMenu: FC<ProfileMenuProps> = ({
-  anchorEl,
-  handleClose,
-}) => {
+export const ProfileMenu = (props: Partial<MenuProps>) => {
   const classes = useStyles();
+  const { spacing } = useTheme();
 
   return (
     <Menu
-      className={classes.menu}
-      classes={{
-        paper: classes.paper,
-      }}
       id="profile-menu"
-      anchorEl={anchorEl}
       keepMounted
-      open={Boolean(anchorEl)}
-      onClose={() => handleClose(null)}
+      open={Boolean(props.anchorEl)}
+      getContentAnchorEl={null}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: spacing(-2), horizontal: 'right' }}
+      classes={{ paper: classes.menu }}
+      {...props}
     >
-      <MenuItem className={classes.menuHeading} color="secondary">
+      <Typography
+        variant="h4"
+        className={classes.menuHeading}
+        {...skipAutoFocus}
+      >
         Profile Info
-      </MenuItem>
-      <Link className={classes.signOut} to="/logout">
-        Sign Out
-      </Link>
+      </Typography>
+      <Divider {...skipAutoFocus} />
+      <MenuItemLink to="/logout">Sign Out</MenuItemLink>
     </Menu>
   );
 };

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
@@ -1,0 +1,61 @@
+import { makeStyles, Menu, MenuItem } from '@material-ui/core';
+import { FC } from 'react';
+import * as React from 'react';
+import { Link } from '../../../../components/Routing';
+
+const useStyles = makeStyles(({ typography }) => ({
+  menu: {
+    width: '230px',
+    position: 'absolute',
+    top: '100px !important',
+    right: '100px !important',
+    left: 'auto !important',
+  },
+  menuHeading: {
+    fontWeight: typography.fontWeightMedium,
+    padding: '8px 0',
+    fontSize: 16,
+  },
+  signOut: {
+    padding: '14px 0 6px 0',
+    borderTop: '1px solid #E5E5E5',
+    display: 'block',
+  },
+  paper: {
+    position: 'static',
+    padding: '16px',
+  },
+}));
+
+export interface ProfileMenuProps {
+  anchorEl: Element | null | undefined;
+  handleClose: (type: any) => void;
+}
+
+export const ProfileMenu: FC<ProfileMenuProps> = ({
+  anchorEl,
+  handleClose,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <Menu
+      className={classes.menu}
+      classes={{
+        paper: classes.paper,
+      }}
+      id="profile-menu"
+      anchorEl={anchorEl}
+      keepMounted
+      open={Boolean(anchorEl)}
+      onClose={() => handleClose(null)}
+    >
+      <MenuItem className={classes.menuHeading} color="secondary">
+        Profile Info
+      </MenuItem>
+      <Link className={classes.signOut} to="/logout">
+        Sign Out
+      </Link>
+    </Menu>
+  );
+};

--- a/src/scenes/Root/Header/ProfileMenu/index.ts
+++ b/src/scenes/Root/Header/ProfileMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileMenu';

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.stories.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.stories.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { ProfileToolbar as PT } from './ProfileToolbar';
+
+export default { title: 'Scenes/Root/Header' };
+
+export const ProfileToolbar = () => <PT />;

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
@@ -1,54 +1,47 @@
-import { Card, IconButton, makeStyles, Typography } from '@material-ui/core';
+import {
+  Card,
+  IconButton,
+  makeStyles,
+  MenuProps,
+  Typography,
+} from '@material-ui/core';
 import { AccountCircle, MoreVert, NotificationsNone } from '@material-ui/icons';
 import { FC, useState } from 'react';
 import * as React from 'react';
 import { useSession } from '../../../../components/Session';
 import { ProfileMenu } from '../ProfileMenu';
 
-const useStyles = makeStyles(({ palette, typography }) => ({
-  name: {
-    fontWeight: typography.fontWeightMedium,
-  },
-  menuWrap: {
-    position: 'relative',
-  },
-  infoWrap: {
+const useStyles = makeStyles(({ typography, spacing }) => ({
+  card: {
+    flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'flex-end',
-    backgroundColor: 'white',
-    padding: '4px 16px',
-    borderRadius: '6px',
+    padding: spacing(1),
   },
-  icon: {
-    marginLeft: '12px',
-    cursor: 'pointer',
-    '&:last-child': {
-      marginLeft: '6px',
-    },
-  },
-  iconProfile: {
-    fill: palette.secondary.main,
+  name: {
+    fontWeight: typography.weight.medium,
+    margin: spacing(0, 1, 0, 2),
   },
 }));
 
 export const ProfileToolbar: FC = () => {
   const classes = useStyles();
   const [session] = useSession();
-  const [anchorEl, setAnchorEl] = useState(undefined);
-
-  const handleClick = (event: any) => {
-    setAnchorEl(event.currentTarget);
-  };
+  const [anchor, setAnchor] = useState<MenuProps['anchorEl']>();
 
   return (
-    <div className={classes.menuWrap}>
-      <Card className={classes.infoWrap}>
+    <>
+      <Card className={classes.card}>
         <Typography className={classes.name} color="primary">
-          Hi, {session?.realFirstName.value}
+          Hi, {session?.realFirstName?.value ?? 'Friend'}
         </Typography>
-        <IconButton onClick={handleClick}>
-          <AccountCircle className={classes.iconProfile} />
+        <IconButton
+          color="secondary"
+          aria-controls="profile-menu"
+          aria-haspopup="true"
+          onClick={(e) => setAnchor(e.currentTarget)}
+        >
+          <AccountCircle />
         </IconButton>
         <IconButton>
           <NotificationsNone />
@@ -57,9 +50,7 @@ export const ProfileToolbar: FC = () => {
           <MoreVert />
         </IconButton>
       </Card>
-      {anchorEl && (
-        <ProfileMenu anchorEl={anchorEl} handleClose={setAnchorEl} />
-      )}
-    </div>
+      <ProfileMenu anchorEl={anchor} onClose={() => setAnchor(null)} />
+    </>
   );
 };

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
@@ -1,0 +1,65 @@
+import { Card, IconButton, makeStyles, Typography } from '@material-ui/core';
+import { AccountCircle, MoreVert, NotificationsNone } from '@material-ui/icons';
+import { FC, useState } from 'react';
+import * as React from 'react';
+import { useSession } from '../../../../components/Session';
+import { ProfileMenu } from '../ProfileMenu';
+
+const useStyles = makeStyles(({ palette, typography }) => ({
+  name: {
+    fontWeight: typography.fontWeightMedium,
+  },
+  menuWrap: {
+    position: 'relative',
+  },
+  infoWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    backgroundColor: 'white',
+    padding: '4px 16px',
+    borderRadius: '6px',
+  },
+  icon: {
+    marginLeft: '12px',
+    cursor: 'pointer',
+    '&:last-child': {
+      marginLeft: '6px',
+    },
+  },
+  iconProfile: {
+    fill: palette.secondary.main,
+  },
+}));
+
+export const ProfileToolbar: FC = () => {
+  const classes = useStyles();
+  const [session] = useSession();
+  const [anchorEl, setAnchorEl] = useState(undefined);
+
+  const handleClick = (event: any) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  return (
+    <div className={classes.menuWrap}>
+      <Card className={classes.infoWrap}>
+        <Typography className={classes.name} color="primary">
+          Hi, {session?.realFirstName.value}
+        </Typography>
+        <IconButton onClick={handleClick}>
+          <AccountCircle className={classes.iconProfile} />
+        </IconButton>
+        <IconButton>
+          <NotificationsNone />
+        </IconButton>
+        <IconButton>
+          <MoreVert />
+        </IconButton>
+      </Card>
+      {anchorEl && (
+        <ProfileMenu anchorEl={anchorEl} handleClose={setAnchorEl} />
+      )}
+    </div>
+  );
+};

--- a/src/scenes/Root/Header/ProfileToolbar/index.ts
+++ b/src/scenes/Root/Header/ProfileToolbar/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileToolbar';

--- a/src/scenes/Root/Header/index.ts
+++ b/src/scenes/Root/Header/index.ts
@@ -1,0 +1,1 @@
+export * from './Header';

--- a/src/scenes/Root/Root.tsx
+++ b/src/scenes/Root/Root.tsx
@@ -17,10 +17,15 @@ const useStyles = makeStyles(() => ({
       display: 'flex',
     },
   },
+  main: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  },
 }));
 
 export const Root = () => {
-  useStyles();
+  const classes = useStyles();
   const routes = (
     <Routes>
       <Route path="/" element={<Home />} />
@@ -33,8 +38,10 @@ export const Root = () => {
   return (
     <Authentication>
       <Sidebar />
-      <Header />
-      {routes}
+      <div className={classes.main}>
+        <Header />
+        {routes}
+      </div>
     </Authentication>
   );
 };

--- a/src/scenes/Root/Root.tsx
+++ b/src/scenes/Root/Root.tsx
@@ -6,6 +6,7 @@ import { DevTest } from '../DevTest';
 import { Home } from '../Home';
 import { Organizations } from '../Organizations';
 import { Projects } from '../Projects';
+import { Header } from './Header';
 import { Sidebar } from './Sidebar';
 
 const useStyles = makeStyles(() => ({
@@ -32,6 +33,7 @@ export const Root = () => {
   return (
     <Authentication>
       <Sidebar />
+      <Header />
       {routes}
     </Authentication>
   );


### PR DESCRIPTION
This PR resolves issue #141 and adds the Header component, which is comprised of two new components - `HeaderSearch` and `ProfileToolbar`. 

Clicking the avatar icon toggles the menu for logout. 

![image](https://user-images.githubusercontent.com/4968115/81511388-12478880-92e7-11ea-858b-ec9ba806cb34.png)

