### PR TITLE
Formatted Text & Number Fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-router-dom": "^6.0.0-alpha.5",
     "react-scripts": "^3.4.1",
     "react-use": "^14.1.1",
+    "rifm": "^0.12.0",
     "ts-essentials": "^6.0.4",
     "validator": "^13.0.0"
   },

--- a/src/components/form/EmailField.stories.tsx
+++ b/src/components/form/EmailField.stories.tsx
@@ -2,23 +2,24 @@ import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import React from 'react';
 import { Form } from 'react-final-form';
-import { EmailField as EF } from './EmailField';
+import { EmailField } from './EmailField';
+import { FieldSpy } from './FieldSpy';
 
 export default { title: 'Components/Forms/Fields' };
 
 export const Email = () => (
-  <Form onSubmit={action('onSubmit')}>
+  <Form onSubmit={action('submit')}>
     {({ handleSubmit }) => (
       <form onSubmit={handleSubmit}>
-        <EF
+        <EmailField
           name="email"
           label={text('Label', 'Email')}
           placeholder={text('placeholder', 'Enter Email Address')}
           required={boolean('Required', true)}
           fullWidth={boolean('Full Width', true)}
           disabled={boolean('Disabled', false)}
-          onClick={action('click')}
         />
+        <FieldSpy name="email" />
       </form>
     )}
   </Form>

--- a/src/components/form/EmailField.tsx
+++ b/src/components/form/EmailField.tsx
@@ -1,23 +1,34 @@
 import React, { FC } from 'react';
 import { Except } from 'type-fest';
+import {
+  FormattedTextField,
+  FormattedTextFieldProps,
+} from './FormattedTextField';
 import { validators } from './index';
-import { TextField, TextFieldProps } from './TextField';
 
-export type EmailFieldProps = Except<TextFieldProps, 'type' | 'name'> & {
+export type EmailFieldProps = Except<
+  FormattedTextFieldProps,
+  'type' | 'name' | 'inputMode' | 'replace'
+> & {
   name?: string;
+  /** If true, input will not be lower-cased */
+  caseSensitive?: boolean;
 };
+
 export const EmailField: FC<EmailFieldProps> = ({
   name = 'email',
   required = true,
+  caseSensitive,
   ...rest
 }) => (
-  <TextField
+  <FormattedTextField
     name={name}
     label="Email"
     placeholder="Enter Email Address"
     validate={[required ? validators.required : null, validators.email]}
     required={required}
     {...rest}
-    type="email"
+    inputMode="email"
+    replace={(v) => (caseSensitive ? v : v.toLowerCase())}
   />
 );

--- a/src/components/form/FormattedTextField.stories.tsx
+++ b/src/components/form/FormattedTextField.stories.tsx
@@ -1,0 +1,51 @@
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+import { Form } from 'react-final-form';
+import { FormattedTextField } from './FormattedTextField';
+
+export default { title: 'Components/Forms/Fields' };
+
+export const FormattedText = () => (
+  <Form onSubmit={action('onSubmit')}>
+    {({ handleSubmit }) => (
+      <form onSubmit={handleSubmit}>
+        <FormattedTextField
+          name="float"
+          label="Mandatory dot"
+          helperText="Mandatory dot (even if user enters comma) as floating point"
+          accept={/[\d.,]+/g}
+          // allow only one floating point
+          formatInput={(v) => (/\d+[.,]?\d*/.exec(v) ?? []).join('')}
+          replace={(v) => v.replace(',', '.')}
+        />
+        <FormattedTextField
+          name="lowercase"
+          label="Lower case"
+          replace={(v) => v.toLowerCase()}
+        />
+        <FormattedTextField
+          name="uppercase"
+          label="Upper case"
+          replace={(v) => v.toUpperCase()}
+        />
+        <FormattedTextField
+          name="latin"
+          label="latin letters"
+          helperText="Allow latin letters only"
+          accept={/[a-zA-Z]/g}
+          formatInput={(v) => (v.match(/[a-zA-Z]/g) ?? []).join('')}
+        />
+        <FormattedTextField
+          name="comment"
+          label="comment"
+          helperText="Leave a comment about Rifm"
+          replace={(v) =>
+            'Rifm is the best mask and formatting library. I love it! '
+              .repeat(20)
+              .slice(0, v.length)
+          }
+        />
+      </form>
+    )}
+  </Form>
+);

--- a/src/components/form/FormattedTextField.tsx
+++ b/src/components/form/FormattedTextField.tsx
@@ -1,0 +1,81 @@
+import { TextField, TextFieldProps } from '@material-ui/core';
+import { identity } from 'lodash';
+import React from 'react';
+import { useRifm } from 'rifm';
+import { Except } from 'type-fest';
+import { useFieldName } from './FieldGroup';
+import { FieldConfig, useField } from './useField';
+import { getHelperText, showError, useFocusOnEnabled } from './util';
+
+export type FormattedTextFieldProps<FieldValue = string> = FieldConfig<
+  FieldValue
+> & {
+  name: string;
+  /**
+   * Format the user input.
+   *
+   * Default is `(value) => value`
+   */
+  formatInput?: (str: string) => string;
+  /**
+   * `formatInput` post-processor which allows you to fully replace any/all
+   * symbol(s) preserving cursor
+   */
+  replace?: (str: string) => string;
+  /**
+   * `formatInput` post-processor called only if cursor is in
+   * the last position and new symbols added.
+   * Used for specific use-case to add non-accepted symbol when you type.
+   */
+  append?: (str: string) => string;
+  /** Use replace input mode if true, use cursor visual hacks if prop provided */
+  mask?: boolean;
+  /** Regex to detect _accepted_ symbols */
+  accept?: RegExp;
+} & Except<
+    TextFieldProps,
+    'defaultValue' | 'error' | 'value' | 'name' | 'inputRef'
+  >;
+
+export function FormattedTextField<FieldValue = string>({
+  formatInput,
+  replace,
+  append,
+  mask,
+  accept,
+  name: nameProp,
+  helperText,
+  disabled: disabledProp,
+  children,
+  variant,
+  ...props
+}: FormattedTextFieldProps<FieldValue>) {
+  const name = useFieldName(nameProp);
+  const { input, meta, rest } = useField(name, props);
+  const disabled = disabledProp ?? meta.submitting;
+  const ref = useFocusOnEnabled(meta, disabled);
+
+  const rifm = useRifm({
+    value: input.value as any,
+    onChange: input.onChange,
+    format: formatInput ?? identity,
+    append,
+    accept: accept ?? /./g,
+    mask,
+    replace,
+  });
+
+  return (
+    <TextField
+      disabled={disabled}
+      required={props.required}
+      {...rest}
+      {...input}
+      {...rifm}
+      variant={variant}
+      inputRef={ref}
+      helperText={getHelperText(meta, helperText)}
+      error={showError(meta)}
+    />
+  );
+}

--- a/src/components/form/NumberField.stories.tsx
+++ b/src/components/form/NumberField.stories.tsx
@@ -1,0 +1,69 @@
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import React from 'react';
+import { Form } from 'react-final-form';
+import { Code } from '../Debug';
+import { NumberField } from './NumberField';
+import { SubmitButton } from './SubmitButton';
+import { max, min } from './validators';
+
+export default { title: 'Components/Forms/Fields' };
+
+export const Number = () => (
+  <Form onSubmit={action('submit')}>
+    {({ handleSubmit, values }) => {
+      const alignRight = boolean('alignRight', true);
+      const allowNegative = boolean('allowNegative', true);
+      return (
+        <form onSubmit={handleSubmit}>
+          <NumberField
+            name="integer"
+            label="Integer"
+            autoComplete="off"
+            alignRight={alignRight}
+            allowNegative={allowNegative}
+            validate={[min(5), max(50_000)]}
+          />
+          <NumberField
+            name="decimal"
+            label="floating decimal"
+            autoComplete="off"
+            alignRight={alignRight}
+            allowNegative={allowNegative}
+            maximumFractionDigits={2}
+          />
+          <NumberField
+            name="fixedDecimal"
+            label="fixed decimal"
+            autoComplete="off"
+            alignRight={alignRight}
+            allowNegative={allowNegative}
+            minimumFractionDigits={2}
+            maximumFractionDigits={2}
+          />
+          <NumberField
+            name="currency"
+            label="currency"
+            autoComplete="off"
+            alignRight={alignRight}
+            allowNegative={allowNegative}
+            prefix="$"
+            minimumFractionDigits={2}
+            maximumFractionDigits={2}
+          />
+          <NumberField
+            name="squareMeters"
+            label="Square Meters"
+            autoComplete="off"
+            alignRight={alignRight}
+            allowNegative={allowNegative}
+            suffix=" m²"
+            maximumFractionDigits={1}
+          />
+          <Code json={values} />
+          <SubmitButton />
+        </form>
+      );
+    }}
+  </Form>
+);

--- a/src/components/form/NumberField.tsx
+++ b/src/components/form/NumberField.tsx
@@ -1,0 +1,232 @@
+import { InputAdornment, makeStyles } from '@material-ui/core';
+import clsx from 'clsx';
+import React from 'react';
+import { Except } from 'type-fest';
+import {
+  FormattedTextField,
+  FormattedTextFieldProps,
+} from './FormattedTextField';
+
+export type NumberFieldProps = Except<
+  FormattedTextFieldProps<number | undefined>,
+  'allowNull'
+> &
+  Partial<FormattingOptions> & {
+    alignRight?: boolean;
+  };
+
+interface FormattingOptions {
+  allowNegative: boolean;
+  minimumFractionDigits: number;
+  maximumFractionDigits: number;
+  prefix: string;
+  suffix: string;
+}
+
+const acceptNumber = (string: string) =>
+  (string.match(/[-\d.]+/g) || []).join('');
+
+const negativeChars = (str: string) => str.match(/-/g)?.length ?? 0;
+const removeNegatives = (str: string) => str.replace(/-/g, '');
+
+const formatNumber = ({
+  allowNegative,
+  minimumFractionDigits,
+  maximumFractionDigits,
+}: FormattingOptions) => (string: string) => {
+  if (!string) {
+    return '';
+  }
+
+  if (allowNegative) {
+    // Handle user-typed negatives
+    if (string === '-') {
+      return '-';
+    }
+    const negChars = negativeChars(string);
+    if (negChars > 1) {
+      // maintain cursor position while turning double negative to positive
+      // Note this does move the cursor to the left of the comma if double is
+      // inserted to the right of the comma :(
+      return removeNegatives(string);
+    } else if (negChars === 1) {
+      const idx = string.indexOf('-');
+      if (idx !== 0) {
+        // neg not at beginning is from user input which means they just typed it
+        // which means the number is already formatted. Skip formatting here,
+        // since we need to keep the invalid dash location to maintain cursor position.
+        // replace() will move it.
+        return string;
+      }
+    }
+  }
+
+  let next = acceptNumber(string);
+  if (!next) {
+    return '';
+  }
+
+  if (!allowNegative) {
+    next = removeNegatives(next);
+  }
+
+  // Remove consecutive periods. This allows allows typing period at period
+  // without truncating the fraction.
+  next = next.replace(/\.+/g, '.');
+
+  let head = '';
+  let tail = '';
+  if (next.includes('.')) {
+    [head, tail] = next.split('.');
+
+    // Avoid rounding errors at toLocaleString as when user enters 1.239
+    // and maxDigits=2 we must not to convert it to 1.24, it must stay 1.23
+    tail = tail ? tail.slice(0, maximumFractionDigits) : '';
+    next = `${head}.${tail}`;
+  }
+
+  // For fixed format numbers deleting period must be no-op.
+  // Imagine you have `123.45` then delete `.` - this would normally get `12345.00`.
+  // This looks bad, so we transform `12345` into `123.45` instead.
+  // The main disadvantage of this, that you need carefully check input value
+  // that it always has fractional part
+  // if (
+  //   minimumFractionDigits > 0 &&
+  //   minimumFractionDigits === maximumFractionDigits &&
+  //   tail == null &&
+  //   head.length > 1 && // if head is 1 char, assume just starting new number
+  //   false // This doesn't work with pasting values
+  // ) {
+  //   const paddedHead = head.padStart(
+  //     minimumFractionDigits + 1 - head.length,
+  //     '0'
+  //   );
+  //   next = `${paddedHead.slice(0, -minimumFractionDigits)}.${paddedHead.slice(
+  //     -minimumFractionDigits
+  //   )}`;
+  // }
+
+  let formatted = formatValidNumber(
+    next === '.' ? 0 : next, // period isn't valid, format as zero
+    minimumFractionDigits,
+    maximumFractionDigits
+  );
+
+  if (maximumFractionDigits > 0) {
+    if (!formatted.includes('.')) {
+      if (next.endsWith('.')) {
+        formatted += '.';
+      } else if (next.startsWith('.')) {
+        formatted = '0.' + formatted;
+      }
+    }
+
+    if (next.includes('.')) {
+      const [formattedHead, formattedTail] = formatted.split('.');
+
+      const newHead =
+        formattedHead === '0' && next.startsWith('.') ? '' : formattedHead;
+
+      formatted = `${newHead}.${formattedTail || tail}`;
+    }
+  }
+
+  return formatted;
+};
+
+const formatValidNumber = (
+  string: string | number | undefined,
+  minimumFractionDigits: number,
+  maximumFractionDigits: number
+) => {
+  if (string == null) {
+    return '';
+  }
+  const number = parseValidNumber(string);
+
+  return number == null
+    ? ''
+    : number.toLocaleString('en', {
+        minimumFractionDigits,
+        maximumFractionDigits,
+      });
+};
+
+const parseValidNumber = (string: string | number) => {
+  if (typeof string === 'number') {
+    return string;
+  }
+  const number = Number.parseFloat(string);
+  return Number.isNaN(number) ? undefined : number;
+};
+
+const replaceNumber = ({ suffix }: FormattingOptions) => (string: string) => {
+  let next = string;
+
+  // move single dash to beginning of string while keeping cursor position
+  const isNeg = negativeChars(string) % 2 !== 0;
+  next = (isNeg ? '-' : '') + removeNegatives(next);
+
+  next += suffix;
+
+  return next;
+};
+
+const parseNumber = (string: string) => parseValidNumber(acceptNumber(string));
+
+const useStyles = makeStyles(() => ({
+  alignRight: {
+    textAlign: 'right',
+  },
+}));
+
+export const NumberField = ({
+  alignRight,
+  allowNegative = false,
+  minimumFractionDigits = 0,
+  maximumFractionDigits = 0,
+  prefix = '',
+  suffix = '',
+  ...props
+}: NumberFieldProps) => {
+  const classes = useStyles();
+  const formatting: FormattingOptions = {
+    allowNegative,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    prefix: '',
+    suffix,
+  };
+  const formatInput = formatNumber(formatting);
+  const replace = replaceNumber(formatting);
+  return (
+    <FormattedTextField<number | undefined>
+      accept={/[\d-.]/g}
+      formatInput={formatInput}
+      replace={replace}
+      format={(val) =>
+        formatValidNumber(val, minimumFractionDigits, maximumFractionDigits)
+      }
+      parse={parseNumber}
+      {...props}
+      type="tel"
+      InputProps={{
+        ...(prefix
+          ? {
+              startAdornment: (
+                <InputAdornment position="start">{prefix}</InputAdornment>
+              ),
+            }
+          : {}),
+        ...props.InputProps,
+        classes: {
+          ...props.InputProps?.classes,
+          input: clsx(
+            alignRight && classes.alignRight,
+            props.InputProps?.classes?.input
+          ),
+        },
+      }}
+    />
+  );
+};

--- a/src/components/form/YearField.stories.tsx
+++ b/src/components/form/YearField.stories.tsx
@@ -1,0 +1,27 @@
+import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+import React from 'react';
+import { Form } from 'react-final-form';
+import { FieldSpy } from './FieldSpy';
+import { YearField } from './YearField';
+
+export default { title: 'Components/Forms/Fields' };
+
+export const Year = () => (
+  <Form onSubmit={action('submit')}>
+    {({ handleSubmit }) => (
+      <form onSubmit={handleSubmit}>
+        <YearField
+          name="year"
+          label={text('Label', 'Year')}
+          autoComplete="off"
+          placeholder={text('placeholder', 'Enter Year')}
+          required={boolean('Required', true)}
+          fullWidth={boolean('Full Width', true)}
+          disabled={boolean('Disabled', false)}
+        />
+        <FieldSpy name="year" />
+      </form>
+    )}
+  </Form>
+);

--- a/src/components/form/YearField.tsx
+++ b/src/components/form/YearField.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { NumberField, NumberFieldProps } from './NumberField';
+import { max, min } from './validators';
+
+export type YearFieldProps = NumberFieldProps;
+
+export const YearField = (props: YearFieldProps) => (
+  <NumberField
+    validate={[
+      min(1900, 'Year is too far in the past'),
+      max(2100, 'Year is too far in the future'),
+    ]}
+    {...props}
+    accept={/[\d]/g}
+    formatInput={formatInput}
+    mask
+  />
+);
+
+const formatInput = (string: string) => {
+  if (!string) {
+    return '';
+  }
+  const accepted = (string.match(/[\d]+/g) || []).join('');
+  return accepted.slice(0, 4);
+};

--- a/src/components/form/validators.ts
+++ b/src/components/form/validators.ts
@@ -29,3 +29,11 @@ export const required = (value: unknown) => (value ? undefined : 'Required');
 
 export const email = (value: string) =>
   !value || isEmail(value) ? undefined : 'Invalid email';
+
+export const min = (min: number, error?: string) => (
+  val: number | null | undefined
+) => (val != null && val < min ? error ?? 'Value is below minimum' : undefined);
+
+export const max = (max: number, error?: string) => (
+  val: number | null | undefined
+) => (val != null && val > max ? error ?? 'Value is above maximum' : undefined);

--- a/src/scenes/Authentication/Register/RegisterForm.tsx
+++ b/src/scenes/Authentication/Register/RegisterForm.tsx
@@ -86,7 +86,7 @@ export const RegisterForm = ({ className, ...props }: RegisterFormProps) => {
                 placeholder="Enter Last Name"
                 required
               />
-              <EmailField />
+              <EmailField caseSensitive />
               <PasswordField />
               <PasswordField
                 name="confirmPassword"

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,4 @@
 export * from './array-helpers';
 export * from './CalenderDate';
+export * from './log';
 export * from './sleep';

--- a/src/util/log.ts
+++ b/src/util/log.ts
@@ -1,0 +1,9 @@
+export const logFn = <T extends (...args: any) => any>(
+  fn: T,
+  fnName?: string,
+  ...extra: any
+) => (...args: Parameters<T>): ReturnType<T> => {
+  const res = fn(...(args as any));
+  console.debug(fnName ?? fn.name, ...extra, ...(args as any), res);
+  return res;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7180,6 +7180,7 @@ __metadata:
     react-router-dom: ^6.0.0-alpha.5
     react-scripts: ^3.4.1
     react-use: ^14.1.1
+    rifm: ^0.12.0
     seedrandom: ^3.0.5
     storybook-dark-mode: ^0.4.1
     ts-essentials: ^6.0.4
@@ -17922,6 +17923,15 @@ resolve@1.15.0:
   peerDependencies:
     react: ">=16.8"
   checksum: 3/7bcc9aea831655bd3292dd45949fbbd47957f9cba999ffff5013641e51007eb21fe6a97ed93e47a8aa1240ff5eb87276b92049b49ca4e3c06772b03f666805b6
+  languageName: node
+  linkType: hard
+
+"rifm@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "rifm@npm:0.12.0"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 3/bca3419639425beb04e8f6376659f6084475768119fba5710021fe646e16807370465c8fc69f6c42d0a618c7c9541d41fb6a6eb48329cf7b1d0654d59bd86ec2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #242 #225 

- Created `FormattedTextField` as base for formatted input
- Created `NumberField` based on this that handles integers, floats, negatives, prefixes/suffixes.
  Turns out this is really hard lol. It's not perfect and there are still some interactions I don't like. I still felt like this was a better base than `react-number-format` library. Happy to be proven wrong and replace it.
- Created `YearField` thin wrapper around `NumberField` for years.
- Updated `EmailField` to lowercase input as emails are case-insensitive. Added option to keep sensitivity like when creating account. The API should handle this insensitivity anyways, this is just for looks.
- Added stories for everything.