### PR TITLE
Custom Scalars

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -23,11 +23,16 @@ generates:
   ./src/api/schema.generated.ts:
     plugins:
       - typescript
+      - add:
+          placement: prepend
+          content: |
+            import { DateTime } from 'luxon';
+            import { CalendarDate } from '../util';
     config:
       reactApolloVersion: 3
       scalars:
-        Date: string
-        DateTime: string
+        Date: CalendarDate
+        DateTime: DateTime
       skipTypename: false
       enumsAsTypes: true
   ./src/:

--- a/codegen.yml
+++ b/codegen.yml
@@ -15,6 +15,11 @@ generates:
           content: export const possibleTypes = result.possibleTypes;
     config:
       apolloClientVersion: 3
+  ./src/api/scalars/scalars.generated.ts:
+    plugins:
+      - ./src/api/scalars/scalars.codegen
+    config:
+      parserImport: ./scalars.parser
   ./src/api/schema.generated.ts:
     plugins:
       - typescript

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@graphql-codegen/fragment-matcher": "^1.13.5",
     "@graphql-codegen/introspection": "^1.13.2",
     "@graphql-codegen/near-operation-file-preset": "^1.13.5",
+    "@graphql-codegen/plugin-helpers": "^1.13.2",
     "@graphql-codegen/typescript": "^1.13.2",
     "@graphql-codegen/typescript-operations": "^1.13.2",
     "@graphql-codegen/typescript-react-apollo": "^1.13.2",

--- a/src/api/ApolloProvider.tsx
+++ b/src/api/ApolloProvider.tsx
@@ -11,6 +11,7 @@ import { Close } from '@material-ui/icons';
 import { ProviderContext as Snackbar, useSnackbar } from 'notistack';
 import React, { FC, useRef, useState } from 'react';
 import { possibleTypes } from './fragmentMatcher.generated';
+import { typePolicies } from './scalars';
 
 const serverHost = process.env.REACT_APP_API_BASE_URL || '';
 
@@ -34,6 +35,7 @@ export const ApolloProvider: FC = ({ children }) => {
     return new ApolloClient({
       cache: new InMemoryCache({
         possibleTypes,
+        typePolicies,
       }),
       link: concat(errorLink, httpLink),
     });

--- a/src/api/scalars/index.ts
+++ b/src/api/scalars/index.ts
@@ -1,0 +1,1 @@
+export * from './scalars.generated';

--- a/src/api/scalars/scalars.codegen.js
+++ b/src/api/scalars/scalars.codegen.js
@@ -1,0 +1,48 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const graphql_1 = require('graphql');
+const lodash_1 = require('lodash');
+const builtInScalars = ['Boolean', 'ID', 'Int', 'Float', 'String'];
+exports.plugin = (schema, documents, config, _info) => {
+  const typePolicies = {};
+  for (const val of Object.values(schema.getTypeMap())) {
+    if (!(val instanceof graphql_1.GraphQLObjectType)) {
+      continue;
+    }
+    for (const field of Object.values(val.getFields())) {
+      let type = field.type;
+      let required = false;
+      if (type instanceof graphql_1.GraphQLNonNull) {
+        required = true;
+        type = type.ofType;
+      }
+      if (
+        !(type instanceof graphql_1.GraphQLScalarType) ||
+        builtInScalars.includes(type.name)
+      ) {
+        continue;
+      }
+      let mapper = `Parsers.${type.name}`;
+      if (!required) {
+        mapper = `optional(${mapper})`;
+      }
+      lodash_1.set(
+        typePolicies,
+        [val.name, 'fields', field.name, 'read'],
+        mapper
+      );
+    }
+  }
+  const content = JSON.stringify(typePolicies, undefined, 2).replace(/"/g, '');
+  // language=TypeScript
+  return `
+import { TypePolicies } from '@apollo/client';
+import { Parsers } from '${config.parserImport}';
+
+const optional = <T, R>(parser: (val: T) => R) => (
+  val: T | null | undefined
+): R | null => (val != null ? parser(val) : null);
+
+export const typePolicies: TypePolicies = ${content}
+`;
+};

--- a/src/api/scalars/scalars.codegen.ts
+++ b/src/api/scalars/scalars.codegen.ts
@@ -1,0 +1,53 @@
+import { TypePolicies } from '@apollo/client';
+import { PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { GraphQLNonNull, GraphQLObjectType, GraphQLScalarType } from 'graphql';
+import { set } from 'lodash';
+
+const builtInScalars = ['Boolean', 'ID', 'Int', 'Float', 'String'];
+
+export const plugin: PluginFunction<
+  {
+    parserImport: string;
+  },
+  string
+> = (schema, documents, config, _info) => {
+  const typePolicies: TypePolicies = {};
+  for (const val of Object.values(schema.getTypeMap())) {
+    if (!(val instanceof GraphQLObjectType)) {
+      continue;
+    }
+    for (const field of Object.values(val.getFields())) {
+      let type = field.type;
+      let required = false;
+      if (type instanceof GraphQLNonNull) {
+        required = true;
+        type = type.ofType;
+      }
+      if (
+        !(type instanceof GraphQLScalarType) ||
+        builtInScalars.includes(type.name)
+      ) {
+        continue;
+      }
+      let mapper = `Parsers.${type.name}`;
+      if (!required) {
+        mapper = `optional(${mapper})`;
+      }
+      set(typePolicies, [val.name, 'fields', field.name, 'read'], mapper);
+    }
+  }
+
+  const content = JSON.stringify(typePolicies, undefined, 2).replace(/"/g, '');
+
+  // language=TypeScript
+  return `
+import { TypePolicies } from '@apollo/client';
+import { Parsers } from '${config.parserImport}';
+
+const optional = <T, R>(parser: (val: T) => R) => (
+  val: T | null | undefined
+): R | null => (val != null ? parser(val) : null);
+
+export const typePolicies: TypePolicies = ${content}
+`;
+};

--- a/src/api/scalars/scalars.generated.ts
+++ b/src/api/scalars/scalars.generated.ts
@@ -1,0 +1,194 @@
+import { TypePolicies } from '@apollo/client';
+import { Parsers } from './scalars.parser';
+
+const optional = <T, R>(parser: (val: T) => R) => (
+  val: T | null | undefined
+): R | null => (val != null ? parser(val) : null);
+
+export const typePolicies: TypePolicies = {
+  Budget: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  BudgetRecord: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Ceremony: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Country: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Directory: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Education: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  File: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      modifiedAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  FileVersion: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  InternshipEngagement: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      modifiedAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  InternshipProject: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      modifiedAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Language: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  LanguageEngagement: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      modifiedAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Organization: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Partnership: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Product: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  ProjectMember: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      modifiedAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Region: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  SecuredDate: {
+    fields: {
+      value: {
+        read: optional(Parsers.Date),
+      },
+    },
+  },
+  SecuredDateTime: {
+    fields: {
+      value: {
+        read: optional(Parsers.DateTime),
+      },
+    },
+  },
+  TranslationProject: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      modifiedAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Unavailability: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+      start: {
+        read: Parsers.DateTime,
+      },
+      end: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  User: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+  Zone: {
+    fields: {
+      createdAt: {
+        read: Parsers.DateTime,
+      },
+    },
+  },
+};

--- a/src/api/scalars/scalars.parser.ts
+++ b/src/api/scalars/scalars.parser.ts
@@ -1,0 +1,7 @@
+import { DateTime } from 'luxon';
+import { CalendarDate } from '../../util';
+
+export const Parsers = {
+  Date: (val: string) => CalendarDate.fromISO(val),
+  DateTime: (val: string) => DateTime.fromISO(val),
+};

--- a/src/api/schema.generated.ts
+++ b/src/api/schema.generated.ts
@@ -1,3 +1,6 @@
+import { DateTime } from 'luxon';
+import { CalendarDate } from '../util';
+
 export type Maybe<T> = T | null;
 /** All built-in and custom scalars, mapped to their actual values */
 export interface Scalars {
@@ -10,9 +13,9 @@ export interface Scalars {
    * An ISO-8601 date string.
    * Time should be ignored for this field.
    */
-  Date: string;
+  Date: CalendarDate;
   /** An ISO-8601 date time string */
-  DateTime: string;
+  DateTime: DateTime;
 }
 
 export interface AddPropertyToSecurityGroup {

--- a/src/components/FieldOverviewCard/FieldOverviewCard.stories.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.stories.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@material-ui/core';
 import { AccountBalance } from '@material-ui/icons';
-import { boolean, date, text } from '@storybook/addon-knobs';
-import { DateTime } from 'luxon';
+import { boolean, text } from '@storybook/addon-knobs';
 import React from 'react';
+import { dateTime } from '../knobs.stories';
 import { AddCurrentPath } from '../Routing/decorators.stories';
 import { FieldOverviewCard as Card } from './FieldOverviewCard';
 
@@ -23,7 +23,7 @@ export const FieldOverviewCard = () => (
           : {
               to: text('to', '/foo'),
               value: text('value', '$45,978'),
-              updatedAt: DateTime.fromMillis(date('updatedAt')),
+              updatedAt: dateTime('updatedAt'),
             }
       }
     />

--- a/src/components/FieldOverviewCard/FieldOverviewCard.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
 
 interface FieldOverviewCardData {
   value: string;
-  updatedAt: DateTime | string;
+  updatedAt: DateTime;
   to: To;
 }
 

--- a/src/components/Formatters/useDateFormatter.tsx
+++ b/src/components/Formatters/useDateFormatter.tsx
@@ -1,13 +1,8 @@
-import { isString } from 'lodash';
 import { DateTime } from 'luxon';
 import { CalendarDate } from '../../util';
 
-export const useDateFormatter = () => (date: CalendarDate | string) => {
-  const dt = isString(date) ? CalendarDate.fromISO(date) : date;
-  return dt.toLocaleString(DateTime.DATE_SHORT);
-};
+export const useDateFormatter = () => (date: CalendarDate) =>
+  date.toLocaleString(DateTime.DATE_SHORT);
 
-export const useDateTimeFormatter = () => (date: DateTime | string) => {
-  const dt = isString(date) ? DateTime.fromISO(date) : date;
-  return dt.toLocaleString(DateTime.DATETIME_SHORT);
-};
+export const useDateTimeFormatter = () => (date: DateTime) =>
+  date.toLocaleString(DateTime.DATETIME_SHORT);

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
@@ -1,7 +1,7 @@
-import { date, number, text } from '@storybook/addon-knobs';
+import { number, text } from '@storybook/addon-knobs';
 import React from 'react';
 import { EngagementStatus } from '../../api';
-import { CalendarDate } from '../../util';
+import { date } from '../knobs.stories';
 import { LanguageEngagementListItemCard as Card } from './LanguageEngagementListItemCard';
 
 export default { title: 'Components' };
@@ -10,12 +10,12 @@ export const LanguageEngagementListItemCard = () => (
   <Card
     id="123123"
     status={text('status', 'InDevelopment') as EngagementStatus}
-    endDate={{ value: CalendarDate.fromMillis(date('endDate')) }}
+    endDate={{ value: date('endDate') }}
     initialEndDate={{
-      value: CalendarDate.fromMillis(date('initialEndDate')),
+      value: date('initialEndDate'),
     }}
     completeDate={{
-      value: CalendarDate.fromMillis(date('completeDate')),
+      value: date('completeDate'),
     }}
     language={{
       value: {

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
@@ -10,12 +10,12 @@ export const LanguageEngagementListItemCard = () => (
   <Card
     id="123123"
     status={text('status', 'InDevelopment') as EngagementStatus}
-    endDate={{ value: CalendarDate.fromMillis(date('endDate')).toISO() }}
+    endDate={{ value: CalendarDate.fromMillis(date('endDate')) }}
     initialEndDate={{
-      value: CalendarDate.fromMillis(date('initialEndDate')).toISO(),
+      value: CalendarDate.fromMillis(date('initialEndDate')),
     }}
     completeDate={{
-      value: CalendarDate.fromMillis(date('completeDate')).toISO(),
+      value: CalendarDate.fromMillis(date('completeDate')),
     }}
     language={{
       value: {

--- a/src/components/ProjectListItemCard/ProjectListItemCard.stories.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.stories.tsx
@@ -10,7 +10,7 @@ export default { title: 'Components' };
 export const ProjectListItemCard = () => {
   const project: ProjectListItemFragment = {
     id: '123',
-    createdAt: '12/12/20',
+    createdAt: DateTime.fromMillis(date('createdAt')),
     type: select('Type', ['Translation', 'Internship'], 'Internship'),
     status: select(
       'status',
@@ -18,12 +18,10 @@ export const ProjectListItemCard = () => {
       'Active'
     ),
     sensitivity: select('sensitivity', ['High', 'Low', 'Medium'], 'High'),
-    modifiedAt: '12/12/20',
+    modifiedAt: DateTime.fromMillis(date('modifiedAt')),
     deptId: { value: text('deptId', '1234567') },
     estimatedSubmission: {
-      value: DateTime.fromMillis(date('estimatedSubmission')).toLocaleString(
-        DateTime.DATE_SHORT
-      ),
+      value: DateTime.fromMillis(date('estimatedSubmission')),
     },
     step: {
       value: select(

--- a/src/components/ProjectListItemCard/ProjectListItemCard.stories.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.stories.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@material-ui/core';
-import { boolean, date, select, text } from '@storybook/addon-knobs';
-import { DateTime } from 'luxon';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import React from 'react';
+import { date, dateTime } from '../knobs.stories';
 import { ProjectListItemFragment } from './ProjectListItem.generated';
 import { ProjectListItemCard as PIC } from './ProjectListItemCard';
 
@@ -10,7 +10,7 @@ export default { title: 'Components' };
 export const ProjectListItemCard = () => {
   const project: ProjectListItemFragment = {
     id: '123',
-    createdAt: DateTime.fromMillis(date('createdAt')),
+    createdAt: dateTime('createdAt'),
     type: select('Type', ['Translation', 'Internship'], 'Internship'),
     status: select(
       'status',
@@ -18,10 +18,10 @@ export const ProjectListItemCard = () => {
       'Active'
     ),
     sensitivity: select('sensitivity', ['High', 'Low', 'Medium'], 'High'),
-    modifiedAt: DateTime.fromMillis(date('modifiedAt')),
+    modifiedAt: dateTime('modifiedAt'),
     deptId: { value: text('deptId', '1234567') },
     estimatedSubmission: {
-      value: DateTime.fromMillis(date('estimatedSubmission')),
+      value: date('estimatedSubmission'),
     },
     step: {
       value: select(

--- a/src/components/knobs.stories.tsx
+++ b/src/components/knobs.stories.tsx
@@ -1,0 +1,9 @@
+import { date as d } from '@storybook/addon-knobs';
+import { DateTime } from 'luxon';
+import { CalendarDate } from '../util';
+
+export const date = (name: string, value?: CalendarDate, groupId?: string) =>
+  CalendarDate.fromMillis(d(name, value?.toJSDate(), groupId));
+
+export const dateTime = (name: string, value?: DateTime, groupId?: string) =>
+  DateTime.fromMillis(d(name, value?.toJSDate(), groupId));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,6 +1995,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-codegen/plugin-helpers@npm:^1.13.2":
+  version: 1.14.0
+  resolution: "@graphql-codegen/plugin-helpers@npm:1.14.0"
+  dependencies:
+    "@graphql-toolkit/common": ~0.10.4
+    camel-case: 4.1.1
+    common-tags: 1.8.0
+    constant-case: 3.0.3
+    import-from: 3.0.0
+    lower-case: 2.0.1
+    param-case: 3.0.3
+    pascal-case: 3.1.1
+    tslib: ~2.0.0
+    upper-case: 2.0.1
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 3/2bed318a15e38b41b5a1bc163194dd96a92e5cb42cdd02073f0dd48873e79cb17b099c7c897ee811700c712bd1ea02af5dd13f231f913889e4338ef54363ce36
+  languageName: node
+  linkType: hard
+
 "@graphql-codegen/typescript-operations@npm:^1.13.2":
   version: 1.13.2
   resolution: "@graphql-codegen/typescript-operations@npm:1.13.2"
@@ -7110,6 +7130,7 @@ __metadata:
     "@graphql-codegen/fragment-matcher": ^1.13.5
     "@graphql-codegen/introspection": ^1.13.2
     "@graphql-codegen/near-operation-file-preset": ^1.13.5
+    "@graphql-codegen/plugin-helpers": ^1.13.2
     "@graphql-codegen/typescript": ^1.13.2
     "@graphql-codegen/typescript-operations": ^1.13.2
     "@graphql-codegen/typescript-react-apollo": ^1.13.2
@@ -19716,6 +19737,13 @@ resolve@1.15.0:
   version: 1.11.1
   resolution: "tslib@npm:1.11.1"
   checksum: 3/d40eba08de267b2d3c458ddbf51f9010a45b8e752d3bf8c0fed63e266afc9277c6a26e65e51223335b8753f9f106aeb600e704f2a6eae05729160671a97c52e7
+  languageName: node
+  linkType: hard
+
+"tslib@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "tslib@npm:2.0.0"
+  checksum: 3/a7369a224f12e223fb42f2a720389601a24a1e1c96c55bf0d8d4b60c131e574c175ae23578b8d1bd3f4ec790c7e0a82b43733f022f866d48a23aeadd3910755d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Create gql codegen plugin to generate type policies to parse custom scalaras
- Update schema generation to define scalars as their parsed types
- Update src & stories to use date objects exclusively
- Defined `date` & `dateTime` knobs which use our types
