### PR TITLE
FE 320 project overview last modified

### DIFF
--- a/src/scenes/Projects/Overview/ProjectOverview.generated.ts
+++ b/src/scenes/Projects/Overview/ProjectOverview.generated.ts
@@ -24,7 +24,7 @@ export type ProjectOverviewQuery = { __typename?: 'Query' } & {
   project:
     | ({ __typename?: 'TranslationProject' } & Pick<
         Types.TranslationProject,
-        'id' | 'status'
+        'id' | 'status' | 'modifiedAt'
       > & {
           name: { __typename?: 'SecuredString' } & Pick<
             Types.SecuredString,
@@ -76,7 +76,7 @@ export type ProjectOverviewQuery = { __typename?: 'Query' } & {
         })
     | ({ __typename?: 'InternshipProject' } & Pick<
         Types.InternshipProject,
-        'id' | 'status'
+        'id' | 'status' | 'modifiedAt'
       > & {
           name: { __typename?: 'SecuredString' } & Pick<
             Types.SecuredString,
@@ -155,6 +155,7 @@ export const ProjectOverviewDocument = gql`
         value
       }
       status
+      modifiedAt
       budget {
         canRead
         value {

--- a/src/scenes/Projects/Overview/ProjectOverview.graphql
+++ b/src/scenes/Projects/Overview/ProjectOverview.graphql
@@ -24,6 +24,7 @@ query ProjectOverview($input: ID!) {
       value
     }
     status
+    modifiedAt
     budget {
       canRead
       value {

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -11,7 +11,10 @@ import { CardGroup } from '../../../components/CardGroup';
 import { DataButton } from '../../../components/DataButton';
 import { Fab } from '../../../components/Fab';
 import { FilesOverviewCard } from '../../../components/FilesOverviewCard';
-import { useDateFormatter } from '../../../components/Formatters';
+import {
+  useDateFormatter,
+  useDateTimeFormatter,
+} from '../../../components/Formatters';
 import { InternshipEngagementListItemCard } from '../../../components/InternshipEngagementListItemCard';
 import { LanguageEngagementListItemCard } from '../../../components/LanguageEngagementListItemCard';
 import { PartnershipSummary } from '../../../components/PartnershipSummary';
@@ -41,12 +44,20 @@ const useStyles = makeStyles(({ spacing, breakpoints, palette }) => ({
   infoColor: {
     color: palette.info.main,
   },
+  subheader: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > *': {
+      marginRight: spacing(2),
+    },
+  },
 }));
 
 export const ProjectOverview: FC = () => {
   const classes = useStyles();
   const { projectId } = useParams();
   const formatDate = useDateFormatter();
+  const formatDateTime = useDateTimeFormatter();
 
   const { data, error } = useProjectOverviewQuery({
     variables: {
@@ -85,9 +96,17 @@ export const ProjectOverview: FC = () => {
             )}
           </Typography>
 
-          <Typography variant="h4">
-            {data ? 'Project Overview' : <Skeleton width="25%" />}
-          </Typography>
+          <div className={classes.subheader}>
+            <Typography variant="h4">
+              {data ? 'Project Overview' : <Skeleton width={200} />}
+            </Typography>
+
+            {data && (
+              <Typography color="textSecondary">
+                Updated {formatDateTime(data.project.modifiedAt)}
+              </Typography>
+            )}
+          </div>
 
           <Grid container spacing={1} alignItems="center">
             <Grid item>

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -102,7 +102,7 @@ export const ProjectOverview: FC = () => {
             </Typography>
 
             {data && (
-              <Typography color="textSecondary">
+              <Typography variant="body2" color="textSecondary">
                 Updated {formatDateTime(data.project.modifiedAt)}
               </Typography>
             )}


### PR DESCRIPTION
Showing the last modified at date under the header

**Tech notes**
Didn't include a skeleton for the updated because the the text "Project Overview" already had a skeleton loader

**Testing**
Go to the project overview page and should look like the screenshot
<img width="995" alt="Screen Shot 2020-07-08 at 9 58 44 AM" src="https://user-images.githubusercontent.com/43487134/86948194-a70d0d80-c101-11ea-8e20-116c3e3746e4.png">


