### PR TITLE
SecuredBreadcrumb & ProjectBreadcrumb

### DIFF
--- a/src/api/operations.generated.ts
+++ b/src/api/operations.generated.ts
@@ -39,6 +39,7 @@ export const GQLOperations = {
     PartnershipCard: 'PartnershipCard',
     PartnershipSummary: 'PartnershipSummary',
     PartnershipItem: 'PartnershipItem',
+    ProjectBreadcrumb: 'ProjectBreadcrumb',
     ProjectListItem: 'ProjectListItem',
     ProjectMember: 'ProjectMember',
     ProjectMemberItem: 'ProjectMemberItem',

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -4,20 +4,28 @@ import { isString } from 'lodash';
 import { FC } from 'react';
 import * as React from 'react';
 import { useMatch } from 'react-router-dom';
-import { Link } from '../Routing';
+import { Link, LinkProps } from '../Routing';
 
 export interface BreadcrumbProps {
   to: string | PathPieces;
+  LinkProps?: Partial<LinkProps>;
 }
 
-export const Breadcrumb: FC<BreadcrumbProps> = ({ to, children }) => {
-  const active = useMatch(isString(to) ? to : to.pathname!);
+export const Breadcrumb: FC<BreadcrumbProps> = ({
+  to,
+  children,
+  LinkProps,
+}) => {
+  const active =
+    useMatch(isString(to) ? to : to.pathname!) ||
+    // RR doesn't think current page is active. maybe a bug?
+    to === '.';
 
   if (active) {
     return <Typography variant="h4">{children}</Typography>;
   } else {
     return (
-      <Link variant="h4" to={to}>
+      <Link variant="h4" to={to} {...LinkProps}>
         {children}
       </Link>
     );

--- a/src/components/Breadcrumb/SecuredBreadcrumb.tsx
+++ b/src/components/Breadcrumb/SecuredBreadcrumb.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from '@material-ui/lab';
+import * as React from 'react';
+import { Except } from 'type-fest';
+import { Secured } from '../../api';
+import { Nullable } from '../../util';
+import { Redacted, RedactedProps } from '../Redacted';
+import { Breadcrumb, BreadcrumbProps } from './Breadcrumb';
+
+export interface SecuredBreadcrumbProps extends BreadcrumbProps {
+  data: Nullable<Except<Secured<string>, 'canEdit'>>;
+  loadingWidth?: string | number;
+  redacted: RedactedProps['info'];
+}
+
+export const SecuredBreadcrumb = ({
+  data,
+  redacted,
+  loadingWidth = 200,
+  ...rest
+}: SecuredBreadcrumbProps) => (
+  <Breadcrumb
+    {...rest}
+    LinkProps={{
+      underline: data?.canRead ? undefined : 'none',
+    }}
+  >
+    {data ? (
+      !data.canRead ? (
+        <Redacted info={redacted} width={loadingWidth} />
+      ) : (
+        data.value
+      )
+    ) : (
+      <Skeleton width={loadingWidth} />
+    )}
+  </Breadcrumb>
+);

--- a/src/components/Breadcrumb/index.ts
+++ b/src/components/Breadcrumb/index.ts
@@ -1,1 +1,2 @@
 export * from './Breadcrumb';
+export * from './SecuredBreadcrumb';

--- a/src/components/ProjectBreadcrumb/ProjectBreadcrumb.generated.ts
+++ b/src/components/ProjectBreadcrumb/ProjectBreadcrumb.generated.ts
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-duplicates, @typescript-eslint/no-empty-interface */
+import gql from 'graphql-tag';
+import * as Types from '../../api/schema.generated';
+
+export type ProjectBreadcrumb_InternshipProject_Fragment = {
+  __typename?: 'InternshipProject';
+} & Pick<Types.InternshipProject, 'id'> & {
+    name: { __typename?: 'SecuredString' } & Pick<
+      Types.SecuredString,
+      'canRead' | 'value'
+    >;
+  };
+
+export type ProjectBreadcrumb_TranslationProject_Fragment = {
+  __typename?: 'TranslationProject';
+} & Pick<Types.TranslationProject, 'id'> & {
+    name: { __typename?: 'SecuredString' } & Pick<
+      Types.SecuredString,
+      'canRead' | 'value'
+    >;
+  };
+
+export type ProjectBreadcrumbFragment =
+  | ProjectBreadcrumb_InternshipProject_Fragment
+  | ProjectBreadcrumb_TranslationProject_Fragment;
+
+export const ProjectBreadcrumbFragmentDoc = gql`
+  fragment ProjectBreadcrumb on Project {
+    id
+    name {
+      canRead
+      value
+    }
+  }
+`;

--- a/src/components/ProjectBreadcrumb/ProjectBreadcrumb.graphql
+++ b/src/components/ProjectBreadcrumb/ProjectBreadcrumb.graphql
@@ -1,0 +1,7 @@
+fragment ProjectBreadcrumb on Project {
+  id
+  name {
+    canRead
+    value
+  }
+}

--- a/src/components/ProjectBreadcrumb/ProjectBreadcrumb.tsx
+++ b/src/components/ProjectBreadcrumb/ProjectBreadcrumb.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { Except } from 'type-fest';
+import { Nullable } from '../../util';
+import { SecuredBreadcrumb, SecuredBreadcrumbProps } from '../Breadcrumb';
+import { ProjectBreadcrumbFragment } from './ProjectBreadcrumb.generated';
+
+export interface ProjectBreadcrumbProps
+  extends Except<Partial<SecuredBreadcrumbProps>, 'data'> {
+  data: Nullable<ProjectBreadcrumbFragment>;
+}
+
+export const ProjectBreadcrumb = ({
+  data,
+  ...rest
+}: ProjectBreadcrumbProps) => (
+  <SecuredBreadcrumb
+    to={data ? `/projects/${data.id}` : '..'} // assume subpage until data loads
+    data={data?.name}
+    redacted="You don't have permission to view this project's name"
+    loadingWidth={200}
+    {...rest}
+  />
+);

--- a/src/components/ProjectBreadcrumb/index.ts
+++ b/src/components/ProjectBreadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectBreadcrumb';

--- a/src/components/Redacted/Redacted.tsx
+++ b/src/components/Redacted/Redacted.tsx
@@ -5,7 +5,7 @@ import { FC } from 'react';
 import * as React from 'react';
 import { Except } from 'type-fest';
 
-interface RedactedProps {
+export interface RedactedProps {
   info: TooltipProps['title'];
   width?: SkeletonProps['width'];
   TooltipProps?: Except<TooltipProps, 'title'>;

--- a/src/scenes/Partnerships/List/PartnershipList.generated.ts
+++ b/src/scenes/Partnerships/List/PartnershipList.generated.ts
@@ -5,6 +5,11 @@ import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
 import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
 import { PartnershipCardFragmentDoc } from '../../../components/PartnershipCard/PartnershipCard.generated';
+import {
+  ProjectBreadcrumb_InternshipProject_Fragment,
+  ProjectBreadcrumb_TranslationProject_Fragment,
+} from '../../../components/ProjectBreadcrumb/ProjectBreadcrumb.generated';
+import { ProjectBreadcrumbFragmentDoc } from '../../../components/ProjectBreadcrumb/ProjectBreadcrumb.generated';
 import { EditPartnershipFragment } from '../Edit/EditPartnership.generated';
 import { EditPartnershipFragmentDoc } from '../Edit/EditPartnership.generated';
 
@@ -14,51 +19,34 @@ export interface ProjectPartnershipsQueryVariables {
 
 export type ProjectPartnershipsQuery = { __typename?: 'Query' } & {
   project:
-    | ({ __typename?: 'InternshipProject' } & Pick<
-        Types.InternshipProject,
-        'id'
-      > & {
-          name: { __typename?: 'SecuredString' } & Pick<
-            Types.SecuredString,
-            'value'
-          >;
-          partnerships: { __typename?: 'SecuredPartnershipList' } & Pick<
-            Types.SecuredPartnershipList,
-            'canCreate' | 'total'
-          > & {
-              items: Array<
-                { __typename?: 'Partnership' } & PartnershipCardFragment &
-                  EditPartnershipFragment
-              >;
-            };
-        })
-    | ({ __typename?: 'TranslationProject' } & Pick<
-        Types.TranslationProject,
-        'id'
-      > & {
-          name: { __typename?: 'SecuredString' } & Pick<
-            Types.SecuredString,
-            'value'
-          >;
-          partnerships: { __typename?: 'SecuredPartnershipList' } & Pick<
-            Types.SecuredPartnershipList,
-            'canCreate' | 'total'
-          > & {
-              items: Array<
-                { __typename?: 'Partnership' } & PartnershipCardFragment &
-                  EditPartnershipFragment
-              >;
-            };
-        });
+    | ({ __typename?: 'InternshipProject' } & {
+        partnerships: { __typename?: 'SecuredPartnershipList' } & Pick<
+          Types.SecuredPartnershipList,
+          'canCreate' | 'total'
+        > & {
+            items: Array<
+              { __typename?: 'Partnership' } & PartnershipCardFragment &
+                EditPartnershipFragment
+            >;
+          };
+      } & ProjectBreadcrumb_InternshipProject_Fragment)
+    | ({ __typename?: 'TranslationProject' } & {
+        partnerships: { __typename?: 'SecuredPartnershipList' } & Pick<
+          Types.SecuredPartnershipList,
+          'canCreate' | 'total'
+        > & {
+            items: Array<
+              { __typename?: 'Partnership' } & PartnershipCardFragment &
+                EditPartnershipFragment
+            >;
+          };
+      } & ProjectBreadcrumb_TranslationProject_Fragment);
 };
 
 export const ProjectPartnershipsDocument = gql`
   query ProjectPartnerships($input: ID!) {
     project(id: $input) {
-      id
-      name {
-        value
-      }
+      ...ProjectBreadcrumb
       partnerships {
         canCreate
         total
@@ -69,6 +57,7 @@ export const ProjectPartnershipsDocument = gql`
       }
     }
   }
+  ${ProjectBreadcrumbFragmentDoc}
   ${PartnershipCardFragmentDoc}
   ${EditPartnershipFragmentDoc}
 `;

--- a/src/scenes/Partnerships/List/PartnershipList.graphql
+++ b/src/scenes/Partnerships/List/PartnershipList.graphql
@@ -1,9 +1,6 @@
 query ProjectPartnerships($input: ID!) {
   project(id: $input) {
-    id
-    name {
-      value
-    }
+    ...ProjectBreadcrumb
     partnerships {
       canCreate
       total

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import { Skeleton } from '@material-ui/lab';
 import React, { FC } from 'react';
 import { useParams } from 'react-router-dom';
 import { Merge } from 'type-fest';
@@ -14,6 +13,7 @@ import { useDialog } from '../../../components/Dialog';
 import { Fab } from '../../../components/Fab';
 import { PartnershipCard } from '../../../components/PartnershipCard';
 import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
+import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { listOrPlaceholders } from '../../../util';
 import { EditPartnership } from '../Edit';
 import { EditPartnershipFragment } from '../Edit/EditPartnership.generated';
@@ -55,9 +55,7 @@ export const PartnershipList: FC = () => {
   return (
     <div className={classes.root}>
       <Breadcrumbs>
-        <Breadcrumb to={`/projects/${projectId}`}>
-          {project?.name?.value ?? <Skeleton width={200} />}
-        </Breadcrumb>
+        <ProjectBreadcrumb data={project} />
         <Breadcrumb to={`/projects/${projectId}/partnerships`}>
           Partnerships
         </Breadcrumb>


### PR DESCRIPTION
## `SecuredBreadcrumb`

Handles loading state and redacted state.
```tsx
  <SecuredBreadcrumb
    to={`/projects/${id}`}
    data={data?.name}
    redacted="You don't have permission to view this"
    loadingWidth={200}
  />
```

## `ProjectBreadcrumb`

Wraps `SecuredBreadcrumb` since project is a common breadcrumb.

```graphql
project(id: $input) {
  ...ProjectBreadcrumb
}
```
```tsx
<ProjectBreadcrumb data={data?.project} />
```