### PR TITLE
Edit Engagement Status

### DIFF
--- a/src/components/form/AutocompleteField.tsx
+++ b/src/components/form/AutocompleteField.tsx
@@ -29,6 +29,7 @@ export type AutocompleteFieldProps<
     name: string;
     getCompareBy?: (item: T) => any;
     ChipProps?: ChipProps;
+    options: readonly T[];
   } & Except<
     AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
     | 'value'
@@ -39,6 +40,7 @@ export type AutocompleteFieldProps<
     | 'loading'
     | 'filterSelectedOptions'
     | 'ChipProps'
+    | 'options'
   >;
 
 const emptyArray = [] as const;
@@ -109,7 +111,7 @@ export function AutocompleteField<
       disableClearable={required}
       disableCloseOnSelect={multiple}
       {...autocompleteProps}
-      options={options}
+      options={options as T[]}
       disabled={disabled}
       // FF also has multiple and defaultValue
       multiple={multiple}

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -2,7 +2,9 @@ import { pick, startCase } from 'lodash';
 import React, { ComponentType, FC } from 'react';
 import { Except, Merge } from 'type-fest';
 import {
+  displayEngagementStatus,
   displayInternPosition,
+  EngagementStatusList,
   InternshipEngagementPositionList,
   MethodologyToApproach,
   UpdateInternshipEngagement,
@@ -23,6 +25,7 @@ import {
   RadioOption,
   SubmitError,
 } from '../../../components/form';
+import { AutocompleteField } from '../../../components/form/AutocompleteField';
 import { CountryField, UserField } from '../../../components/form/Lookup';
 import { UserLookupItemFragment } from '../../../components/form/Lookup/User/UserLookup.generated';
 import { ExtractStrict, many, Many } from '../../../util';
@@ -49,6 +52,7 @@ export type EditableEngagementField = ExtractStrict<
   | 'mentorId'
   | 'firstScripture'
   | 'lukePartnership'
+  | 'status'
 >;
 
 interface EngagementFieldProps {
@@ -120,6 +124,17 @@ const fieldMapping: Record<
   lukePartnership: ({ props }) => (
     <CheckboxField {...props} label="Luke Partnership" />
   ),
+  status: ({ props }) => (
+    <AutocompleteField
+      label="Engagement Status"
+      required
+      {...props}
+      options={EngagementStatusList}
+      getOptionLabel={displayEngagementStatus}
+      variant="outlined"
+      autoComplete
+    />
+  ),
 };
 
 interface EngagementFormValues {
@@ -165,6 +180,7 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
     completeDate: engagement.completeDate.value,
     disbursementCompleteDate: engagement.disbursementCompleteDate.value,
     communicationsCompleteDate: engagement.communicationsCompleteDate.value,
+    status: engagement.status,
     ...(engagement.__typename === 'LanguageEngagement'
       ? {
           lukePartnership: engagement.lukePartnership.value,

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -149,7 +149,7 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
             />
           </Grid>
           <Grid item>
-            <DataButton>
+            <DataButton onClick={() => show('status')}>
               {displayEngagementStatus(engagement.status)}
             </DataButton>
           </Grid>

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -150,7 +150,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
             />
           </Grid>
           <Grid item>
-            <DataButton>
+            <DataButton onClick={() => show('status')}>
               {displayEngagementStatus(engagement.status)}
             </DataButton>
           </Grid>


### PR DESCRIPTION
Use the existing dialog to edit engagement status.

![Screen Shot 2020-08-24 at 6 06 25 PM](https://user-images.githubusercontent.com/43487134/91111130-8b6bb100-e634-11ea-9529-b11924a2e3fd.png)
