### PR TITLE
FE 262 Error and Not Found components

### DIFF
--- a/src/components/Error/Error.stories.tsx
+++ b/src/components/Error/Error.stories.tsx
@@ -1,6 +1,13 @@
+import { action } from '@storybook/addon-actions';
+import { select } from '@storybook/addon-knobs';
 import React from 'react';
 import { Error as ErrorComponent } from './Error';
 
 export default { title: 'Components/Error' };
 
-export const Error = () => <ErrorComponent />;
+export const Error = () => (
+  <ErrorComponent
+    navigateBack={action('go back')}
+    variant={select('Error Type', ['Error', '404'], 'Error')}
+  />
+);

--- a/src/components/Error/Error.stories.tsx
+++ b/src/components/Error/Error.stories.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Error as ErrorComponent } from './Error';
+
+export default { title: 'Components/Error' };
+
+export const Error = () => <ErrorComponent />;

--- a/src/components/Error/Error.stories.tsx
+++ b/src/components/Error/Error.stories.tsx
@@ -1,4 +1,3 @@
-import { action } from '@storybook/addon-actions';
 import { select } from '@storybook/addon-knobs';
 import React from 'react';
 import { Error as ErrorComponent } from './Error';
@@ -6,8 +5,5 @@ import { Error as ErrorComponent } from './Error';
 export default { title: 'Components/Error' };
 
 export const Error = () => (
-  <ErrorComponent
-    navigateBack={action('go back')}
-    variant={select('Error Type', ['Error', '404'], 'Error')}
-  />
+  <ErrorComponent variant={select('Error Type', ['Error', '404'], 'Error')} />
 );

--- a/src/components/Error/Error.stories.tsx
+++ b/src/components/Error/Error.stories.tsx
@@ -1,9 +1,27 @@
-import { select } from '@storybook/addon-knobs';
+import { ApolloError } from '@apollo/client';
+import { boolean } from '@storybook/addon-knobs';
+import { GraphQLError } from 'graphql';
 import React from 'react';
 import { Error as ErrorComponent } from './Error';
 
 export default { title: 'Components/Error' };
 
+const apolloErrorInstance = new ApolloError({
+  graphQLErrors: [
+    new GraphQLError(
+      'error message',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { code: 'NOT_FOUND' }
+    ),
+  ],
+});
+
 export const Error = () => (
-  <ErrorComponent variant={select('Error Type', ['Error', '404'], 'Error')} />
+  <ErrorComponent
+    error={boolean('Not Found', true) ? apolloErrorInstance : undefined}
+  />
 );

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,3 +1,36 @@
+import { Button, makeStyles, Typography } from '@material-ui/core';
 import React from 'react';
 
-export const Error = () => <div>This is the Error component</div>;
+const useStyles = makeStyles(({ spacing }) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    '& h3': {
+      fontWeight: 'bold',
+    },
+  },
+  button: {
+    height: spacing(4),
+    width: spacing(16),
+    marginTop: spacing(2),
+  },
+}));
+
+export const Error = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <Typography>Oops, Sorry.</Typography>
+      <Typography variant="h3">ERROR</Typography>
+      <Button
+        variant="contained"
+        color="secondary"
+        classes={{ root: classes.button }}
+      >
+        Back
+      </Button>
+    </div>
+  );
+};

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,8 +1,8 @@
 import { Button, makeStyles, Typography } from '@material-ui/core';
 import React, { FC } from 'react';
+import { useNavigate } from 'react-router';
 
 interface ErrorProps {
-  navigateBack: (event: React.MouseEvent<HTMLButtonElement>) => void;
   variant?: 'Error' | '404';
 }
 
@@ -26,8 +26,9 @@ const useStyles = makeStyles(({ spacing }) => ({
   },
 }));
 
-export const Error: FC<ErrorProps> = ({ navigateBack, variant = 'Error' }) => {
+export const Error: FC<ErrorProps> = ({ variant = 'Error' }) => {
   const classes = useStyles();
+  const navigate = useNavigate();
 
   const errorMessage =
     variant === 'Error' ? (
@@ -47,7 +48,7 @@ export const Error: FC<ErrorProps> = ({ navigateBack, variant = 'Error' }) => {
       <Typography>Oops, Sorry.</Typography>
       {errorMessage}
       <Button
-        onClick={navigateBack}
+        onClick={() => navigate(-1)}
         variant="contained"
         color="secondary"
         classes={{ root: classes.button }}

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,9 +1,10 @@
+import { ApolloError } from '@apollo/client';
 import { Button, makeStyles, Typography } from '@material-ui/core';
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router';
 
 interface ErrorProps {
-  variant?: 'Error' | '404';
+  error?: ApolloError;
 }
 
 const useStyles = makeStyles(({ spacing, typography }) => ({
@@ -24,15 +25,19 @@ const useStyles = makeStyles(({ spacing, typography }) => ({
   },
 }));
 
-export const Error: FC<ErrorProps> = ({ variant = 'Error' }) => {
+export const Error: FC<ErrorProps> = ({ error }) => {
   const classes = useStyles();
   const navigate = useNavigate();
+
+  const isNotFoundError = error?.graphQLErrors.some(
+    (error) => error.extensions?.code === 'NOT_FOUND'
+  );
 
   return (
     <div className={classes.container}>
       <Typography>Oops, Sorry.</Typography>
       <Typography variant="h3" className={classes.boldText}>
-        {error ? 'ERROR' : 'PAGE NOT FOUND'}
+        {isNotFoundError ? 'PAGE NOT FOUND' : 'ERROR'}
       </Typography>
       <Button
         onClick={() => navigate(-1)}

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 
 interface ErrorProps {
   navigateBack: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  variant?: 'Error' | '404';
 }
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -10,9 +11,13 @@ const useStyles = makeStyles(({ spacing }) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-start',
-    '& h3': {
-      fontWeight: 'bold',
-    },
+  },
+  errorType: {
+    display: 'flex',
+  },
+  boldText: {
+    fontWeight: 'bold',
+    marginRight: spacing(1),
   },
   button: {
     height: spacing(4),
@@ -21,13 +26,26 @@ const useStyles = makeStyles(({ spacing }) => ({
   },
 }));
 
-export const Error: FC<ErrorProps> = ({ navigateBack }) => {
+export const Error: FC<ErrorProps> = ({ navigateBack, variant = 'Error' }) => {
   const classes = useStyles();
 
+  const errorMessage =
+    variant === 'Error' ? (
+      <Typography variant="h3" className={classes.boldText}>
+        ERROR
+      </Typography>
+    ) : (
+      <div className={classes.errorType}>
+        <Typography variant="h3" className={classes.boldText}>
+          404
+        </Typography>
+        <Typography variant="h3">PAGE NOT FOUND</Typography>
+      </div>
+    );
   return (
     <div className={classes.container}>
       <Typography>Oops, Sorry.</Typography>
-      <Typography variant="h3">ERROR</Typography>
+      {errorMessage}
       <Button
         onClick={navigateBack}
         variant="contained"

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -6,7 +6,7 @@ interface ErrorProps {
   variant?: 'Error' | '404';
 }
 
-const useStyles = makeStyles(({ spacing }) => ({
+const useStyles = makeStyles(({ spacing, typography }) => ({
   container: {
     display: 'flex',
     flexDirection: 'column',
@@ -16,12 +16,10 @@ const useStyles = makeStyles(({ spacing }) => ({
     display: 'flex',
   },
   boldText: {
-    fontWeight: 'bold',
+    fontWeight: typography.weight.bold,
     marginRight: spacing(1),
   },
   button: {
-    height: spacing(4),
-    width: spacing(16),
     marginTop: spacing(2),
   },
 }));
@@ -30,28 +28,17 @@ export const Error: FC<ErrorProps> = ({ variant = 'Error' }) => {
   const classes = useStyles();
   const navigate = useNavigate();
 
-  const errorMessage =
-    variant === 'Error' ? (
-      <Typography variant="h3" className={classes.boldText}>
-        ERROR
-      </Typography>
-    ) : (
-      <div className={classes.errorType}>
-        <Typography variant="h3" className={classes.boldText}>
-          404
-        </Typography>
-        <Typography variant="h3">PAGE NOT FOUND</Typography>
-      </div>
-    );
   return (
     <div className={classes.container}>
       <Typography>Oops, Sorry.</Typography>
-      {errorMessage}
+      <Typography variant="h3" className={classes.boldText}>
+        {error ? 'ERROR' : 'PAGE NOT FOUND'}
+      </Typography>
       <Button
         onClick={() => navigate(-1)}
         variant="contained"
         color="secondary"
-        classes={{ root: classes.button }}
+        className={classes.button}
       >
         Back
       </Button>

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const Error = () => <div>This is the Error component</div>;

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -1,5 +1,9 @@
 import { Button, makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
+import React, { FC } from 'react';
+
+interface ErrorProps {
+  navigateBack: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
 
 const useStyles = makeStyles(({ spacing }) => ({
   container: {
@@ -17,7 +21,7 @@ const useStyles = makeStyles(({ spacing }) => ({
   },
 }));
 
-export const Error = () => {
+export const Error: FC<ErrorProps> = ({ navigateBack }) => {
   const classes = useStyles();
 
   return (
@@ -25,6 +29,7 @@ export const Error = () => {
       <Typography>Oops, Sorry.</Typography>
       <Typography variant="h3">ERROR</Typography>
       <Button
+        onClick={navigateBack}
         variant="contained"
         color="secondary"
         classes={{ root: classes.button }}

--- a/src/components/Error/index.ts
+++ b/src/components/Error/index.ts
@@ -1,0 +1,1 @@
+export * from './Error';


### PR DESCRIPTION
Created Error component to view Error and Not Found.  

**Technical notes**

- Combined the two views into one component because they're so similar but can be broken into 2 if needed.

- Need to pass in navigate back as a prop for the back button.  Was going to put in the navigate back through the history object but `useHistory` is not available for router v6: https://github.com/ReactTraining/react-router/issues/7189.

**Testing:**
See the views in storybook.
<img width="1626" alt="Screen Shot 2020-06-23 at 1 04 49 PM" src="https://user-images.githubusercontent.com/43487134/85454807-23c0b900-b552-11ea-90d7-761778314d60.png">
<img width="1635" alt="Screen Shot 2020-06-23 at 1 04 43 PM" src="https://user-images.githubusercontent.com/43487134/85454830-26bba980-b552-11ea-9263-56a43221b467.png">

