### PR TITLE
useRandomPicture Hook

### DIFF
--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
@@ -7,13 +7,12 @@ import {
   TypographyProps,
 } from '@material-ui/core';
 import clsx from 'clsx';
-import { random } from 'lodash';
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import * as React from 'react';
 import { displayEngagementStatus } from '../../api/displayStatus';
 import { useDateFormatter, useNumberFormatter } from '../Formatters';
 import { PencilCircledIcon, ScriptIcon } from '../Icons';
-import { Picture } from '../Picture';
+import { Picture, useRandomPicture } from '../Picture';
 import { CardActionAreaLink } from '../Routing';
 import { LanguageEngagementListItemFragment } from './LanguageEngagementListItem.generated';
 
@@ -75,9 +74,7 @@ export const LanguageEngagementListItemCard: FC<LanguageEngagementListItemCardPr
   const numberFormatter = useNumberFormatter();
   const dateFormatter = useDateFormatter();
   const classes = useStyles();
-  const genSrc = () => `https://picsum.photos/id/${random(1, 2000)}/300/200`;
-  const [pic, setPic] = useState(genSrc);
-  const nextPic = () => setPic(genSrc());
+  const pic = useRandomPicture({ seed: props.id, width: 300, height: 200 });
 
   const language = props.language.value;
   const name = language?.name.value ?? language?.displayName?.value;
@@ -94,7 +91,7 @@ export const LanguageEngagementListItemCard: FC<LanguageEngagementListItemCardPr
         className={classes.card}
       >
         <div className={classes.media}>
-          <Picture source={pic} fit="cover" onError={nextPic} />
+          <Picture fit="cover" {...pic} />
         </div>
         <CardContent className={classes.cardContent}>
           <Grid

--- a/src/components/Picture/index.ts
+++ b/src/components/Picture/index.ts
@@ -1,1 +1,2 @@
 export * from './Picture';
+export * from './useRandomPicture';

--- a/src/components/Picture/picsum.ts
+++ b/src/components/Picture/picsum.ts
@@ -1,0 +1,31 @@
+export interface PicsumOptions {
+  width: number;
+  height?: number;
+  seed?: string;
+  id?: number;
+  grayscale?: boolean;
+  blur?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+  webp?: boolean;
+}
+
+export const picsumUrl = (options: PicsumOptions) => {
+  const parts = [
+    'https://picsum.photos/',
+    options.id
+      ? `id/${options.id}`
+      : options.seed
+      ? `seed/${options.seed}/`
+      : '',
+    `${options.width}`,
+    options.height ? `/${options.height}` : '',
+    options.webp ? `.webp` : '',
+  ];
+  const query = new URLSearchParams();
+  if (options.grayscale) {
+    query.set('grayscale', '');
+  }
+  if (options.blur) {
+    query.set('blur', `${options.blur}`);
+  }
+  return parts.join('') + '?' + query.toString();
+};

--- a/src/components/Picture/useRandomPicture.tsx
+++ b/src/components/Picture/useRandomPicture.tsx
@@ -1,0 +1,7 @@
+import { PicsumOptions, picsumUrl } from './picsum';
+
+export const useRandomPicture = (options: PicsumOptions) => ({
+  width: options.width,
+  height: options.height,
+  source: picsumUrl(options),
+});

--- a/src/components/ProjectListItemCard/ProjectListItemCard.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.tsx
@@ -8,12 +8,11 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import { random } from 'lodash';
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import * as React from 'react';
 import { displayStatus } from '../../api/displayStatus';
 import { displayLocation } from '../../api/location-helper';
-import { Picture } from '../Picture';
+import { Picture, useRandomPicture } from '../Picture';
 import { CardActionAreaLink } from '../Routing';
 import { Sensitivity } from '../Sensitivity';
 import { ProjectListItemFragment } from './ProjectListItem.generated';
@@ -73,9 +72,7 @@ export const ProjectListItemCard: FC<ProjectListItemCardProps> = ({
   className,
 }) => {
   const classes = useStyles();
-  const genSrc = () => `https://picsum.photos/id/${random(1, 2000)}/300/200`;
-  const [pic, setPic] = useState(genSrc);
-  const nextPic = () => setPic(genSrc());
+  const pic = useRandomPicture({ seed: project?.id, width: 300, height: 200 });
 
   return (
     <Card className={clsx(classes.root, className)}>
@@ -88,13 +85,7 @@ export const ProjectListItemCard: FC<ProjectListItemCardProps> = ({
           {!project ? (
             <Skeleton variant="rect" height={200} />
           ) : (
-            <Picture
-              source={pic}
-              fit="cover"
-              width={300}
-              height={200}
-              onError={nextPic}
-            />
+            <Picture fit="cover" {...pic} />
           )}
         </div>
         <CardContent className={classes.cardContent}>


### PR DESCRIPTION
- Added `useRandomPicture` with all of picsum's options, which generate a url from them and give back props for the `Picture` component
- Using item's `id` as the picture `seed` so it is consistent between reloads and we don't have to do the random guess with an error loop