### PR TITLE
FE 228 User Detail and Edit User

### DIFF
--- a/src/api/operations.generated.ts
+++ b/src/api/operations.generated.ts
@@ -48,5 +48,7 @@ export const GQLOperations = {
     orgDetails: 'orgDetails',
     EditPartnership: 'EditPartnership',
     userDetails: 'userDetails',
+    UserForm: 'UserForm',
+    ss: 'ss',
   },
 };

--- a/src/api/operations.generated.ts
+++ b/src/api/operations.generated.ts
@@ -23,6 +23,7 @@ export const GQLOperations = {
     DeletePartnership: 'DeletePartnership',
     CreateProject: 'CreateProject',
     CreatePerson: 'CreatePerson',
+    UpdateUser: 'UpdateUser',
   },
   Fragment: {
     DisplayLocation: 'DisplayLocation',

--- a/src/api/operations.generated.ts
+++ b/src/api/operations.generated.ts
@@ -7,6 +7,7 @@ export const GQLOperations = {
     ProjectPartnerships: 'ProjectPartnerships',
     ProjectList: 'ProjectList',
     ProjectOverview: 'ProjectOverview',
+    User: 'User',
     Users: 'Users',
   },
   Mutation: {
@@ -45,5 +46,6 @@ export const GQLOperations = {
     UserListItem: 'UserListItem',
     orgDetails: 'orgDetails',
     EditPartnership: 'EditPartnership',
+    userDetails: 'userDetails',
   },
 };

--- a/src/api/secured.ts
+++ b/src/api/secured.ts
@@ -1,3 +1,4 @@
+import isPlainObject from 'is-plain-object';
 import { Nullable } from '../util';
 
 export interface Secured<T> {
@@ -5,3 +6,9 @@ export interface Secured<T> {
   canEdit: boolean;
   value?: Nullable<T>;
 }
+
+export const isSecured = <T>(value: unknown): value is Secured<T> =>
+  value &&
+  isPlainObject(value) &&
+  'canEdit' in (value as any) &&
+  'canRead' in (value as any);

--- a/src/components/DisplaySimpleProperty/DisplaySimpleProperty.tsx
+++ b/src/components/DisplaySimpleProperty/DisplaySimpleProperty.tsx
@@ -8,7 +8,7 @@ export type DisplaySimplePropertyProps = TypographyProps & {
   LabelProps?: TypographyProps;
   value?: ReactNode;
   ValueProps?: TypographyProps;
-  loading?: boolean;
+  loading?: boolean | ReactNode;
   loadingWidth?: number | string;
 };
 
@@ -22,8 +22,10 @@ export const DisplaySimpleProperty = ({
   ...props
 }: DisplaySimplePropertyProps) => (
   <Typography variant="body2" {...props}>
-    {loading ? (
-      <Skeleton variant="text" width={loadingWidth} />
+    {loading === true ? (
+      <Skeleton width={loadingWidth} />
+    ) : loading ? (
+      loading
     ) : label && value ? (
       <>
         <Typography variant="inherit" {...LabelProps}>

--- a/src/components/form/SecuredField.tsx
+++ b/src/components/form/SecuredField.tsx
@@ -1,0 +1,32 @@
+import { ReactElement } from 'react';
+import { ConditionalKeys } from 'type-fest';
+import { Secured } from '../../api';
+import { Nullable } from '../../util';
+
+interface SecuredFieldRenderProps {
+  name: string;
+  disabled?: boolean;
+}
+
+/**
+ * An experimental way to render a form field of a secured property.
+ * @experimental
+ */
+export const SecuredField = <T, K extends ConditionalKeys<T, Secured<any>>>({
+  obj,
+  name,
+  children,
+}: {
+  obj: Nullable<T>;
+  name: K;
+  children: (props: SecuredFieldRenderProps) => ReactElement;
+}) => {
+  const field = obj?.[name] as Nullable<Secured<any>>;
+  if (field && !field.canRead) {
+    return null;
+  }
+  return children({
+    name: name as string,
+    disabled: obj ? !field?.canEdit : undefined,
+  });
+};

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -6,6 +6,7 @@ export * from './EmailField';
 export * from './FieldGroup';
 export * from './PasswordField';
 export * from './RadioField';
+export * from './SecuredField';
 export * from './SubmitButton';
 export * from './SubmitError';
 export * from './TextField';

--- a/src/scenes/Users/Create/CreateUser.generated.ts
+++ b/src/scenes/Users/Create/CreateUser.generated.ts
@@ -3,8 +3,8 @@ import * as ApolloReactCommon from '@apollo/client';
 import * as ApolloReactHooks from '@apollo/client';
 import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
-import { LoggedInUserFragment } from '../../../components/Session/session.generated';
-import { LoggedInUserFragmentDoc } from '../../../components/Session/session.generated';
+import { UserDetailsFragment } from '../Detail/UserDetail.generated';
+import { UserDetailsFragmentDoc } from '../Detail/UserDetail.generated';
 
 export interface CreatePersonMutationVariables {
   input: Types.CreatePersonInput;
@@ -12,8 +12,8 @@ export interface CreatePersonMutationVariables {
 
 export type CreatePersonMutation = { __typename?: 'Mutation' } & {
   createPerson: { __typename?: 'CreatePersonOutput' } & {
-    user: { __typename?: 'User' } & Pick<Types.User, 'fullName'> &
-      LoggedInUserFragment;
+    user: { __typename?: 'User' } & Pick<Types.User, 'id' | 'fullName'> &
+      UserDetailsFragment;
   };
 };
 
@@ -21,12 +21,13 @@ export const CreatePersonDocument = gql`
   mutation CreatePerson($input: CreatePersonInput!) {
     createPerson(input: $input) {
       user {
+        id
         fullName
-        ...LoggedInUser
+        ...userDetails
       }
     }
   }
-  ${LoggedInUserFragmentDoc}
+  ${UserDetailsFragmentDoc}
 `;
 export type CreatePersonMutationFn = ApolloReactCommon.MutationFunction<
   CreatePersonMutation,

--- a/src/scenes/Users/Create/CreateUser.graphql
+++ b/src/scenes/Users/Create/CreateUser.graphql
@@ -1,9 +1,9 @@
 mutation CreatePerson($input: CreatePersonInput!) {
   createPerson(input: $input) {
     user {
-      # TODO use fragment used by detail view
+      id
       fullName
-      ...LoggedInUser
+      ...userDetails
     }
   }
 }

--- a/src/scenes/Users/Create/CreateUser.tsx
+++ b/src/scenes/Users/Create/CreateUser.tsx
@@ -1,42 +1,25 @@
-import { Grid } from '@material-ui/core';
-import { Decorator } from 'final-form';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
 import { CreatePersonInput, GQLOperations } from '../../../api';
-import {
-  DialogForm,
-  DialogFormProps,
-} from '../../../components/Dialog/DialogForm';
-import {
-  EmailField,
-  FieldGroup,
-  matchFieldIfSame,
-  SubmitError,
-  TextField,
-} from '../../../components/form';
 import { ButtonLink } from '../../../components/Routing';
+import { UserForm, UserFormProps } from '../UserForm';
 import { useCreatePersonMutation } from './CreateUser.generated';
 
-type CreateUserProps = Except<DialogFormProps<CreatePersonInput>, 'onSubmit'>;
-
-const decorators: Array<Decorator<CreatePersonInput>> = [
-  matchFieldIfSame('person.realFirstName', 'person.displayFirstName'),
-  matchFieldIfSame('person.realLastName', 'person.displayLastName'),
-];
+export type CreateUserProps = Except<
+  UserFormProps<CreatePersonInput>,
+  'prefix' | 'onSubmit'
+>;
 
 export const CreateUser = (props: CreateUserProps) => {
   const [createPerson] = useCreatePersonMutation();
   const { enqueueSnackbar } = useSnackbar();
 
   return (
-    <DialogForm<CreatePersonInput>
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'sm',
-      }}
+    <UserForm<CreatePersonInput>
       title="Create Person"
       {...props}
+      prefix="person"
       onSubmit={async (input) => {
         const { data } = await createPerson({
           variables: { input },
@@ -53,66 +36,6 @@ export const CreateUser = (props: CreateUserProps) => {
           ),
         });
       }}
-      decorators={decorators}
-    >
-      <SubmitError />
-      <FieldGroup prefix="person">
-        <Grid container spacing={2}>
-          <Grid item xs>
-            <TextField
-              name="realFirstName"
-              label="First Name"
-              placeholder="Enter First Name"
-              required
-            />
-          </Grid>
-          <Grid item xs>
-            <TextField
-              name="realLastName"
-              label="Last Name"
-              placeholder="Enter Last Name"
-              required
-            />
-          </Grid>
-        </Grid>
-        <Grid container spacing={2}>
-          <Grid item xs>
-            <TextField
-              name="displayFirstName"
-              label="Public First Name"
-              placeholder="Enter Public First Name"
-              required
-            />
-          </Grid>
-          <Grid item xs>
-            <TextField
-              name="displayLastName"
-              label="Public Last Name"
-              placeholder="Enter Public Last Name"
-              required
-            />
-          </Grid>
-        </Grid>
-        <EmailField required={false} />
-        <TextField
-          name="phone"
-          label="Phone"
-          placeholder="Enter Phone Number"
-          type="tel"
-        />
-        <TextField
-          name="timezone"
-          label="Timezone"
-          placeholder="Enter Timezone"
-        />
-        <TextField
-          name="bio"
-          label="Biography"
-          multiline
-          placeholder="Enter Biography"
-          rows={3}
-        />
-      </FieldGroup>
-    </DialogForm>
+    />
   );
 };

--- a/src/scenes/Users/Detail/UserDetail.generated.ts
+++ b/src/scenes/Users/Detail/UserDetail.generated.ts
@@ -21,10 +21,13 @@ export type UserDetailsFragment = { __typename?: 'User' } & Pick<
       Types.SecuredString,
       'value'
     >;
-    bio: { __typename?: 'SecuredString' } & Pick<Types.SecuredString, 'value'>;
+    bio: { __typename?: 'SecuredString' } & Pick<
+      Types.SecuredString,
+      'value' | 'canEdit'
+    >;
     phone: { __typename?: 'SecuredString' } & Pick<
       Types.SecuredString,
-      'value'
+      'value' | 'canEdit'
     >;
     timezone: { __typename?: 'SecuredTimeZone' } & {
       value?: Types.Maybe<
@@ -42,9 +45,11 @@ export const UserDetailsFragmentDoc = gql`
     fullName
     bio {
       value
+      canEdit
     }
     phone {
       value
+      canEdit
     }
     timezone {
       value {

--- a/src/scenes/Users/Detail/UserDetail.generated.ts
+++ b/src/scenes/Users/Detail/UserDetail.generated.ts
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
 
 export interface UserQueryVariables {
-  input: Types.Scalars['ID'];
+  userId: Types.Scalars['ID'];
 }
 
 export type UserQuery = { __typename?: 'Query' } & {
@@ -21,14 +21,16 @@ export type UserDetailsFragment = { __typename?: 'User' } & Pick<
       Types.SecuredString,
       'value'
     >;
-    realFirstName: { __typename?: 'SecuredString' } & Pick<
+    bio: { __typename?: 'SecuredString' } & Pick<Types.SecuredString, 'value'>;
+    phone: { __typename?: 'SecuredString' } & Pick<
       Types.SecuredString,
       'value'
     >;
-    realLastName: { __typename?: 'SecuredString' } & Pick<
-      Types.SecuredString,
-      'value'
-    >;
+    timezone: { __typename?: 'SecuredTimeZone' } & {
+      value?: Types.Maybe<
+        { __typename?: 'TimeZone' } & Pick<Types.TimeZone, 'name'>
+      >;
+    };
   };
 
 export const UserDetailsFragmentDoc = gql`
@@ -38,18 +40,23 @@ export const UserDetailsFragmentDoc = gql`
       value
     }
     fullName
-    realFirstName {
+    bio {
       value
     }
-    realLastName {
+    phone {
       value
+    }
+    timezone {
+      value {
+        name
+      }
     }
     createdAt
   }
 `;
 export const UserDocument = gql`
-  query User($input: ID!) {
-    user(id: $input) {
+  query User($userId: ID!) {
+    user(id: $userId) {
       ...userDetails
     }
   }
@@ -68,7 +75,7 @@ export const UserDocument = gql`
  * @example
  * const { data, loading, error } = useUserQuery({
  *   variables: {
- *      input: // value for 'input'
+ *      userId: // value for 'userId'
  *   },
  * });
  */

--- a/src/scenes/Users/Detail/UserDetail.generated.ts
+++ b/src/scenes/Users/Detail/UserDetail.generated.ts
@@ -1,16 +1,17 @@
 /* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
-
 import * as ApolloReactCommon from '@apollo/client';
 import * as ApolloReactHooks from '@apollo/client';
 import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
+import { UserFormFragment } from '../UserForm/UserForm.generated';
+import { UserFormFragmentDoc } from '../UserForm/UserForm.generated';
 
 export interface UserQueryVariables {
   userId: Types.Scalars['ID'];
 }
 
 export type UserQuery = { __typename?: 'Query' } & {
-  user: { __typename?: 'User' } & UserDetailsFragment;
+  user: { __typename?: 'User' } & UserDetailsFragment & UserFormFragment;
 };
 
 export type UserDetailsFragment = { __typename?: 'User' } & Pick<
@@ -63,9 +64,11 @@ export const UserDocument = gql`
   query User($userId: ID!) {
     user(id: $userId) {
       ...userDetails
+      ...UserForm
     }
   }
   ${UserDetailsFragmentDoc}
+  ${UserFormFragmentDoc}
 `;
 
 /**

--- a/src/scenes/Users/Detail/UserDetail.generated.ts
+++ b/src/scenes/Users/Detail/UserDetail.generated.ts
@@ -1,0 +1,99 @@
+/* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
+
+import * as ApolloReactCommon from '@apollo/client';
+import * as ApolloReactHooks from '@apollo/client';
+import gql from 'graphql-tag';
+import * as Types from '../../../api/schema.generated';
+
+export interface UserQueryVariables {
+  input: Types.Scalars['ID'];
+}
+
+export type UserQuery = { __typename?: 'Query' } & {
+  user: { __typename?: 'User' } & UserDetailsFragment;
+};
+
+export type UserDetailsFragment = { __typename?: 'User' } & Pick<
+  Types.User,
+  'id' | 'fullName' | 'createdAt'
+> & {
+    email: { __typename?: 'SecuredString' } & Pick<
+      Types.SecuredString,
+      'value'
+    >;
+    realFirstName: { __typename?: 'SecuredString' } & Pick<
+      Types.SecuredString,
+      'value'
+    >;
+    realLastName: { __typename?: 'SecuredString' } & Pick<
+      Types.SecuredString,
+      'value'
+    >;
+  };
+
+export const UserDetailsFragmentDoc = gql`
+  fragment userDetails on User {
+    id
+    email {
+      value
+    }
+    fullName
+    realFirstName {
+      value
+    }
+    realLastName {
+      value
+    }
+    createdAt
+  }
+`;
+export const UserDocument = gql`
+  query User($input: ID!) {
+    user(id: $input) {
+      ...userDetails
+    }
+  }
+  ${UserDetailsFragmentDoc}
+`;
+
+/**
+ * __useUserQuery__
+ *
+ * To run a query within a React component, call `useUserQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useUserQuery({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUserQuery(
+  baseOptions?: ApolloReactHooks.QueryHookOptions<UserQuery, UserQueryVariables>
+) {
+  return ApolloReactHooks.useQuery<UserQuery, UserQueryVariables>(
+    UserDocument,
+    baseOptions
+  );
+}
+export function useUserLazyQuery(
+  baseOptions?: ApolloReactHooks.LazyQueryHookOptions<
+    UserQuery,
+    UserQueryVariables
+  >
+) {
+  return ApolloReactHooks.useLazyQuery<UserQuery, UserQueryVariables>(
+    UserDocument,
+    baseOptions
+  );
+}
+export type UserQueryHookResult = ReturnType<typeof useUserQuery>;
+export type UserLazyQueryHookResult = ReturnType<typeof useUserLazyQuery>;
+export type UserQueryResult = ApolloReactCommon.QueryResult<
+  UserQuery,
+  UserQueryVariables
+>;

--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -1,5 +1,5 @@
-query User($input: ID!) {
-  user(id: $input) {
+query User($userId: ID!) {
+  user(id: $userId) {
     ...userDetails
   }
 }
@@ -10,11 +10,16 @@ fragment userDetails on User {
     value
   }
   fullName
-  realFirstName {
+  bio {
     value
   }
-  realLastName {
+  phone {
     value
+  }
+  timezone {
+    value {
+      name
+    }
   }
   createdAt
 }

--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -12,9 +12,11 @@ fragment userDetails on User {
   fullName
   bio {
     value
+    canEdit
   }
   phone {
     value
+    canEdit
   }
   timezone {
     value {

--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -1,6 +1,7 @@
 query User($userId: ID!) {
   user(id: $userId) {
     ...userDetails
+    ...UserForm
   }
 }
 

--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -1,0 +1,20 @@
+query User($input: ID!) {
+  user(id: $input) {
+    ...userDetails
+  }
+}
+
+fragment userDetails on User {
+  id
+  email {
+    value
+  }
+  fullName
+  realFirstName {
+    value
+  }
+  realLastName {
+    value
+  }
+  createdAt
+}

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -139,9 +139,20 @@ const DisplayProperty = (props: DisplaySimplePropertyProps) =>
   !props.value && !props.loading ? null : (
     <DisplaySimpleProperty
       variant="body1"
-      loadingWidth="40%"
       {...{ component: 'div' }}
       {...props}
+      loading={
+        props.loading ? (
+          <>
+            <Typography variant="body2">
+              <Skeleton width="10%" />
+            </Typography>
+            <Typography variant="body1">
+              <Skeleton width="40%" />
+            </Typography>
+          </>
+        ) : null
+      }
       LabelProps={{
         color: 'textSecondary',
         variant: 'body2',

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -6,12 +6,14 @@ import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 import { useParams } from 'react-router';
 import { useInterval } from 'react-use';
+import { useDialog } from '../../../components/Dialog';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
 } from '../../../components/DisplaySimpleProperty';
 import { Fab } from '../../../components/Fab';
 import { Redacted } from '../../../components/Redacted';
+import { EditUser } from '../Edit';
 import { useUserQuery } from './UserDetail.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
@@ -41,6 +43,8 @@ export const UserDetail = () => {
   const { data, error } = useUserQuery({
     variables: { userId },
   });
+
+  const [editUserState, editUser] = useDialog();
 
   const user = data?.user;
 
@@ -73,7 +77,7 @@ export const UserDetail = () => {
               )}
             </Typography>
             {canEditAnyFields ? (
-              <Fab color="primary" aria-label="edit person">
+              <Fab color="primary" aria-label="edit person" onClick={editUser}>
                 <Edit />
               </Fab>
             ) : null}
@@ -102,6 +106,7 @@ export const UserDetail = () => {
             value={user?.bio.value}
             loading={!user}
           />
+          {user ? <EditUser user={user} {...editUserState} /> : null}
         </>
       )}
     </main>

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -1,0 +1,98 @@
+import {
+  Breadcrumbs,
+  IconButton,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+import { Skeleton } from '@material-ui/lab';
+import clsx from 'clsx';
+import React from 'react';
+import { useParams } from 'react-router';
+import { Breadcrumb } from '../../../components/Breadcrumb';
+import { DisplaySimpleProperty } from '../../../components/DisplaySimpleProperty';
+import { useDateFormatter } from '../../../components/Formatters';
+import { PencilCircledIcon } from '../../../components/Icons';
+import { useUserQuery } from './UserDetail.generated';
+
+const useStyles = makeStyles(({ spacing }) => ({
+  root: {
+    overflowY: 'scroll',
+    padding: spacing(4),
+    '& > *': {
+      marginBottom: spacing(3),
+    },
+  },
+  name: {
+    marginRight: spacing(2),
+  },
+  nameLoading: {
+    flex: 1,
+  },
+  header: {
+    flex: 1,
+    display: 'flex',
+  },
+  bio: {
+    marginBottom: 0,
+  },
+}));
+
+export const UserDetail = () => {
+  const classes = useStyles();
+  const { userId } = useParams();
+  const { data, error } = useUserQuery({
+    variables: {
+      input: userId,
+    },
+  });
+
+  const user = data?.user;
+
+  const formatDateTime = useDateFormatter();
+
+  return (
+    <main className={classes.root}>
+      {error ? (
+        <Typography variant="h4">Error fetching Project</Typography>
+      ) : (
+        <>
+          <Breadcrumbs>
+            <Breadcrumb to="/users">Users</Breadcrumb>
+          </Breadcrumbs>
+          <div className={classes.header}>
+            <Typography
+              variant="h2"
+              className={clsx(classes.name, user ? null : classes.nameLoading)}
+            >
+              {user ? user.fullName : <Skeleton width="75%" />}
+            </Typography>
+            {user ? (
+              <IconButton
+                color="primary"
+                aria-label="edit user"
+                // onClick={editOrg}
+              >
+                <PencilCircledIcon />
+              </IconButton>
+            ) : null}
+          </div>
+          {user ? (
+            <>
+              <Typography>Email: {user.email.value}</Typography>
+              <Typography>Phone: {user.phone.value}</Typography>
+              <Typography variant="h4" className={classes.bio}>
+                Bio
+              </Typography>
+              <Typography>{user.bio.value}</Typography>
+              <DisplaySimpleProperty
+                label="Created At"
+                value={formatDateTime(user.createdAt)}
+                ValueProps={{ color: 'textSecondary' }}
+              />
+            </>
+          ) : null}
+        </>
+      )}
+    </main>
+  );
+};

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 import { useParams } from 'react-router';
 import { useInterval } from 'react-use';
+import { isSecured } from '../../../api';
 import { useDialog } from '../../../components/Dialog';
 import {
   DisplaySimpleProperty,
@@ -48,8 +49,11 @@ export const UserDetail = () => {
 
   const user = data?.user;
 
-  // TODO calculate if they can edit any fields
-  const canEditAnyFields = !!user;
+  const canEditAnyFields = !user
+    ? false
+    : Object.entries(user).some(([_, value]) =>
+        isSecured(value) ? value.canEdit : false
+      );
 
   return (
     <main className={classes.root}>

--- a/src/scenes/Users/Detail/index.ts
+++ b/src/scenes/Users/Detail/index.ts
@@ -1,0 +1,1 @@
+export * from './UserDetail';

--- a/src/scenes/Users/Edit/EditUser.generated.ts
+++ b/src/scenes/Users/Edit/EditUser.generated.ts
@@ -1,0 +1,71 @@
+/* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
+import * as ApolloReactCommon from '@apollo/client';
+import * as ApolloReactHooks from '@apollo/client';
+import gql from 'graphql-tag';
+import * as Types from '../../../api/schema.generated';
+import { UserDetailsFragment } from '../Detail/UserDetail.generated';
+import { UserDetailsFragmentDoc } from '../Detail/UserDetail.generated';
+
+export interface UpdateUserMutationVariables {
+  input: Types.UpdateUserInput;
+}
+
+export type UpdateUserMutation = { __typename?: 'Mutation' } & {
+  updateUser: { __typename?: 'UpdateUserOutput' } & {
+    user: { __typename?: 'User' } & UserDetailsFragment;
+  };
+};
+
+export const UpdateUserDocument = gql`
+  mutation UpdateUser($input: UpdateUserInput!) {
+    updateUser(input: $input) {
+      user {
+        ...userDetails
+      }
+    }
+  }
+  ${UserDetailsFragmentDoc}
+`;
+export type UpdateUserMutationFn = ApolloReactCommon.MutationFunction<
+  UpdateUserMutation,
+  UpdateUserMutationVariables
+>;
+
+/**
+ * __useUpdateUserMutation__
+ *
+ * To run a mutation, you first call `useUpdateUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateUserMutation, { data, loading, error }] = useUpdateUserMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateUserMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    UpdateUserMutation,
+    UpdateUserMutationVariables
+  >
+) {
+  return ApolloReactHooks.useMutation<
+    UpdateUserMutation,
+    UpdateUserMutationVariables
+  >(UpdateUserDocument, baseOptions);
+}
+export type UpdateUserMutationHookResult = ReturnType<
+  typeof useUpdateUserMutation
+>;
+export type UpdateUserMutationResult = ApolloReactCommon.MutationResult<
+  UpdateUserMutation
+>;
+export type UpdateUserMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  UpdateUserMutation,
+  UpdateUserMutationVariables
+>;

--- a/src/scenes/Users/Edit/EditUser.graphql
+++ b/src/scenes/Users/Edit/EditUser.graphql
@@ -1,0 +1,7 @@
+mutation UpdateUser($input: UpdateUserInput!) {
+  updateUser(input: $input) {
+    user {
+      ...userDetails
+    }
+  }
+}

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Except } from 'type-fest';
+import { UpdateUserInput } from '../../../api';
+import {
+  DialogForm,
+  DialogFormProps,
+} from '../../../components/Dialog/DialogForm';
+import { SubmitError, TextField } from '../../../components/form';
+import { UserDetailsFragment } from '../Detail/UserDetail.generated';
+import { useUpdateUserMutation } from './EditUser.generated';
+
+export type EditUserProps = Except<
+  DialogFormProps<UpdateUserInput>,
+  'onSubmit' | 'initialValues'
+> & {
+  user: UserDetailsFragment;
+};
+
+export const EditUser = ({ user, ...props }: EditUserProps) => {
+  const [updateUser] = useUpdateUserMutation();
+
+  return (
+    <DialogForm<UpdateUserInput>
+      DialogProps={{
+        fullWidth: true,
+        maxWidth: 'xs',
+      }}
+      title="Edit User"
+      {...props}
+      onlyDirtySubmit
+      initialValues={{ user: { id: user.id } }}
+      onSubmit={(input) => {
+        updateUser({
+          variables: { input },
+        });
+      }}
+    >
+      <SubmitError />
+      <TextField
+        name="user.realFirstName"
+        label="First Name"
+        placeholder="New First Name"
+        disabled={!user.realFirstName.canEdit}
+        autoFocus
+      />
+      <TextField
+        name="user.realLastName"
+        label="Last Name"
+        placeholder="New Last Name"
+        disabled={!user.realLastName.canEdit}
+      />
+      <TextField
+        name="user.phone"
+        label="Phone"
+        placeholder="New Phone Number"
+        disabled={!user.phone.canEdit}
+      />
+      <TextField
+        name="user.bio"
+        label="Bio"
+        placeholder="User Bio"
+        disabled={!user.bio.canEdit}
+        multiline
+      />
+    </DialogForm>
+  );
+};

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -1,67 +1,44 @@
 import React from 'react';
 import { Except } from 'type-fest';
 import { UpdateUserInput } from '../../../api';
-import {
-  DialogForm,
-  DialogFormProps,
-} from '../../../components/Dialog/DialogForm';
-import { SubmitError, TextField } from '../../../components/form';
-import { UserDetailsFragment } from '../Detail/UserDetail.generated';
+import { UserForm, UserFormProps } from '../UserForm';
 import { useUpdateUserMutation } from './EditUser.generated';
 
 export type EditUserProps = Except<
-  DialogFormProps<UpdateUserInput>,
-  'onSubmit' | 'initialValues'
-> & {
-  user: UserDetailsFragment;
-};
+  UserFormProps<UpdateUserInput>,
+  'prefix' | 'onSubmit' | 'initialValues'
+>;
 
-export const EditUser = ({ user, ...props }: EditUserProps) => {
+export const EditUser = (props: EditUserProps) => {
   const [updateUser] = useUpdateUserMutation();
+  const user = props.user;
 
   return (
-    <DialogForm<UpdateUserInput>
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
-      title="Edit User"
+    <UserForm<UpdateUserInput>
+      title="Edit Person"
       {...props}
-      onlyDirtySubmit
-      initialValues={{ user: { id: user.id } }}
+      prefix="user"
+      initialValues={
+        user
+          ? {
+              user: {
+                id: user.id,
+                realFirstName: user.realFirstName.value,
+                realLastName: user.realLastName.value,
+                displayFirstName: user.displayFirstName.value,
+                displayLastName: user.displayLastName.value,
+                phone: user.phone.value,
+                timezone: user.timezone.value?.name,
+                bio: user.bio.value,
+              },
+            }
+          : undefined
+      }
       onSubmit={(input) => {
         updateUser({
           variables: { input },
         });
       }}
-    >
-      <SubmitError />
-      <TextField
-        name="user.realFirstName"
-        label="First Name"
-        placeholder="New First Name"
-        disabled={!user.realFirstName.canEdit}
-        autoFocus
-      />
-      <TextField
-        name="user.realLastName"
-        label="Last Name"
-        placeholder="New Last Name"
-        disabled={!user.realLastName.canEdit}
-      />
-      <TextField
-        name="user.phone"
-        label="Phone"
-        placeholder="New Phone Number"
-        disabled={!user.phone.canEdit}
-      />
-      <TextField
-        name="user.bio"
-        label="Bio"
-        placeholder="User Bio"
-        disabled={!user.bio.canEdit}
-        multiline
-      />
-    </DialogForm>
+    />
   );
 };

--- a/src/scenes/Users/Edit/index.ts
+++ b/src/scenes/Users/Edit/index.ts
@@ -1,0 +1,1 @@
+export * from './EditUser';

--- a/src/scenes/Users/UserForm/UserForm.generated.ts
+++ b/src/scenes/Users/UserForm/UserForm.generated.ts
@@ -1,0 +1,82 @@
+/* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
+import gql from 'graphql-tag';
+import * as Types from '../../../api/schema.generated';
+
+export type UserFormFragment = { __typename?: 'User' } & Pick<
+  Types.User,
+  'id'
+> & {
+    realFirstName: { __typename?: 'SecuredString' } & SsFragment;
+    realLastName: { __typename?: 'SecuredString' } & SsFragment;
+    displayFirstName: { __typename?: 'SecuredString' } & SsFragment;
+    displayLastName: { __typename?: 'SecuredString' } & SsFragment;
+    email: { __typename?: 'SecuredString' } & SsFragment;
+    timezone: { __typename?: 'SecuredTimeZone' } & Pick<
+      Types.SecuredTimeZone,
+      'canRead' | 'canEdit'
+    > & {
+        value?: Types.Maybe<
+          { __typename?: 'TimeZone' } & Pick<Types.TimeZone, 'name'> & {
+              countries: Array<
+                { __typename?: 'IanaCountry' } & Pick<
+                  Types.IanaCountry,
+                  'code' | 'name'
+                >
+              >;
+            }
+        >;
+      };
+    phone: { __typename?: 'SecuredString' } & SsFragment;
+    bio: { __typename?: 'SecuredString' } & SsFragment;
+  };
+
+export type SsFragment = { __typename?: 'SecuredString' } & Pick<
+  Types.SecuredString,
+  'value' | 'canRead' | 'canEdit'
+>;
+
+export const SsFragmentDoc = gql`
+  fragment ss on SecuredString {
+    value
+    canRead
+    canEdit
+  }
+`;
+export const UserFormFragmentDoc = gql`
+  fragment UserForm on User {
+    id
+    realFirstName {
+      ...ss
+    }
+    realLastName {
+      ...ss
+    }
+    displayFirstName {
+      ...ss
+    }
+    displayLastName {
+      ...ss
+    }
+    email {
+      ...ss
+    }
+    timezone {
+      value {
+        name
+        countries {
+          code
+          name
+        }
+      }
+      canRead
+      canEdit
+    }
+    phone {
+      ...ss
+    }
+    bio {
+      ...ss
+    }
+  }
+  ${SsFragmentDoc}
+`;

--- a/src/scenes/Users/UserForm/UserForm.graphql
+++ b/src/scenes/Users/UserForm/UserForm.graphql
@@ -1,0 +1,41 @@
+fragment UserForm on User {
+  id
+  realFirstName {
+    ...ss
+  }
+  realLastName {
+    ...ss
+  }
+  displayFirstName {
+    ...ss
+  }
+  displayLastName {
+    ...ss
+  }
+  email {
+    ...ss
+  }
+  timezone {
+    value {
+      name
+      countries {
+        code
+        name
+      }
+    }
+    canRead
+    canEdit
+  }
+  phone {
+    ...ss
+  }
+  bio {
+    ...ss
+  }
+}
+
+fragment ss on SecuredString {
+  value
+  canRead
+  canEdit
+}

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -1,0 +1,137 @@
+import { Grid } from '@material-ui/core';
+import { Decorator } from 'final-form';
+import { memoize } from 'lodash';
+import React from 'react';
+import {
+  DialogForm,
+  DialogFormProps,
+} from '../../../components/Dialog/DialogForm';
+import {
+  EmailField,
+  FieldGroup,
+  matchFieldIfSame,
+  SecuredField,
+  SubmitError,
+  TextField,
+} from '../../../components/form';
+import { UserFormFragment } from './UserForm.generated';
+
+export type UserFormProps<T> = DialogFormProps<T> & {
+  /** The pre-existing user to edit */
+  user?: UserFormFragment;
+  prefix: string;
+};
+
+const decorators = memoize((prefix: string) => [
+  matchFieldIfSame(`${prefix}.realFirstName`, `${prefix}.displayFirstName`),
+  matchFieldIfSame(`${prefix}.realLastName`, `${prefix}.displayLastName`),
+]);
+
+export const UserForm = <T extends any>({
+  user,
+  prefix,
+  ...rest
+}: UserFormProps<T>) => (
+  <DialogForm<T>
+    DialogProps={{
+      fullWidth: true,
+      maxWidth: 'sm',
+    }}
+    onlyDirtySubmit
+    {...rest}
+    decorators={decorators(prefix) as Array<Decorator<T>>}
+  >
+    <SubmitError />
+    <FieldGroup prefix={prefix}>
+      <Grid container spacing={2}>
+        <Grid item xs>
+          <SecuredField obj={user} name="realFirstName">
+            {(props) => (
+              <TextField
+                label="First Name"
+                placeholder="Enter First Name"
+                required
+                {...props}
+              />
+            )}
+          </SecuredField>
+        </Grid>
+        <Grid item xs>
+          <SecuredField obj={user} name="realLastName">
+            {(props) => (
+              <TextField
+                label="Last Name"
+                placeholder="Enter Last Name"
+                required
+                {...props}
+              />
+            )}
+          </SecuredField>
+        </Grid>
+      </Grid>
+      <Grid container spacing={2}>
+        <Grid item xs>
+          <SecuredField obj={user} name="displayFirstName">
+            {(props) => (
+              <TextField
+                label="Public First Name"
+                placeholder="Enter Public First Name"
+                required
+                {...props}
+              />
+            )}
+          </SecuredField>
+        </Grid>
+        <Grid item xs>
+          <SecuredField obj={user} name="displayLastName">
+            {(props) => (
+              <TextField
+                label="Public Last Name"
+                placeholder="Enter Public Last Name"
+                required
+                {...props}
+              />
+            )}
+          </SecuredField>
+        </Grid>
+      </Grid>
+      <SecuredField obj={user} name="email">
+        {(props) => (
+          <EmailField
+            required={false}
+            {...props}
+            // Email can't be changed right now but still show it
+            initialValue={user?.email.value ?? ''}
+            disabled={!!user}
+          />
+        )}
+      </SecuredField>
+      <SecuredField obj={user} name="phone">
+        {(props) => (
+          <TextField
+            label="Phone"
+            placeholder="Enter Phone Number"
+            type="tel"
+            {...props}
+          />
+        )}
+      </SecuredField>
+      <SecuredField obj={user} name="timezone">
+        {(props) => (
+          <TextField label="Timezone" placeholder="Enter Timezone" {...props} />
+        )}
+      </SecuredField>
+      <SecuredField obj={user} name="bio">
+        {(props) => (
+          <TextField
+            label="Biography"
+            multiline
+            placeholder="Enter Biography"
+            inputProps={{ rowsMin: 2 }}
+            {...props}
+          />
+        )}
+      </SecuredField>
+    </FieldGroup>
+  </DialogForm>
+);

--- a/src/scenes/Users/UserForm/index.ts
+++ b/src/scenes/Users/UserForm/index.ts
@@ -1,0 +1,2 @@
+export * from './UserForm';
+export * from './UserForm.generated';

--- a/src/scenes/Users/Users.tsx
+++ b/src/scenes/Users/Users.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useRoutes } from 'react-router-dom';
+import { UserDetail } from './Detail';
 import { UserList } from './List';
 
 export const Users = () => {
@@ -7,6 +8,10 @@ export const Users = () => {
     {
       path: '/',
       element: <UserList />,
+    },
+    {
+      path: '/:userId',
+      element: <UserDetail />,
     },
   ]);
 


### PR DESCRIPTION
The User Detail and Edit User Dialog scenes.
<img width="1524" alt="Screen Shot 2020-06-23 at 11 19 17 AM" src="https://user-images.githubusercontent.com/43487134/85440934-662ec980-b543-11ea-92fc-8a2b12bd5076.png">
<img width="895" alt="Screen Shot 2020-06-23 at 11 19 08 AM" src="https://user-images.githubusercontent.com/43487134/85440938-68912380-b543-11ea-864a-16d6b3f6ad6f.png">

**Technical Notes**

- Used the same fragment for UserDetail and EditUser (like implemented in Organizations).  I thought that was ok because these two scenes are paired.  Let me know if that understanding is incorrect.

- chose not to put in the initialValues for the dialog

- email is a not supported to edit based on the EditUserInput schema.  Let me know if that's a mistake

**Testing**
Go to /users/{userId} and see your user details.  Click the pencil icon to edit, and on submit see the changes.

