### PR TITLE
[storybook] Fix app contexts not being available when rendering stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 import { addDecorator, addParameters } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { HashRouter } from 'react-router-dom';
-import React, { createElement } from 'react';
+import React, { createElement, Fragment } from 'react';
 import { appProviders } from '../src/App';
 import { Nest } from '../src/components/Nest';
 import { SessionProvider } from '../src/components/Session';
@@ -18,11 +18,18 @@ const storybookProviders = [
   createElement(SessionProvider, { user: null }),
 ];
 
-addDecorator(story => createElement(
-  Nest,
-  { elements: storybookProviders },
-  story()
-));
+addDecorator(story => {
+  // render story with contexts provided here.
+  // if story fn is called directly it won't be a child the providers
+  // defined here and thus contexts will not be provided.
+  const Story = () => createElement(Fragment, {}, story());
+
+  return createElement(
+    Nest,
+    { elements: storybookProviders },
+    createElement(Story),
+  );
+});
 
 addParameters({
   options: {

--- a/src/components/Routing/decorators.stories.tsx
+++ b/src/components/Routing/decorators.stories.tsx
@@ -4,17 +4,13 @@ import { useLocation } from 'react-router';
 import { Code } from '../Debug';
 
 export const AddCurrentPath = (fn: () => ReactElement) => {
-  // render fn with provider's context
-  const Fn = () => {
-    const { pathname } = useLocation();
-    return (
-      <>
-        {fn()}
-        <Box mt={4} display="flex">
-          <Code>Current path: {pathname}</Code>
-        </Box>
-      </>
-    );
-  };
-  return <Fn />;
+  const { pathname } = useLocation();
+  return (
+    <>
+      {fn()}
+      <Box mt={4} display="flex">
+        <Code>Current path: {pathname}</Code>
+      </Box>
+    </>
+  );
 };

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -3,22 +3,10 @@ import { Close } from '@material-ui/icons';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { OptionsObject, useSnackbar } from 'notistack';
-import { ReactElement } from 'react';
 import * as React from 'react';
-import { SnackbarProvider } from './SnackbarProvider';
 
 export default {
   title: 'Components/Snackbar',
-  decorators: [
-    (fn: () => ReactElement) => {
-      const Fn = () => <>{fn()}</>; // render fn with provider's context
-      return (
-        <SnackbarProvider>
-          <Fn />
-        </SnackbarProvider>
-      );
-    },
-  ],
 };
 
 export const Basic = () => {


### PR DESCRIPTION
The `story()` function was called directly, causing it to be rendered _not_ as a child of the app providers. Wrapped it un a custom component, so the function is evaluated as a child of the providers.

Fixing this removed the need to do it in `AddCurrentPath` decorator and in snackbar stories.