### PR TITLE
FE issue 227 edit partnerships

### DIFF
--- a/src/api/displayEnums.ts
+++ b/src/api/displayEnums.ts
@@ -19,3 +19,9 @@ export const displayEngagementStatus = displayEnum<EngagementStatus>();
 export const displayRole = displayEnum<Role>();
 export const displayRoles = (roles: Role[]) =>
   roles.map(displayRole).join(', ');
+
+export const PartnershipStatuses: PartnershipAgreementStatus[] = [
+  'NotAttached',
+  'AwaitingSignature',
+  'Signed',
+];

--- a/src/api/operations.generated.ts
+++ b/src/api/operations.generated.ts
@@ -9,6 +9,8 @@ export const GQLOperations = {
     ProjectOverview: 'ProjectOverview',
   },
   Mutation: {
+    UpdatePartnership: 'UpdatePartnership',
+    DeletePartnership: 'DeletePartnership',
     ForgotPassword: 'ForgotPassword',
     Login: 'Login',
     Logout: 'Logout',
@@ -26,6 +28,7 @@ export const GQLOperations = {
     DisplayZone: 'DisplayZone',
     DisplayPlace: 'DisplayPlace',
     BudgetOverview: 'BudgetOverview',
+    EditPartnership: 'EditPartnership',
     InternshipEngagementListItem: 'InternshipEngagementListItem',
     LanguageEngagementListItem: 'LanguageEngagementListItem',
     LanguageListItem: 'LanguageListItem',

--- a/src/components/PartnershipCard/PartnershipCard.stories.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { select, text } from '@storybook/addon-knobs';
 import React from 'react';
+import { PartnershipStatuses } from '../../api';
 import { csv } from '../../util';
 import { dateTime } from '../knobs.stories';
 import { PartnershipCard } from './PartnershipCard';
@@ -19,18 +20,10 @@ export const WithData = () => {
       value: csv(text('Types', 'Managing, Funding')),
     },
     mouStatus: {
-      value: select(
-        'Mou Status',
-        ['NotAttached', 'AwaitingSignature', 'Signed'],
-        'NotAttached'
-      ),
+      value: select('Mou Status', PartnershipStatuses, 'NotAttached'),
     },
     agreementStatus: {
-      value: select(
-        'Mou Status',
-        ['NotAttached', 'AwaitingSignature', 'Signed'],
-        'NotAttached'
-      ),
+      value: select('Mou Status', PartnershipStatuses, 'NotAttached'),
     },
   };
 

--- a/src/scenes/Partnerships/Edit/EditPartnership.generated.ts
+++ b/src/scenes/Partnerships/Edit/EditPartnership.generated.ts
@@ -1,0 +1,173 @@
+/* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
+import * as ApolloReactCommon from '@apollo/client';
+import * as ApolloReactHooks from '@apollo/client';
+import gql from 'graphql-tag';
+import * as Types from '../../../api/schema.generated';
+import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
+import { PartnershipCardFragmentDoc } from '../../../components/PartnershipCard/PartnershipCard.generated';
+
+export interface UpdatePartnershipMutationVariables {
+  input: Types.UpdatePartnershipInput;
+}
+
+export type UpdatePartnershipMutation = { __typename?: 'Mutation' } & {
+  updatePartnership: { __typename?: 'UpdatePartnershipOutput' } & {
+    partnership: { __typename?: 'Partnership' } & PartnershipCardFragment;
+  };
+};
+
+export interface DeletePartnershipMutationVariables {
+  input: Types.Scalars['ID'];
+}
+
+export type DeletePartnershipMutation = { __typename?: 'Mutation' } & Pick<
+  Types.Mutation,
+  'deletePartnership'
+>;
+
+export type EditPartnershipFragment = { __typename?: 'Partnership' } & Pick<
+  Types.Partnership,
+  'id'
+> & {
+    types: { __typename?: 'SecuredPartnershipTypes' } & Pick<
+      Types.SecuredPartnershipTypes,
+      'value' | 'canEdit'
+    >;
+    agreementStatus: {
+      __typename?: 'SecuredPartnershipAgreementStatus';
+    } & Pick<Types.SecuredPartnershipAgreementStatus, 'value' | 'canEdit'>;
+    mouStatus: { __typename?: 'SecuredPartnershipAgreementStatus' } & Pick<
+      Types.SecuredPartnershipAgreementStatus,
+      'value' | 'canEdit'
+    >;
+    organization: { __typename?: 'Organization' } & {
+      name: { __typename?: 'SecuredString' } & Pick<
+        Types.SecuredString,
+        'value'
+      >;
+    };
+  };
+
+export const EditPartnershipFragmentDoc = gql`
+  fragment EditPartnership on Partnership {
+    id
+    types {
+      value
+      canEdit
+    }
+    agreementStatus {
+      value
+      canEdit
+    }
+    mouStatus {
+      value
+      canEdit
+    }
+    organization {
+      name {
+        value
+      }
+    }
+  }
+`;
+export const UpdatePartnershipDocument = gql`
+  mutation UpdatePartnership($input: UpdatePartnershipInput!) {
+    updatePartnership(input: $input) {
+      partnership {
+        ...PartnershipCard
+      }
+    }
+  }
+  ${PartnershipCardFragmentDoc}
+`;
+export type UpdatePartnershipMutationFn = ApolloReactCommon.MutationFunction<
+  UpdatePartnershipMutation,
+  UpdatePartnershipMutationVariables
+>;
+
+/**
+ * __useUpdatePartnershipMutation__
+ *
+ * To run a mutation, you first call `useUpdatePartnershipMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdatePartnershipMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updatePartnershipMutation, { data, loading, error }] = useUpdatePartnershipMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdatePartnershipMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    UpdatePartnershipMutation,
+    UpdatePartnershipMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    UpdatePartnershipMutation,
+    UpdatePartnershipMutationVariables
+  >(UpdatePartnershipDocument, baseOptions);
+}
+export type UpdatePartnershipMutationHookResult = ReturnType<
+  typeof useUpdatePartnershipMutation
+>;
+export type UpdatePartnershipMutationResult = ApolloReactCommon.MutationResult<
+  UpdatePartnershipMutation
+>;
+export type UpdatePartnershipMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  UpdatePartnershipMutation,
+  UpdatePartnershipMutationVariables
+>;
+export const DeletePartnershipDocument = gql`
+  mutation DeletePartnership($input: ID!) {
+    deletePartnership(id: $input)
+  }
+`;
+export type DeletePartnershipMutationFn = ApolloReactCommon.MutationFunction<
+  DeletePartnershipMutation,
+  DeletePartnershipMutationVariables
+>;
+
+/**
+ * __useDeletePartnershipMutation__
+ *
+ * To run a mutation, you first call `useDeletePartnershipMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeletePartnershipMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [deletePartnershipMutation, { data, loading, error }] = useDeletePartnershipMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useDeletePartnershipMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    DeletePartnershipMutation,
+    DeletePartnershipMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    DeletePartnershipMutation,
+    DeletePartnershipMutationVariables
+  >(DeletePartnershipDocument, baseOptions);
+}
+export type DeletePartnershipMutationHookResult = ReturnType<
+  typeof useDeletePartnershipMutation
+>;
+export type DeletePartnershipMutationResult = ApolloReactCommon.MutationResult<
+  DeletePartnershipMutation
+>;
+export type DeletePartnershipMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  DeletePartnershipMutation,
+  DeletePartnershipMutationVariables
+>;

--- a/src/scenes/Partnerships/Edit/EditPartnership.graphql
+++ b/src/scenes/Partnerships/Edit/EditPartnership.graphql
@@ -1,0 +1,32 @@
+mutation UpdatePartnership($input: UpdatePartnershipInput!) {
+  updatePartnership(input: $input) {
+    partnership {
+      ...PartnershipCard
+    }
+  }
+}
+
+mutation DeletePartnership($input: ID!) {
+  deletePartnership(id: $input)
+}
+
+fragment EditPartnership on Partnership {
+  id
+  types {
+    value
+    canEdit
+  }
+  agreementStatus {
+    value
+    canEdit
+  }
+  mouStatus {
+    value
+    canEdit
+  }
+  organization {
+    name {
+      value
+    }
+  }
+}

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -1,0 +1,119 @@
+import { Box, Button } from '@material-ui/core';
+import React, { FC } from 'react';
+import { Except } from 'type-fest';
+import {
+  displayPartnershipStatus,
+  GQLOperations,
+  PartnershipStatuses,
+  PartnershipType,
+  UpdatePartnershipInput,
+} from '../../../api';
+import {
+  DialogForm,
+  DialogFormProps,
+} from '../../../components/Dialog/DialogForm';
+import {
+  CheckboxesField,
+  CheckboxOption,
+  RadioField,
+  RadioOption,
+  SubmitError,
+} from '../../../components/form';
+import {
+  EditPartnershipFragment,
+  useDeletePartnershipMutation,
+  useUpdatePartnershipMutation,
+} from './EditPartnership.generated';
+
+type EditPartnershipProps = Except<
+  DialogFormProps<UpdatePartnershipInput>,
+  'onSubmit' | 'initialValues'
+> & {
+  partnership: EditPartnershipFragment;
+};
+
+export const EditPartnership: FC<EditPartnershipProps> = ({
+  partnership,
+  ...props
+}) => {
+  const [updatePartnership] = useUpdatePartnershipMutation();
+  const [deletePartnership] = useDeletePartnershipMutation();
+
+  const onDeleteClick = () => {
+    const { id } = partnership;
+    deletePartnership({
+      variables: { input: id },
+      refetchQueries: [GQLOperations.Query.ProjectPartnerships],
+    });
+    //TODO: correctly handle closing the dialog.  props.onClose has a TS errors
+    // props.onClose && props.onClose('cancel');
+  };
+
+  const radioOptions = PartnershipStatuses.map((status) => (
+    <RadioOption
+      key={status}
+      label={displayPartnershipStatus(status)}
+      value={status}
+    />
+  ));
+
+  return (
+    <DialogForm<UpdatePartnershipInput>
+      DialogProps={{
+        fullWidth: true,
+        maxWidth: 'xs',
+      }}
+      {...props}
+      onSubmit={(input) => {
+        updatePartnership({
+          variables: { input },
+          refetchQueries: [GQLOperations.Query.ProjectPartnerships],
+        });
+      }}
+      title={`Edit Partnership with ${partnership.organization.name.value}`}
+      leftAction={<Button onClick={onDeleteClick}>Delete</Button>}
+      initialValues={{
+        partnership: {
+          id: partnership.id,
+          agreementStatus: partnership.agreementStatus.value,
+          mouStatus: partnership.mouStatus.value,
+          types: partnership.types.value,
+        },
+      }}
+    >
+      <SubmitError />
+      <CheckboxesField
+        name="partnership.types"
+        label="Types"
+        row
+        disabled={!partnership.types.canEdit}
+      >
+        {([
+          'Managing',
+          'Funding',
+          'Impact',
+          'Technical',
+          'Resource',
+        ] as PartnershipType[]).map((type: PartnershipType) => (
+          <Box width="50%" key={type}>
+            <CheckboxOption key={type} label={type} value={type} />
+          </Box>
+        ))}
+      </CheckboxesField>
+      <RadioField
+        name="partnership.agreementStatus"
+        label="Agreement Status"
+        disabled={!partnership.agreementStatus.canEdit}
+      >
+        {radioOptions}
+      </RadioField>
+      <RadioField
+        name="partnership.mouStatus"
+        label="Mou Status"
+        disabled={!partnership.mouStatus.canEdit}
+      >
+        {radioOptions}
+      </RadioField>
+    </DialogForm>
+  );
+};

--- a/src/scenes/Partnerships/Edit/index.ts
+++ b/src/scenes/Partnerships/Edit/index.ts
@@ -1,0 +1,1 @@
+export * from './EditPartnership';

--- a/src/scenes/Partnerships/List/PartnershipList.generated.ts
+++ b/src/scenes/Partnerships/List/PartnershipList.generated.ts
@@ -5,6 +5,8 @@ import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
 import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
 import { PartnershipCardFragmentDoc } from '../../../components/PartnershipCard/PartnershipCard.generated';
+import { EditPartnershipFragment } from '../Edit/EditPartnership.generated';
+import { EditPartnershipFragmentDoc } from '../Edit/EditPartnership.generated';
 
 export interface ProjectPartnershipsQueryVariables {
   input: Types.Scalars['ID'];
@@ -25,7 +27,8 @@ export type ProjectPartnershipsQuery = { __typename?: 'Query' } & {
             'canCreate' | 'total'
           > & {
               items: Array<
-                { __typename?: 'Partnership' } & PartnershipCardFragment
+                { __typename?: 'Partnership' } & PartnershipCardFragment &
+                  EditPartnershipFragment
               >;
             };
         })
@@ -42,7 +45,8 @@ export type ProjectPartnershipsQuery = { __typename?: 'Query' } & {
             'canCreate' | 'total'
           > & {
               items: Array<
-                { __typename?: 'Partnership' } & PartnershipCardFragment
+                { __typename?: 'Partnership' } & PartnershipCardFragment &
+                  EditPartnershipFragment
               >;
             };
         });
@@ -60,11 +64,13 @@ export const ProjectPartnershipsDocument = gql`
         total
         items {
           ...PartnershipCard
+          ...EditPartnership
         }
       }
     }
   }
   ${PartnershipCardFragmentDoc}
+  ${EditPartnershipFragmentDoc}
 `;
 
 /**

--- a/src/scenes/Partnerships/List/PartnershipList.graphql
+++ b/src/scenes/Partnerships/List/PartnershipList.graphql
@@ -9,6 +9,7 @@ query ProjectPartnerships($input: ID!) {
       total
       items {
         ...PartnershipCard
+        ...EditPartnership
       }
     }
   }

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -8,11 +8,15 @@ import { Add } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import React, { FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { noop } from 'ts-essentials';
+import { Merge } from 'type-fest';
 import { Breadcrumb } from '../../../components/Breadcrumb';
+import { useDialog } from '../../../components/Dialog';
 import { Fab } from '../../../components/Fab';
 import { PartnershipCard } from '../../../components/PartnershipCard';
+import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
 import { listOrPlaceholders } from '../../../util';
+import { EditPartnership } from '../Edit';
+import { EditPartnershipFragment } from '../Edit/EditPartnership.generated';
 import { useProjectPartnershipsQuery } from './PartnershipList.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
@@ -44,6 +48,10 @@ export const PartnershipList: FC = () => {
   const project = data?.project;
   const partnerships = project?.partnerships;
 
+  const [dialogState, openDialog, partnership] = useDialog<
+    Merge<PartnershipCardFragment, EditPartnershipFragment>
+  >();
+
   return (
     <div className={classes.root}>
       <Breadcrumbs>
@@ -70,10 +78,13 @@ export const PartnershipList: FC = () => {
         <PartnershipCard
           key={item?.id ?? index}
           partnership={item}
-          onEdit={noop}
+          onEdit={() => item && openDialog(item)}
           className={classes.item}
         />
       ))}
+      {partnership && (
+        <EditPartnership {...dialogState} partnership={partnership} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
**DO NOT MERGE**. This is branched off https://github.com/SeedCompany/cord-field/tree/feature-FE-227-Partnerships_List

Edit partnership feature on the project partnerships. 

**Tech Notes**
`DialogForm` to show the edit modal.  With radios for statuses and checkboxes for types.  I'm not sure what the statuses and types mean so let me know if I'm missing anything.

The `DialogForm`'s `initialValues` prop doesn't pass down to the radio field, only the types.  We'll need to add that to see the initial values selected.  Imo it's better UX.  `RadioField` has a `initialValue` prop but it's not working

<img width="578" alt="Screen Shot 2020-06-17 at 8 47 51 AM" src="https://user-images.githubusercontent.com/43487134/84919794-4137e380-b077-11ea-9f04-43d00d7f5448.png">

**Testing**
Create Project partnerships in the gql playground if you haven't already.  Click the edit icon on a Partnership Card, see the modal open.  Change the statuses/types and click submit.  You should see the partnership reflect the new status.  Delete deletes the partnership and closes the modal.