### PR TITLE
Refetch after mutation (CreateProjects -> Projects List update)

### DIFF
--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -14,6 +14,7 @@ export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
   const submit: Props['onSubmit'] = async (input) => {
     const res = await createProject({
       variables: { input },
+      refetchQueries: ['ProjectList'],
     });
     const project = res.data!.createProject.project;
 

--- a/src/scenes/Projects/List/ProjectList.tsx
+++ b/src/scenes/Projects/List/ProjectList.tsx
@@ -4,7 +4,7 @@ import { Project } from '../../../api';
 import { ProjectListItemCard } from '../../../components/ProjectListItemCard';
 import { SortButtonDialog, useSort } from '../../../components/Sort';
 import { listOrPlaceholders } from '../../../util';
-import { useProjectsQuery } from './projects.generated';
+import { useProjectListQuery } from './projects.generated';
 import { ProjectSortOptions } from './ProjectSortOptions';
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -24,7 +24,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 export const ProjectList: FC = () => {
   const sort = useSort<Project>();
 
-  const { data } = useProjectsQuery({
+  const { data } = useProjectListQuery({
     variables: {
       input: {
         ...sort.value,

--- a/src/scenes/Projects/List/projects.generated.ts
+++ b/src/scenes/Projects/List/projects.generated.ts
@@ -9,11 +9,11 @@ import {
 } from '../../../components/ProjectListItemCard/ProjectListItem.generated';
 import { ProjectListItemFragmentDoc } from '../../../components/ProjectListItemCard/ProjectListItem.generated';
 
-export interface ProjectsQueryVariables {
+export interface ProjectListQueryVariables {
   input: Types.ProjectListInput;
 }
 
-export type ProjectsQuery = { __typename?: 'Query' } & {
+export type ProjectListQuery = { __typename?: 'Query' } & {
   projects: { __typename?: 'ProjectListOutput' } & Pick<
     Types.ProjectListOutput,
     'hasMore' | 'total'
@@ -29,8 +29,8 @@ export type ProjectsQuery = { __typename?: 'Query' } & {
     };
 };
 
-export const ProjectsDocument = gql`
-  query Projects($input: ProjectListInput!) {
+export const ProjectListDocument = gql`
+  query ProjectList($input: ProjectListInput!) {
     projects(input: $input) {
       items {
         ...ProjectListItem
@@ -43,48 +43,48 @@ export const ProjectsDocument = gql`
 `;
 
 /**
- * __useProjectsQuery__
+ * __useProjectListQuery__
  *
- * To run a query within a React component, call `useProjectsQuery` and pass it any options that fit your needs.
- * When your component renders, `useProjectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useProjectListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useProjectListQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useProjectsQuery({
+ * const { data, loading, error } = useProjectListQuery({
  *   variables: {
  *      input: // value for 'input'
  *   },
  * });
  */
-export function useProjectsQuery(
+export function useProjectListQuery(
   baseOptions?: ApolloReactHooks.QueryHookOptions<
-    ProjectsQuery,
-    ProjectsQueryVariables
+    ProjectListQuery,
+    ProjectListQueryVariables
   >
 ) {
-  return ApolloReactHooks.useQuery<ProjectsQuery, ProjectsQueryVariables>(
-    ProjectsDocument,
+  return ApolloReactHooks.useQuery<ProjectListQuery, ProjectListQueryVariables>(
+    ProjectListDocument,
     baseOptions
   );
 }
-export function useProjectsLazyQuery(
+export function useProjectListLazyQuery(
   baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
-    ProjectsQuery,
-    ProjectsQueryVariables
+    ProjectListQuery,
+    ProjectListQueryVariables
   >
 ) {
-  return ApolloReactHooks.useLazyQuery<ProjectsQuery, ProjectsQueryVariables>(
-    ProjectsDocument,
-    baseOptions
-  );
+  return ApolloReactHooks.useLazyQuery<
+    ProjectListQuery,
+    ProjectListQueryVariables
+  >(ProjectListDocument, baseOptions);
 }
-export type ProjectsQueryHookResult = ReturnType<typeof useProjectsQuery>;
-export type ProjectsLazyQueryHookResult = ReturnType<
-  typeof useProjectsLazyQuery
+export type ProjectListQueryHookResult = ReturnType<typeof useProjectListQuery>;
+export type ProjectListLazyQueryHookResult = ReturnType<
+  typeof useProjectListLazyQuery
 >;
-export type ProjectsQueryResult = ApolloReactCommon.QueryResult<
-  ProjectsQuery,
-  ProjectsQueryVariables
+export type ProjectListQueryResult = ApolloReactCommon.QueryResult<
+  ProjectListQuery,
+  ProjectListQueryVariables
 >;

--- a/src/scenes/Projects/List/projects.graphql
+++ b/src/scenes/Projects/List/projects.graphql
@@ -1,4 +1,4 @@
-query Projects($input: ProjectListInput!) {
+query ProjectList($input: ProjectListInput!) {
   projects(input: $input) {
     items {
       ...ProjectListItem


### PR DESCRIPTION
Here's an example of how we can update the Projects list page after executing a mutation.

Seeing as how the `Projects` list query has sort and filter variables being passed into it, it's difficult to invalidate the cache or update it manually. We don't want to start abstracting filter variables into global state just so that we can deduce how to invalidate or update cached Projects list results. 

So the easiest thing to do here is refetch existing `Projects` queries. Luckily, Apollo handles this smoothly:
* We add `refetchQueries` param to the mutation. This tells Apollo to refetch any query with the name "Projects"
  * **IMPORTANT:** Apollo will find all queries of the name "Projects" and automatically refetch them using whatever variables they were previously fetched with!
  * In the event we wanted to pass in our own variables, we're free to do that as well, e.g.:
    * `refetchQueries: [{ query: ProjectsDocument, variables: { ... } }]`
* We set `awaitRefetchQueries` to `true` so that our mutation will resolve after the refetch is complete, making for a smooth UX