### PR TITLE
[Bugfix][FE-349] Redirect after login

### DIFF
--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -14,12 +14,13 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
   const [session, sessionLoading, setUserSession] = useSession();
   const [success, setSuccess] = useState(false);
 
-  // Redirect to homepage if already logged in (and not from successful login)
+  // Redirect to homepage or returnTo url if already logged in (and not from successful login)
   useEffect(() => {
     if (!sessionLoading && session && !success) {
-      navigate('/', { replace: true });
+      const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
+      navigate(returnTo, { replace: true });
     }
-  }, [navigate, session, sessionLoading, success]);
+  }, [navigate, query, session, sessionLoading, success]);
 
   const submit: Props['onSubmit'] = async (input) => {
     try {


### PR DESCRIPTION
The login component was always redirecting to home if already logged in, so now reading the `returnTo`

**Testing**
open incognito, go to /users, after login /users should be open