### PR TITLE
[FE-371] Show Ethnologue code on language engagement card

### DIFF
--- a/src/components/DisplaySimpleProperty/DisplaySimpleProperty.tsx
+++ b/src/components/DisplaySimpleProperty/DisplaySimpleProperty.tsx
@@ -22,6 +22,8 @@ export const DisplaySimpleProperty = ({
   wrap,
   ...props
 }: DisplaySimplePropertyProps) => {
+  const shouldRenderElement = loading || (label && value);
+  if (!shouldRenderElement) return null;
   const property = (
     <Typography variant="body2" {...props}>
       {loading === true ? (

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItem.graphql
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItem.graphql
@@ -15,6 +15,13 @@ fragment LanguageEngagementListItem on LanguageEngagement {
       registryOfDialectsCode {
         value
       }
+      ethnologue {
+        code {
+          canRead
+          canEdit
+          value
+        }
+      }
       avatarLetters
     }
   }

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
@@ -24,6 +24,13 @@ export const LanguageEngagementListItemCard = () => (
         registryOfDialectsCode: {
           value: text('Registry Of Dialects Code', '01234'),
         },
+        ethnologue: {
+          code: {
+            canRead: true,
+            canEdit: true,
+            value: text('Ethnologue Code', 'abc'),
+          },
+        },
         population: { value: number('population', 10000) },
         avatarLetters: 'E',
         displayName: {},

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
@@ -81,6 +81,7 @@ export const LanguageEngagementListItemCard: FC<LanguageEngagementListItemCardPr
   const name = language?.name.value ?? language?.displayName?.value;
   const population = language?.population.value;
   const registryOfDialectsCode = language?.registryOfDialectsCode.value;
+  const ethnologueCode = language?.ethnologue.code.value;
   const endDate = getEndDate(props);
 
   return (
@@ -103,19 +104,21 @@ export const LanguageEngagementListItemCard: FC<LanguageEngagementListItemCardPr
             <Grid item>
               <Typography variant="h4">{name}</Typography>
             </Grid>
-            {registryOfDialectsCode ? (
-              <Grid item>
-                <Typography variant="body2" color="textSecondary">
-                  Registry Of Dialects Code: {registryOfDialectsCode}
-                </Typography>
-              </Grid>
-            ) : null}
-            <Grid item>
-              <DisplaySimpleProperty
-                label="Status"
-                value={displayEngagementStatus(props.status)}
-              />
-            </Grid>
+            <DisplaySimpleProperty
+              label="Registry Of Dialects Code"
+              value={registryOfDialectsCode}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+            <DisplaySimpleProperty
+              label="Ethnologue Code"
+              value={ethnologueCode}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+            <DisplaySimpleProperty
+              label="Status"
+              value={displayEngagementStatus(props.status)}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
             {props.products.total > 0 ? (
               <Grid item>
                 <Typography variant="body2" gutterBottom>
@@ -148,26 +151,28 @@ export const LanguageEngagementListItemCard: FC<LanguageEngagementListItemCardPr
               </Typography>
             </Grid>
           </Grid>
-          <div className={classes.rightContent}>
-            <DisplaySimpleProperty aria-hidden="true" />
-            {population ? (
-              <div>
-                <Typography variant="h1">
-                  {numberFormatter(population)}
-                </Typography>
-                <Typography variant="body2" color="primary">
-                  Population
-                </Typography>
-              </div>
-            ) : null}
-            {endDate ? (
-              <DisplaySimpleProperty
-                label={endDate.label}
-                value={dateFormatter(endDate.value)}
-                ValueProps={{ color: 'primary' }}
-              />
-            ) : null}
-          </div>
+          {population && endDate ? (
+            <div className={classes.rightContent}>
+              <DisplaySimpleProperty aria-hidden="true" />
+              {population ? (
+                <div>
+                  <Typography variant="h1">
+                    {numberFormatter(population)}
+                  </Typography>
+                  <Typography variant="body2" color="primary">
+                    Population
+                  </Typography>
+                </div>
+              ) : null}
+              {endDate ? (
+                <DisplaySimpleProperty
+                  label={endDate.label}
+                  value={dateFormatter(endDate.value)}
+                  ValueProps={{ color: 'primary' }}
+                />
+              ) : null}
+            </div>
+          ) : null}
         </CardContent>
       </CardActionAreaLink>
     </Card>


### PR DESCRIPTION
Shown same as Registry of Dialects Code if exists.  Ignoring the `canRead` property same as the other fields for now.

<img width="719" alt="Screen Shot 2020-08-12 at 3 39 56 PM" src="https://user-images.githubusercontent.com/43487134/90076072-b0b30380-dcb3-11ea-880d-ad4bc2b3141c.png">
