### PR TITLE
Add AutocompleteField / SelectField

### DIFF
--- a/src/components/form/AutocompleteField.stories.tsx
+++ b/src/components/form/AutocompleteField.stories.tsx
@@ -1,0 +1,69 @@
+import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+import { startCase } from 'lodash';
+import React from 'react';
+import { Form } from 'react-final-form';
+import { csv } from '../../util';
+import { AutocompleteField } from './AutocompleteField';
+import { FieldSpy } from './FieldSpy';
+import { SubmitButton } from './SubmitButton';
+
+export default {
+  title: 'Components/Forms/Fields/Autocomplete',
+};
+
+export const SelectSingle = () => {
+  const disabled = boolean('Disabled', false);
+  const initialValue = text('initialValue', '');
+
+  return (
+    <Form
+      onSubmit={action('submit')}
+      initialValues={{ color: initialValue || undefined }}
+    >
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <AutocompleteField
+            options={['red', 'blue', 'green']}
+            getOptionLabel={startCase}
+            name="color"
+            label={text('Label', 'Color')}
+            disabled={disabled}
+            required={boolean('Required', false)}
+            helperText={text('Helper Text', 'Choose carefully')}
+          />
+          <FieldSpy name="color" />
+          <SubmitButton />
+        </form>
+      )}
+    </Form>
+  );
+};
+
+export const SelectMultiple = () => {
+  const disabled = boolean('Disabled', false);
+  const initialValue = csv(text('initialValues', ''));
+
+  return (
+    <Form onSubmit={action('submit')} initialValues={{ color: initialValue }}>
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <AutocompleteField
+            multiple
+            variant="outlined"
+            ChipProps={{ variant: 'default' }}
+            options={['red', 'blue', 'green']}
+            getOptionLabel={startCase}
+            name="color"
+            label={text('Label', 'Color')}
+            disabled={disabled}
+            required={boolean('Required', false)}
+            helperText={text('Helper Text', 'Choose carefully')}
+          />
+          <FieldSpy name="color" />
+          <SubmitButton />
+        </form>
+      )}
+    </Form>
+  );
+};

--- a/src/components/form/AutocompleteField.tsx
+++ b/src/components/form/AutocompleteField.tsx
@@ -1,0 +1,135 @@
+import { Chip, ChipProps, TextField, TextFieldProps } from '@material-ui/core';
+import { Autocomplete, AutocompleteProps, Value } from '@material-ui/lab';
+import { identity } from 'lodash';
+import React from 'react';
+import { Except } from 'type-fest';
+import { useFieldName } from './FieldGroup';
+import { FieldConfig, useField } from './useField';
+import {
+  areListsEqual,
+  compareNullable,
+  getHelperText,
+  showError,
+  useFocusOnEnabled,
+} from './util';
+
+export type LookupFieldProps<
+  T,
+  Multiple extends boolean | undefined,
+  DisableClearable extends boolean | undefined,
+  FreeSolo extends boolean | undefined
+> = Except<
+  FieldConfig<Value<T, Multiple, DisableClearable, FreeSolo>>,
+  'multiple' | 'allowNull' | 'parse' | 'format'
+> &
+  Pick<
+    TextFieldProps,
+    'helperText' | 'label' | 'required' | 'autoFocus' | 'variant'
+  > & {
+    name: string;
+    getCompareBy?: (item: T) => any;
+    ChipProps?: ChipProps;
+  } & Except<
+    AutocompleteProps<T, Multiple, DisableClearable, FreeSolo>,
+    | 'value'
+    | 'onChange'
+    | 'defaultValue'
+    | 'renderInput'
+    | 'renderTags'
+    | 'loading'
+    | 'filterSelectedOptions'
+    | 'ChipProps'
+  >;
+
+const emptyArray = [] as const;
+
+/**
+ * This is useful as a select combo field for single or multiple values.
+ */
+export function AutocompleteField<
+  T,
+  Multiple extends boolean | undefined,
+  DisableClearable extends boolean | undefined,
+  FreeSolo extends boolean | undefined
+>({
+  name: nameProp,
+  multiple,
+  defaultValue,
+  disabled: disabledProp,
+  ChipProps,
+  autoFocus,
+  helperText,
+  label,
+  variant,
+  required,
+  getCompareBy = identity,
+  options,
+  ...props
+}: LookupFieldProps<T, Multiple, DisableClearable, FreeSolo>) {
+  type Val = Value<T, Multiple, DisableClearable, FreeSolo>;
+
+  const name = useFieldName(nameProp);
+  const { input: field, meta, rest: autocompleteProps } = useField<Val>(name, {
+    ...props,
+    required,
+    allowNull: !multiple,
+    defaultValue: (multiple ? emptyArray : null) as Val,
+    isEqual: compareNullable((a, b) =>
+      multiple
+        ? areListsEqual(a.map(getCompareBy), b.map(getCompareBy))
+        : getCompareBy(a) === getCompareBy(b)
+    ),
+    // Default to at least one item if required & multiple
+    validate:
+      !props.validate && required && multiple
+        ? (val) =>
+            !val || (Array.isArray(val) && val.length === 0)
+              ? 'Required'
+              : undefined
+        : undefined,
+  });
+  const disabled = disabledProp ?? meta.submitting;
+  const ref = useFocusOnEnabled(meta, disabled);
+  const getOptionLabel = props.getOptionLabel || identity;
+
+  return (
+    <Autocomplete<T, Multiple, typeof required, FreeSolo>
+      disableClearable={required}
+      disableCloseOnSelect={multiple}
+      {...autocompleteProps}
+      options={options}
+      disabled={disabled}
+      // FF also has multiple and defaultValue
+      multiple={multiple}
+      renderTags={(values: T[], getTagProps) =>
+        values.map((option: T, index: number) => (
+          <Chip
+            variant="outlined"
+            {...ChipProps}
+            label={getOptionLabel(option)}
+            {...getTagProps({ index })}
+          />
+        ))
+      }
+      value={field.value}
+      onBlur={field.onBlur}
+      onFocus={field.onFocus}
+      onChange={(_, value) => {
+        field.onChange(value);
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          helperText={getHelperText(meta, helperText)}
+          required={required}
+          inputRef={ref}
+          error={showError(meta)}
+          autoFocus={autoFocus}
+          variant={variant}
+        />
+      )}
+      getOptionSelected={(a, b) => getCompareBy(a) === getCompareBy(b)}
+    />
+  );
+}


### PR DESCRIPTION
This is intended to be used for enum-like values.

This differs from `LookupField` in that there's no "as user types" API integration.

This still could be used to do a one time lookup from the API for a complete list (i.e. timezones or countries)
