### PR TITLE
Bugfix: fix styling on project detail engagement header section 

### DIFF
--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -275,22 +275,22 @@ export const ProjectOverview: FC = () => {
                 </Tooltip>
               )}
             </Grid>
-            {data?.project.engagements.items.map((engagement) =>
-              engagement.__typename === 'LanguageEngagement' ? (
-                <LanguageEngagementListItemCard
-                  key={engagement.id}
-                  projectId={projectId}
-                  {...engagement}
-                />
-              ) : (
-                <InternshipEngagementListItemCard
-                  key={engagement.id}
-                  projectId={projectId}
-                  {...engagement}
-                />
-              )
-            )}
           </Grid>
+          {data?.project.engagements.items.map((engagement) =>
+            engagement.__typename === 'LanguageEngagement' ? (
+              <LanguageEngagementListItemCard
+                key={engagement.id}
+                projectId={projectId}
+                {...engagement}
+              />
+            ) : (
+              <InternshipEngagementListItemCard
+                key={engagement.id}
+                projectId={projectId}
+                {...engagement}
+              />
+            )
+          )}
         </div>
       )}
     </main>


### PR DESCRIPTION
The engagement cards moved out of the header grid

Before:
![Screen Shot 2020-08-24 at 12 14 45 PM](https://user-images.githubusercontent.com/43487134/91086186-6a3e9c80-e603-11ea-8334-9a1444cec1ca.png)

After:
![Screen Shot 2020-08-24 at 12 13 06 PM](https://user-images.githubusercontent.com/43487134/91086168-627ef800-e603-11ea-87a4-5b2559dd9172.png)
