### PR TITLE
Create `CreateProject` components and mutation

### DIFF
--- a/src/scenes/Projects/Create/CreateProject.generated.ts
+++ b/src/scenes/Projects/Create/CreateProject.generated.ts
@@ -1,0 +1,94 @@
+/* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
+
+import * as ApolloReactCommon from '@apollo/client';
+import * as ApolloReactHooks from '@apollo/client';
+import gql from 'graphql-tag';
+import * as Types from '../../../api/schema.generated';
+
+export interface CreateProjectMutationVariables {
+  input: Types.CreateProjectInput;
+}
+
+export type CreateProjectMutation = { __typename?: 'Mutation' } & {
+  createProject: { __typename?: 'CreateProjectOutput' } & {
+    project:
+      | ({ __typename?: 'InternshipProject' } & Pick<
+          Types.InternshipProject,
+          'id' | 'type' | 'createdAt'
+        > & {
+            name: { __typename?: 'SecuredString' } & Pick<
+              Types.SecuredString,
+              'value' | 'canRead' | 'canEdit'
+            >;
+          })
+      | ({ __typename?: 'TranslationProject' } & Pick<
+          Types.TranslationProject,
+          'id' | 'type' | 'createdAt'
+        > & {
+            name: { __typename?: 'SecuredString' } & Pick<
+              Types.SecuredString,
+              'value' | 'canRead' | 'canEdit'
+            >;
+          });
+  };
+};
+
+export const CreateProjectDocument = gql`
+  mutation CreateProject($input: CreateProjectInput!) {
+    createProject(input: $input) {
+      project {
+        id
+        name {
+          value
+          canRead
+          canEdit
+        }
+        type
+        createdAt
+      }
+    }
+  }
+`;
+export type CreateProjectMutationFn = ApolloReactCommon.MutationFunction<
+  CreateProjectMutation,
+  CreateProjectMutationVariables
+>;
+
+/**
+ * __useCreateProjectMutation__
+ *
+ * To run a mutation, you first call `useCreateProjectMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateProjectMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createProjectMutation, { data, loading, error }] = useCreateProjectMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateProjectMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    CreateProjectMutation,
+    CreateProjectMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    CreateProjectMutation,
+    CreateProjectMutationVariables
+  >(CreateProjectDocument, baseOptions);
+}
+export type CreateProjectMutationHookResult = ReturnType<
+  typeof useCreateProjectMutation
+>;
+export type CreateProjectMutationResult = ApolloReactCommon.MutationResult<
+  CreateProjectMutation
+>;
+export type CreateProjectMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  CreateProjectMutation,
+  CreateProjectMutationVariables
+>;

--- a/src/scenes/Projects/Create/CreateProject.graphql
+++ b/src/scenes/Projects/Create/CreateProject.graphql
@@ -1,0 +1,14 @@
+mutation CreateProject($input: CreateProjectInput!) {
+  createProject(input: $input) {
+    project {
+      id
+      name {
+        value
+        canRead
+        canEdit
+      }
+      type
+      createdAt
+    }
+  }
+}

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -1,0 +1,31 @@
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { Except } from 'type-fest';
+import { ButtonLink } from '../../../components/Routing';
+import { useCreateProjectMutation } from './CreateProject.generated';
+import {
+  CreateProjectForm,
+  CreateProjectFormProps as Props,
+} from './CreateProjectForm';
+
+export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
+  const [createProject] = useCreateProjectMutation();
+  const { enqueueSnackbar } = useSnackbar();
+  const submit: Props['onSubmit'] = async (input) => {
+    const res = await createProject({
+      variables: { input },
+    });
+    const project = res.data!.createProject.project;
+
+    enqueueSnackbar(`Created project: ${project.name.value}`, {
+      variant: 'success',
+      action: () => (
+        <ButtonLink color="inherit" to={`/projects/${project.id}`}>
+          View
+        </ButtonLink>
+      ),
+    });
+  };
+
+  return <CreateProjectForm {...props} onSubmit={submit} />;
+};

--- a/src/scenes/Projects/Create/CreateProjectForm.stories.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.stories.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@material-ui/core';
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+import { useDialog } from '../../../components/Dialog';
+import { CreateProjectForm as Form } from './CreateProjectForm';
+
+export default { title: 'Scenes/Projects' };
+
+export const CreateProjectForm = () => {
+  const [state, open] = useDialog();
+  return (
+    <>
+      <Button onClick={open}>Create Project</Button>
+      <Form onSubmit={action('onSubmit')} {...state} />
+    </>
+  );
+};

--- a/src/scenes/Projects/Create/CreateProjectForm.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { CreateProjectInput } from '../../../api';
+import {
+  DialogForm,
+  DialogFormProps,
+} from '../../../components/Dialog/DialogForm';
+import {
+  RadioField,
+  RadioOption,
+  SubmitError,
+  TextField,
+} from '../../../components/form';
+
+export type CreateProjectFormProps = DialogFormProps<CreateProjectInput>;
+
+export const CreateProjectForm = (props: CreateProjectFormProps) => (
+  <DialogForm
+    DialogProps={{
+      fullWidth: true,
+      maxWidth: 'xs',
+    }}
+    {...props}
+    title="Create Project"
+  >
+    <SubmitError />
+    <TextField
+      name="project.name"
+      label="Name"
+      placeholder="Enter project name"
+      autoFocus
+    />
+    <RadioField name="project.type" label="Type">
+      <RadioOption label="Translation" value="Translation" />
+      <RadioOption label="Internship" value="Internship" />
+    </RadioField>
+  </DialogForm>
+);

--- a/src/scenes/Projects/Create/index.ts
+++ b/src/scenes/Projects/Create/index.ts
@@ -1,0 +1,1 @@
+export * from './CreateProject';

--- a/src/scenes/Root/Sidebar/Sidebar.tsx
+++ b/src/scenes/Root/Sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import { CreateButton } from '../../../components/CreateButton';
 import { useDialog } from '../../../components/Dialog';
 import { ListItemLink, ListItemLinkProps } from '../../../components/Routing';
 import { CreateOrganization } from '../../Organizations/Create';
+import { CreateProject } from '../../Projects/Create';
 import { sidebarTheme } from './sidebar.theme';
 import { SidebarHeader } from './SidebarHeader';
 
@@ -44,6 +45,7 @@ export const Sidebar: FC = () => {
     fn();
   };
   const [createOrgState, createOrg] = useDialog();
+  const [createProjectState, createProject] = useDialog();
 
   const createMenu = (
     <Menu
@@ -63,6 +65,7 @@ export const Sidebar: FC = () => {
       }}
     >
       <MenuItem onClick={closeAnd(createOrg)}>Organization</MenuItem>
+      <MenuItem onClick={closeAnd(createProject)}>Project</MenuItem>
     </Menu>
   );
 
@@ -105,6 +108,7 @@ export const Sidebar: FC = () => {
     <>
       {sidebar}
       <CreateOrganization {...createOrgState} />
+      <CreateProject {...createProjectState} />
     </>
   );
 };


### PR DESCRIPTION
Closes #221 

- Create `Create` folder in `scenes/Projects` with:
  - `CreateProject.graphql`, containing `CreateProject` mutation
  - `CreateProject.tsx`
  - `CreateProjectForm.tsx`
  - `CreateProjectForm.stories.tsx`
  - `index.ts`
  - generated types
- Update `scenes/Root/Sidebar/Sidebar.tsx` with menu option to create project