### PR TITLE
Bugfix: LanguageEngagementListItemCard show population or end date

### DIFF
--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
@@ -151,7 +151,7 @@ export const LanguageEngagementListItemCard: FC<LanguageEngagementListItemCardPr
               </Typography>
             </Grid>
           </Grid>
-          {population && endDate ? (
+          {population || endDate ? (
             <div className={classes.rightContent}>
               <DisplaySimpleProperty aria-hidden="true" />
               {population ? (


### PR DESCRIPTION
LanguageEngagementListItemCard should use || operator if either `population` or `endDate` available