### PR TITLE
Member List Summary initial blockout done

### DIFF
--- a/src/components/MemberListSummary/MemberListSummary.stories.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.stories.tsx
@@ -1,0 +1,7 @@
+import {} from '@storybook/addon-knobs';
+import React from 'react';
+import { MemberListSummary as MemberListSummaryComponent } from './MemberListSummary';
+
+export default { title: 'Components' };
+
+export const MemberListSummary = () => <MemberListSummaryComponent />;

--- a/src/components/MemberListSummary/MemberListSummary.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.tsx
@@ -1,0 +1,64 @@
+import {
+  Avatar,
+  CardContent,
+  Grid,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+import { Group } from '@material-ui/icons';
+import { AvatarGroup } from '@material-ui/lab';
+import { FC } from 'react';
+import * as React from 'react';
+import { HugeIcon } from '../Icons';
+import { CardActionAreaLink, Link } from '../Routing';
+
+const useStyles = makeStyles(() => ({
+  topContent: {
+    display: 'flex',
+  },
+  bottomContent: {
+    display: 'flex',
+  },
+}));
+
+export const MemberListSummary: FC = () => {
+  const classes = useStyles();
+
+  return (
+    // TODO figure out where this route is supposed to go
+    <CardActionAreaLink to="/somewhere">
+      <CardContent>
+        <Grid container spacing={4}>
+          <Grid item>
+            <HugeIcon icon={Group} />
+          </Grid>
+          <Grid item>
+            <Typography>Team Members</Typography>
+            <Typography variant="h1">12</Typography>
+          </Grid>
+          {/* TODO figure out where this link is supposed to go */}
+          <Grid item>
+            <Link to="/somewhere">See All</Link>
+          </Grid>
+        </Grid>
+        <div className={classes.bottomContent}>
+          <AvatarGroup max={4}>
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+            <Avatar alt="someName" src="images/favicon-32x32.png" />
+          </AvatarGroup>
+          {/* TODO figure out if this is supposed to be link that goes
+          somewhere and what text is supposed to be */}
+          <Link to="/somewhere">
+            You, Tyler, Vanessa
+            <br />& 8 others
+          </Link>
+        </div>
+      </CardContent>
+    </CardActionAreaLink>
+  );
+};

--- a/src/components/MemberListSummary/index.ts
+++ b/src/components/MemberListSummary/index.ts
@@ -1,0 +1,1 @@
+export * from './MemberListSummary';

--- a/src/components/PersonCard/PersonCard.tsx
+++ b/src/components/PersonCard/PersonCard.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   Card,
   CardActions,
   CardContent,
@@ -8,7 +9,6 @@ import {
 import clsx from 'clsx';
 import * as React from 'react';
 import { FC } from 'react';
-import { Picture } from '../Picture';
 import { ButtonLink } from '../Routing';
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
@@ -79,7 +79,12 @@ export const PersonCard: FC<PersonCardProps> = ({
   return (
     <Card className={classes.personCard}>
       <CardContent className={classes.cardContent}>
-        <Picture className={classes.personImage} source={imageSource} />
+        <Avatar
+          variant="circle"
+          alt={name}
+          src={imageSource}
+          className={classes.personImage}
+        />
         <Typography
           color="textPrimary"
           variant="body2"


### PR DESCRIPTION
Initial member list summary card pr. Still need to add loading skeletons in. Had a few questions:
- Where is the path link should redirect to for entire card?
- I'm using Material UI group icon instead of what is in Figma because I was having difficulty extracting entire svg.
- For props I'm just passing in an array for all the users. Should I assume the array is of type User?