### PR TITLE
FE 323 unique member key

### DIFF
--- a/src/components/MemberListSummary/MemberListSummary.stories.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.stories.tsx
@@ -21,19 +21,20 @@ export const randomPersonPic = (name: string, gender: 'female' | 'male') => {
   }/${id}.jpg`;
 };
 
-const people: Array<{ name: string; gender: 'female' | 'male' }> = [
-  { name: 'Jim', gender: 'male' },
-  { name: 'Sarah', gender: 'female' },
-  { name: 'Julius', gender: 'male' },
-  { name: 'Rachel', gender: 'female' },
-  { name: 'Rob', gender: 'male' },
-  { name: 'Katie', gender: 'female' },
+const people: Array<{ name: string; gender: 'female' | 'male'; id: string }> = [
+  { name: 'Jim', gender: 'male', id: '1' },
+  { name: 'Sarah', gender: 'female', id: '2' },
+  { name: 'Julius', gender: 'male', id: '3' },
+  { name: 'Rachel', gender: 'female', id: '4' },
+  { name: 'Rob', gender: 'male', id: '5' },
+  { name: 'Katie', gender: 'female', id: '6' },
 ];
 export const members = people.map(
-  ({ name, gender }): MemberSummaryItem => ({
+  ({ name, gender, id }): MemberSummaryItem => ({
     label: name,
     avatarLetters: name[0],
     picture: randomPersonPic(name, gender),
+    id,
   })
 );
 

--- a/src/components/MemberListSummary/MemberListSummary.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.tsx
@@ -37,6 +37,7 @@ export interface MemberSummaryItem {
   // will display these letters if picture url isn't given
   avatarLetters?: string;
   label: string;
+  id: string;
 }
 
 export interface MemberListSummaryProps extends Pick<HugeIconProps, 'icon'> {
@@ -78,7 +79,7 @@ export const MemberListSummary: FC<MemberListSummaryProps> = ({
           <AvatarGroup max={max} className={classes.avatarGroup}>
             {listOrPlaceholders(members, max).map((member, i) => (
               <Avatar
-                key={member?.label || i}
+                key={member?.id || i}
                 loading={!member}
                 alt={member?.label}
                 src={member?.picture}

--- a/src/components/PartnershipSummary/PartnershipSummary.tsx
+++ b/src/components/PartnershipSummary/PartnershipSummary.tsx
@@ -21,6 +21,7 @@ export const PartnershipSummary: FC<PartnershipSummaryProps> = ({
 }) => {
   const members = partnerships?.items.map(
     (item): MemberSummaryItem => ({
+      id: item.id,
       label: item.organization.name.value ?? '',
       avatarLetters: item.organization.avatarLetters ?? '',
     })

--- a/src/components/ProjectMembersSummary/ProjectMemberItem.generated.ts
+++ b/src/components/ProjectMembersSummary/ProjectMemberItem.generated.ts
@@ -3,19 +3,24 @@ import gql from 'graphql-tag';
 import * as Types from '../../api/schema.generated';
 
 export type ProjectMemberItemFragment = { __typename?: 'ProjectMember' } & {
-  user: { __typename?: 'SecuredUser' } & {
-    value?: Types.Maybe<
-      { __typename?: 'User' } & Pick<
-        Types.User,
-        'id' | 'avatarLetters' | 'firstName'
-      >
-    >;
-  };
+  user: { __typename?: 'SecuredUser' } & Pick<
+    Types.SecuredUser,
+    'canRead' | 'canEdit'
+  > & {
+      value?: Types.Maybe<
+        { __typename?: 'User' } & Pick<
+          Types.User,
+          'id' | 'avatarLetters' | 'firstName'
+        >
+      >;
+    };
 };
 
 export const ProjectMemberItemFragmentDoc = gql`
   fragment ProjectMemberItem on ProjectMember {
     user {
+      canRead
+      canEdit
       value {
         id
         avatarLetters

--- a/src/components/ProjectMembersSummary/ProjectMemberItem.graphql
+++ b/src/components/ProjectMembersSummary/ProjectMemberItem.graphql
@@ -1,5 +1,7 @@
 fragment ProjectMemberItem on ProjectMember {
   user {
+    canRead
+    canEdit
     value {
       id
       avatarLetters

--- a/src/components/ProjectMembersSummary/ProjectMembersSummary.stories.tsx
+++ b/src/components/ProjectMembersSummary/ProjectMembersSummary.stories.tsx
@@ -19,6 +19,8 @@ const generateUser = (
       firstName,
       avatarLetters,
     },
+    canRead: true,
+    canEdit: true,
   },
 });
 

--- a/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
+++ b/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
@@ -11,13 +11,15 @@ export interface ProjectMembersSummaryProps {
 export const ProjectMembersSummary: FC<ProjectMembersSummaryProps> = ({
   members,
 }) => {
-  const summarizedMembers = members?.items.map(
-    ({ user }): MemberSummaryItem => ({
-      avatarLetters: user?.value?.avatarLetters ?? undefined,
-      label: user?.value?.firstName ?? '',
-      id: user?.value?.id || '',
-    })
-  );
+  const summarizedMembers = members?.items
+    .filter(({ user }) => user.canRead)
+    .map(
+      ({ user }): MemberSummaryItem => ({
+        avatarLetters: user?.value?.avatarLetters ?? undefined,
+        label: user?.value?.firstName ?? '',
+        id: user?.value?.id || '',
+      })
+    );
 
   return (
     <MemberListSummary

--- a/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
+++ b/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
@@ -12,12 +12,13 @@ export const ProjectMembersSummary: FC<ProjectMembersSummaryProps> = ({
   members,
 }) => {
   const summarizedMembers = members?.items
-    .filter(({ user }) => user.canRead)
+    .filter(({ user }) => user.canRead && user.value)
+    .map(({ user }) => user.value!)
     .map(
-      ({ user }): MemberSummaryItem => ({
-        avatarLetters: user?.value?.avatarLetters ?? undefined,
-        label: user?.value?.firstName ?? '',
-        id: user?.value?.id || '',
+      (user): MemberSummaryItem => ({
+        avatarLetters: user.avatarLetters ?? undefined,
+        label: user.firstName ?? '',
+        id: user.id,
       })
     );
 

--- a/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
+++ b/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
@@ -15,6 +15,7 @@ export const ProjectMembersSummary: FC<ProjectMembersSummaryProps> = ({
     ({ user }): MemberSummaryItem => ({
       avatarLetters: user?.value?.avatarLetters ?? undefined,
       label: user?.value?.firstName ?? '',
+      id: user?.value?.id || '',
     })
   );
 


### PR DESCRIPTION
Fixed unique key react bug.  The on the project overview page, the project partnerships were using the organization name as the unique mapping key.

Testing:
Create two partnerships with the same projectId and organizationID (can be done in playground).  Then go to that project overview page on the browser, you should see the two partnerships with the same org name.  In the devtools console you should **not** see the React same key warning.