### PR TITLE
Bugfix: FE 334 edit user crash

### DIFF
--- a/src/scenes/Users/Detail/UserDetail.generated.ts
+++ b/src/scenes/Users/Detail/UserDetail.generated.ts
@@ -3,8 +3,11 @@ import * as ApolloReactCommon from '@apollo/client';
 import * as ApolloReactHooks from '@apollo/client';
 import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
-import { UserFormFragment } from '../UserForm/UserForm.generated';
-import { UserFormFragmentDoc } from '../UserForm/UserForm.generated';
+import { SsFragment, UserFormFragment } from '../UserForm/UserForm.generated';
+import {
+  SsFragmentDoc,
+  UserFormFragmentDoc,
+} from '../UserForm/UserForm.generated';
 
 export interface UserQueryVariables {
   userId: Types.Scalars['ID'];
@@ -18,47 +21,53 @@ export type UserDetailsFragment = { __typename?: 'User' } & Pick<
   Types.User,
   'id' | 'fullName' | 'createdAt'
 > & {
-    email: { __typename?: 'SecuredString' } & Pick<
-      Types.SecuredString,
-      'value'
-    >;
-    bio: { __typename?: 'SecuredString' } & Pick<
-      Types.SecuredString,
-      'value' | 'canEdit'
-    >;
-    phone: { __typename?: 'SecuredString' } & Pick<
-      Types.SecuredString,
-      'value' | 'canEdit'
-    >;
-    timezone: { __typename?: 'SecuredTimeZone' } & {
-      value?: Types.Maybe<
-        { __typename?: 'TimeZone' } & Pick<Types.TimeZone, 'name'>
-      >;
-    };
+    email: { __typename?: 'SecuredString' } & SsFragment;
+    bio: { __typename?: 'SecuredString' } & SsFragment;
+    phone: { __typename?: 'SecuredString' } & SsFragment;
+    timezone: { __typename?: 'SecuredTimeZone' } & Pick<
+      Types.SecuredTimeZone,
+      'canRead' | 'canEdit'
+    > & {
+        value?: Types.Maybe<
+          { __typename?: 'TimeZone' } & Pick<Types.TimeZone, 'name'> & {
+              countries: Array<
+                { __typename?: 'IanaCountry' } & Pick<
+                  Types.IanaCountry,
+                  'code' | 'name'
+                >
+              >;
+            }
+        >;
+      };
   };
 
 export const UserDetailsFragmentDoc = gql`
   fragment userDetails on User {
     id
     email {
-      value
+      ...ss
     }
     fullName
     bio {
-      value
-      canEdit
+      ...ss
     }
     phone {
-      value
-      canEdit
+      ...ss
     }
     timezone {
       value {
         name
+        countries {
+          code
+          name
+        }
       }
+      canRead
+      canEdit
     }
     createdAt
   }
+  ${SsFragmentDoc}
 `;
 export const UserDocument = gql`
   query User($userId: ID!) {

--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -8,21 +8,25 @@ query User($userId: ID!) {
 fragment userDetails on User {
   id
   email {
-    value
+    ...ss
   }
   fullName
   bio {
-    value
-    canEdit
+    ...ss
   }
   phone {
-    value
-    canEdit
+    ...ss
   }
   timezone {
     value {
       name
+      countries {
+        code
+        name
+      }
     }
+    canRead
+    canEdit
   }
   createdAt
 }

--- a/src/scenes/Users/Edit/EditUser.generated.ts
+++ b/src/scenes/Users/Edit/EditUser.generated.ts
@@ -5,6 +5,8 @@ import gql from 'graphql-tag';
 import * as Types from '../../../api/schema.generated';
 import { UserDetailsFragment } from '../Detail/UserDetail.generated';
 import { UserDetailsFragmentDoc } from '../Detail/UserDetail.generated';
+import { UserFormFragment } from '../UserForm/UserForm.generated';
+import { UserFormFragmentDoc } from '../UserForm/UserForm.generated';
 
 export interface UpdateUserMutationVariables {
   input: Types.UpdateUserInput;
@@ -12,7 +14,7 @@ export interface UpdateUserMutationVariables {
 
 export type UpdateUserMutation = { __typename?: 'Mutation' } & {
   updateUser: { __typename?: 'UpdateUserOutput' } & {
-    user: { __typename?: 'User' } & UserDetailsFragment;
+    user: { __typename?: 'User' } & UserDetailsFragment & UserFormFragment;
   };
 };
 
@@ -21,10 +23,12 @@ export const UpdateUserDocument = gql`
     updateUser(input: $input) {
       user {
         ...userDetails
+        ...UserForm
       }
     }
   }
   ${UserDetailsFragmentDoc}
+  ${UserFormFragmentDoc}
 `;
 export type UpdateUserMutationFn = ApolloReactCommon.MutationFunction<
   UpdateUserMutation,

--- a/src/scenes/Users/Edit/EditUser.graphql
+++ b/src/scenes/Users/Edit/EditUser.graphql
@@ -2,6 +2,7 @@ mutation UpdateUser($input: UpdateUserInput!) {
   updateUser(input: $input) {
     user {
       ...userDetails
+      ...UserForm
     }
   }
 }

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Except } from 'type-fest';
-import { UpdateUserInput } from '../../../api';
+import { Maybe, UpdateUserInput } from '../../../api';
 import { UserForm, UserFormProps } from '../UserForm';
 import { useUpdateUserMutation } from './EditUser.generated';
 
@@ -14,7 +14,7 @@ export const EditUser = (props: EditUserProps) => {
   const user = props.user;
 
   return (
-    <UserForm<UpdateUserInput>
+    <UserForm<UpdateUserInput & { user: { email?: Maybe<string> } }>
       title="Edit Person"
       {...props}
       prefix="user"
@@ -30,13 +30,18 @@ export const EditUser = (props: EditUserProps) => {
                 phone: user.phone.value,
                 timezone: user.timezone.value?.name,
                 bio: user.bio.value,
+                email: user.email?.value,
               },
             }
           : undefined
       }
-      onSubmit={async (input) => {
+      onSubmit={async ({ user: { email, ...user } }) => {
         await updateUser({
-          variables: { input },
+          variables: {
+            input: {
+              user,
+            },
+          },
         });
       }}
     />

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -34,8 +34,8 @@ export const EditUser = (props: EditUserProps) => {
             }
           : undefined
       }
-      onSubmit={(input) => {
-        updateUser({
+      onSubmit={async (input) => {
+        await updateUser({
           variables: { input },
         });
       }}


### PR DESCRIPTION
App was crashing because the UserForm didn't wrap onSubmit in an async await, so the function resolved immediately and the error was never caught by the try catch in the DialogForm (instead caught by CRA)

Hide the email field on UserForm during edit user.  Showing but disabling is more involved because on the EditUser component the email field is not recognized by typescript because it's reading the input type as `UpdateUserInput`.