### PR TITLE
[FE-373] Show department id on project list item card

### DIFF
--- a/src/components/ProjectListItemCard/ProjectListItemCard.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.tsx
@@ -104,15 +104,18 @@ export const ProjectListItemCard: FC<ProjectListItemCardProps> = ({
                 {!project ? <Skeleton variant="text" /> : project.name?.value}
               </Typography>
             </Grid>
-            <Grid item>
-              <Typography variant="body2" color="textSecondary">
-                {!project ? (
-                  <Skeleton variant="text" width="30%" />
-                ) : (
-                  project.deptId.value ?? project.id
-                )}
-              </Typography>
-            </Grid>
+            <DisplaySimpleProperty
+              loading={!project}
+              label="Project ID"
+              value={project?.id}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+            <DisplaySimpleProperty
+              loading={!project}
+              label="Department ID"
+              value={project?.deptId.value}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
             <Grid item>
               <Typography variant="body2" color="primary">
                 {!project ? (


### PR DESCRIPTION
Only Show if exists, otherwise show nothing
![Screen Shot 2020-08-13 at 11 30 44 AM](https://user-images.githubusercontent.com/43487134/90172888-79e2f900-dd58-11ea-9286-144ca93a1004.png)

There's an empty space if the location doesn't exist but seems like that was deliberate.
