### PR TITLE
Feature: FE 319 show project Id and project department ID

### DIFF
--- a/src/scenes/Projects/Overview/ProjectOverview.generated.ts
+++ b/src/scenes/Projects/Overview/ProjectOverview.generated.ts
@@ -26,6 +26,10 @@ export type ProjectOverviewQuery = { __typename?: 'Query' } & {
         Types.TranslationProject,
         'id' | 'status' | 'modifiedAt'
       > & {
+          deptId: { __typename?: 'SecuredString' } & Pick<
+            Types.SecuredString,
+            'canRead' | 'canEdit' | 'value'
+          >;
           name: { __typename?: 'SecuredString' } & Pick<
             Types.SecuredString,
             'canRead' | 'canEdit' | 'value'
@@ -78,6 +82,10 @@ export type ProjectOverviewQuery = { __typename?: 'Query' } & {
         Types.InternshipProject,
         'id' | 'status' | 'modifiedAt'
       > & {
+          deptId: { __typename?: 'SecuredString' } & Pick<
+            Types.SecuredString,
+            'canRead' | 'canEdit' | 'value'
+          >;
           name: { __typename?: 'SecuredString' } & Pick<
             Types.SecuredString,
             'canRead' | 'canEdit' | 'value'
@@ -132,6 +140,11 @@ export const ProjectOverviewDocument = gql`
   query ProjectOverview($input: ID!) {
     project(id: $input) {
       id
+      deptId {
+        canRead
+        canEdit
+        value
+      }
       name {
         canRead
         canEdit

--- a/src/scenes/Projects/Overview/ProjectOverview.graphql
+++ b/src/scenes/Projects/Overview/ProjectOverview.graphql
@@ -1,6 +1,11 @@
 query ProjectOverview($input: ID!) {
   project(id: $input) {
     id
+    deptId {
+      canRead
+      canEdit
+      value
+    }
     name {
       canRead
       canEdit

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -9,6 +9,7 @@ import { displayLocation } from '../../../api/location-helper';
 import { BudgetOverviewCard } from '../../../components/BudgetOverviewCard';
 import { CardGroup } from '../../../components/CardGroup';
 import { DataButton } from '../../../components/DataButton';
+import { DisplaySimpleProperty } from '../../../components/DisplaySimpleProperty';
 import { Fab } from '../../../components/Fab';
 import { FilesOverviewCard } from '../../../components/FilesOverviewCard';
 import {
@@ -108,6 +109,29 @@ export const ProjectOverview: FC = () => {
             )}
           </div>
 
+          <Grid container spacing={1}>
+            <Grid item>
+              <DisplaySimpleProperty
+                loading={!data}
+                label="Project ID"
+                value={data?.project.id}
+                loadingWidth={100}
+                LabelProps={{ color: 'textSecondary' }}
+                ValueProps={{ color: 'textPrimary' }}
+              />
+            </Grid>
+            <Grid item>
+              <DisplaySimpleProperty
+                loading={!data}
+                label="Department ID"
+                value={data?.project.deptId.value}
+                loadingWidth={100}
+                LabelProps={{ color: 'textSecondary' }}
+                ValueProps={{ color: 'textPrimary' }}
+              />
+            </Grid>
+          </Grid>
+
           <Grid container spacing={1} alignItems="center">
             <Grid item>
               <DataButton
@@ -126,21 +150,6 @@ export const ProjectOverview: FC = () => {
                 redacted="You do not have permission to view start/end dates"
                 children={formatDate.range}
                 empty="Start - End"
-              />
-            </Grid>
-            <Grid item>
-              <DataButton
-                loading={!data}
-                children={`Project Id: ${data?.project.id}`}
-              />
-            </Grid>
-            <Grid item>
-              <DataButton
-                loading={!data}
-                secured={data?.project.deptId}
-                redacted="You do not have permission to view department Id"
-                children={`Department Id: ${data?.project.deptId.value}`}
-                empty="Department Id Not Available"
               />
             </Grid>
             <Grid item>

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -129,6 +129,21 @@ export const ProjectOverview: FC = () => {
               />
             </Grid>
             <Grid item>
+              <DataButton
+                loading={!data}
+                children={`Project Id: ${data?.project.id}`}
+              />
+            </Grid>
+            <Grid item>
+              <DataButton
+                loading={!data}
+                secured={data?.project.deptId}
+                redacted="You do not have permission to view department Id"
+                children={`Department Id: ${data?.project.deptId.value}`}
+                empty="Department Id Not Available"
+              />
+            </Grid>
+            <Grid item>
               <DataButton loading={!data}>
                 {displayStatus(data?.project.status)}
               </DataButton>


### PR DESCRIPTION
On project overview page, show project Id and dept id on a data button

Testing:
<img width="932" alt="Screen Shot 2020-07-08 at 11 53 30 AM" src="https://user-images.githubusercontent.com/43487134/86958862-a8decd00-c111-11ea-8669-c4fc1ebbf366.png">
