### PR TITLE
Create Project Team Members

### DIFF
--- a/src/components/form/Lookup/User/UserLookup.graphql
+++ b/src/components/form/Lookup/User/UserLookup.graphql
@@ -11,4 +11,8 @@ query UserLookup($query: String!) {
 fragment UserLookupItem on User {
   id
   fullName
+  roles {
+    canRead
+    value
+  }
 }

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagement.graphql
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagement.graphql
@@ -48,6 +48,10 @@ fragment InternshipEngagementDetail on InternshipEngagement {
   }
   mentor {
     ...MentorCard
+    # Needed for edit. Should this be moved?
+    value {
+      ...UserLookupItem
+    }
   }
   ceremony {
     ...CeremonyCard

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.graphql
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.graphql
@@ -1,0 +1,7 @@
+mutation CreateProjectMember($input: CreateProjectMemberInput!) {
+  createProjectMember(input: $input) {
+    projectMember {
+      id
+    }
+  }
+}

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -1,3 +1,5 @@
+import { Decorator } from 'final-form';
+import onFieldChange from 'final-form-calculate';
 import React, { useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
 import {
@@ -33,6 +35,15 @@ type CreateProjectMemberProps = Except<
   projectId: string;
 };
 
+const decorators: Array<Decorator<FormValues>> = [
+  ...DialogForm.defaultDecorators,
+  onFieldChange({
+    field: 'projectMember.userId',
+    isEqual: UserField.isEqual,
+    updates: { 'projectMember.roles': () => [] },
+  }),
+];
+
 export const CreateProjectMember = ({
   projectId,
   ...props
@@ -60,6 +71,7 @@ export const CreateProjectMember = ({
       title="Add Team Member"
       {...props}
       initialValues={initialValues}
+      decorators={decorators}
       onSubmit={async ({ projectMember }) => {
         const data = projectMember as Required<typeof projectMember>;
         const input = {

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import { FormSpy } from 'react-final-form';
 import { Except, Merge } from 'type-fest';
 import {
   CreateProjectMember as CreateProjectMemberInput,
@@ -10,7 +9,7 @@ import {
   DialogForm,
   DialogFormProps,
 } from '../../../../components/Dialog/DialogForm';
-import { FieldGroup, SubmitError } from '../../../../components/form';
+import { SubmitError } from '../../../../components/form';
 import { AutocompleteField } from '../../../../components/form/AutocompleteField';
 import { UserField, UserLookupItem } from '../../../../components/form/Lookup';
 import { ProjectMembersDocument } from '../List/ProjectMembers.generated';
@@ -72,40 +71,39 @@ export const CreateProjectMember = ({
 
         await createProjectMember({ variables: { input } });
       }}
+      fieldsPrefix="projectMember"
     >
-      <SubmitError />
-      <FormSpy<FormValues> subscription={{ values: true }}>
-        {({ values }) => {
-          const user = values.projectMember.userId;
-          const canRead = user?.roles.canRead;
-          const userRoles = user?.roles.value;
+      {({ values }) => {
+        const user = values.projectMember.userId;
+        const canRead = user?.roles.canRead;
+        const userRoles = user?.roles.value;
 
-          return (
-            <FieldGroup prefix="projectMember">
-              <UserField name="userId" required variant="outlined" />
-              <AutocompleteField
-                disabled={!canRead || !userRoles}
-                multiple
-                options={RoleList}
-                getOptionLabel={displayRole}
-                name="roles"
-                label="Roles"
-                helperText={
-                  user
-                    ? canRead
-                      ? ''
-                      : `You cannot read this person's roles`
-                    : 'Select a person first'
-                }
-                getOptionDisabled={(option) =>
-                  !!userRoles && !userRoles.includes(option)
-                }
-                variant="outlined"
-              />
-            </FieldGroup>
-          );
-        }}
-      </FormSpy>
+        return (
+          <>
+            <SubmitError />
+            <UserField name="userId" required variant="outlined" />
+            <AutocompleteField
+              disabled={!canRead || !userRoles}
+              multiple
+              options={RoleList}
+              getOptionLabel={displayRole}
+              name="roles"
+              label="Roles"
+              helperText={
+                user
+                  ? canRead
+                    ? ''
+                    : `You cannot read this person's roles`
+                  : 'Select a person first'
+              }
+              getOptionDisabled={(option) =>
+                !!userRoles && !userRoles.includes(option)
+              }
+              variant="outlined"
+            />
+          </>
+        );
+      }}
     </DialogForm>
   );
 };

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -1,0 +1,138 @@
+import { Container, makeStyles } from '@material-ui/core';
+import React from 'react';
+import { FormSpy } from 'react-final-form';
+import { Except } from 'type-fest';
+import { displayRole, Role } from '../../../../api';
+import {
+  DialogForm,
+  DialogFormProps,
+} from '../../../../components/Dialog/DialogForm';
+import { FieldGroup, SubmitError } from '../../../../components/form';
+import { AutocompleteField } from '../../../../components/form/AutocompleteField';
+import { UserField, UserLookupItem } from '../../../../components/form/Lookup';
+import { Nullable } from '../../../../util';
+import { ProjectMembersDocument } from '../List/ProjectMembers.generated';
+import { useCreateProjectMemberMutation } from './CreateProjectMember.generated';
+
+interface DialogValues {
+  projectMember: {
+    userId: Nullable<UserLookupItem>;
+    projectId: string;
+    roles?: Role[];
+  };
+}
+
+type CreateProjectMemberProps = Except<
+  DialogFormProps<DialogValues>,
+  'onSubmit' | 'initialValues'
+> & {
+  projectId: string;
+};
+
+const Roles: Role[] = [
+  'BibleTranslationLiaison',
+  'Consultant',
+  'ConsultantManager',
+  'Controller',
+  'Development',
+  'ExecutiveDevelopmentRepresentative',
+  'ExecutiveLeadership',
+  'FieldOperationsDirector',
+  'FieldPartner',
+  'FinancialAnalyst',
+  'Intern',
+  'Liaison',
+  'LeadFinancialAnalyst',
+  'Mentor',
+  'OfficeOfThePresident',
+  'ProjectManager',
+  'RegionalCommunicationsCoordinator',
+  'RegionalDirector',
+  'SupportingProjectManager',
+  'Translator',
+  'Writer',
+];
+
+const useStyles = makeStyles({
+  container: {
+    width: 400,
+  },
+});
+
+export const CreateProjectMember = ({
+  projectId,
+  ...props
+}: CreateProjectMemberProps) => {
+  const classes = useStyles();
+  const [createProjectMember] = useCreateProjectMemberMutation({
+    refetchQueries: [
+      {
+        query: ProjectMembersDocument,
+        variables: { input: projectId },
+      },
+    ],
+  });
+
+  return (
+    <DialogForm<DialogValues>
+      title="Create Team Member"
+      closeLabel="Close"
+      submitLabel="Save"
+      onlyDirtySubmit
+      {...props}
+      initialValues={{
+        projectMember: {
+          roles: [],
+          projectId,
+          userId: null,
+        },
+      }}
+      onSubmit={async ({ projectMember: { userId, ...rest } }) => {
+        const input = {
+          projectMember: {
+            userId: userId!.id,
+            ...rest,
+          },
+        };
+
+        await createProjectMember({ variables: { input } });
+      }}
+    >
+      <Container className={classes.container}>
+        <SubmitError />
+        <FormSpy>
+          {({ values }) => {
+            const formValues = values as DialogValues;
+            const canRead = formValues.projectMember.userId?.roles.canRead;
+            const userRoles = formValues.projectMember.userId?.roles.value;
+
+            return (
+              <FieldGroup prefix="projectMember">
+                <UserField
+                  name="userId"
+                  label="Team member"
+                  required
+                  variant="outlined"
+                  fullWidth
+                />
+                <AutocompleteField
+                  fullWidth
+                  disabled={!canRead || !userRoles}
+                  multiple
+                  options={Roles}
+                  getOptionLabel={displayRole}
+                  name="roles"
+                  label="Roles"
+                  getOptionDisabled={(option) =>
+                    !!userRoles && !userRoles.includes(option)
+                  }
+                  variant="outlined"
+                />
+              </FieldGroup>
+            );
+          }}
+        </FormSpy>
+      </Container>
+    </DialogForm>
+  );
+};

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -1,8 +1,7 @@
-import { Container, makeStyles } from '@material-ui/core';
 import React from 'react';
 import { FormSpy } from 'react-final-form';
 import { Except } from 'type-fest';
-import { displayRole, Role } from '../../../../api';
+import { displayRole, Role, RoleList } from '../../../../api';
 import {
   DialogForm,
   DialogFormProps,
@@ -29,41 +28,10 @@ type CreateProjectMemberProps = Except<
   projectId: string;
 };
 
-const Roles: Role[] = [
-  'BibleTranslationLiaison',
-  'Consultant',
-  'ConsultantManager',
-  'Controller',
-  'Development',
-  'ExecutiveDevelopmentRepresentative',
-  'ExecutiveLeadership',
-  'FieldOperationsDirector',
-  'FieldPartner',
-  'FinancialAnalyst',
-  'Intern',
-  'Liaison',
-  'LeadFinancialAnalyst',
-  'Mentor',
-  'OfficeOfThePresident',
-  'ProjectManager',
-  'RegionalCommunicationsCoordinator',
-  'RegionalDirector',
-  'SupportingProjectManager',
-  'Translator',
-  'Writer',
-];
-
-const useStyles = makeStyles({
-  container: {
-    width: 400,
-  },
-});
-
 export const CreateProjectMember = ({
   projectId,
   ...props
 }: CreateProjectMemberProps) => {
-  const classes = useStyles();
   const [createProjectMember] = useCreateProjectMemberMutation({
     refetchQueries: [
       {
@@ -76,9 +44,6 @@ export const CreateProjectMember = ({
   return (
     <DialogForm<DialogValues>
       title="Create Team Member"
-      closeLabel="Close"
-      submitLabel="Save"
-      onlyDirtySubmit
       {...props}
       initialValues={{
         projectMember: {
@@ -98,41 +63,32 @@ export const CreateProjectMember = ({
         await createProjectMember({ variables: { input } });
       }}
     >
-      <Container className={classes.container}>
-        <SubmitError />
-        <FormSpy>
-          {({ values }) => {
-            const formValues = values as DialogValues;
-            const canRead = formValues.projectMember.userId?.roles.canRead;
-            const userRoles = formValues.projectMember.userId?.roles.value;
+      <SubmitError />
+      <FormSpy>
+        {({ values }) => {
+          const formValues = values as DialogValues;
+          const canRead = formValues.projectMember.userId?.roles.canRead;
+          const userRoles = formValues.projectMember.userId?.roles.value;
 
-            return (
-              <FieldGroup prefix="projectMember">
-                <UserField
-                  name="userId"
-                  label="Team member"
-                  required
-                  variant="outlined"
-                  fullWidth
-                />
-                <AutocompleteField
-                  fullWidth
-                  disabled={!canRead || !userRoles}
-                  multiple
-                  options={Roles}
-                  getOptionLabel={displayRole}
-                  name="roles"
-                  label="Roles"
-                  getOptionDisabled={(option) =>
-                    !!userRoles && !userRoles.includes(option)
-                  }
-                  variant="outlined"
-                />
-              </FieldGroup>
-            );
-          }}
-        </FormSpy>
-      </Container>
+          return (
+            <FieldGroup prefix="projectMember">
+              <UserField name="userId" required variant="outlined" />
+              <AutocompleteField
+                disabled={!canRead || !userRoles}
+                multiple
+                options={RoleList}
+                getOptionLabel={displayRole}
+                name="roles"
+                label="Roles"
+                getOptionDisabled={(option) =>
+                  !!userRoles && !userRoles.includes(option)
+                }
+                variant="outlined"
+              />
+            </FieldGroup>
+          );
+        }}
+      </FormSpy>
     </DialogForm>
   );
 };

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -58,7 +58,7 @@ export const CreateProjectMember = ({
 
   return (
     <DialogForm<FormValues>
-      title="Create Team Member"
+      title="Add Team Member"
       {...props}
       initialValues={initialValues}
       onSubmit={async ({ projectMember }) => {
@@ -90,6 +90,13 @@ export const CreateProjectMember = ({
                 getOptionLabel={displayRole}
                 name="roles"
                 label="Roles"
+                helperText={
+                  user
+                    ? canRead
+                      ? ''
+                      : `You cannot read this person's roles`
+                    : 'Select a person first'
+                }
                 getOptionDisabled={(option) =>
                   !!userRoles && !userRoles.includes(option)
                 }

--- a/src/scenes/Projects/Members/List/ProjectMembersList.tsx
+++ b/src/scenes/Projects/Members/List/ProjectMembersList.tsx
@@ -9,10 +9,12 @@ import { FC } from 'react';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { Breadcrumb } from '../../../../components/Breadcrumb';
+import { useDialog } from '../../../../components/Dialog';
 import { Fab } from '../../../../components/Fab';
 import { ProjectBreadcrumb } from '../../../../components/ProjectBreadcrumb';
 import { ProjectMemberCard } from '../../../../components/ProjectMemberCard';
 import { listOrPlaceholders } from '../../../../util';
+import { CreateProjectMember } from '../Create/CreateProjectMember';
 import { useProjectMembersQuery } from './ProjectMembers.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
@@ -44,6 +46,10 @@ export const ProjectMembersList: FC = () => {
   });
   const members = data?.project.team;
 
+  const [
+    createProjectMemberDialogState,
+    openCreateProjectMemberDialog,
+  ] = useDialog();
   return (
     <div className={classes.root}>
       <Breadcrumbs>
@@ -56,11 +62,20 @@ export const ProjectMembersList: FC = () => {
         </Typography>
         {(!members || members.canCreate) && (
           <Tooltip title="Add Team Member">
-            <Fab color="error" aria-label="Add Team Member" loading={!members}>
+            <Fab
+              color="error"
+              aria-label="Add Team Member"
+              loading={!members}
+              onClick={openCreateProjectMemberDialog}
+            >
               <Add />
             </Fab>
           </Tooltip>
         )}
+        <CreateProjectMember
+          {...createProjectMemberDialogState}
+          projectId={projectId}
+        />
       </div>
       {members?.canRead === false ? (
         <Typography>


### PR DESCRIPTION
Create Project Team Members

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/43487134/91328708-1dca9c80-e77c-11ea-8ad4-11e90e405c7a.gif)

There's still a bug where if there's already an existing team member, the api call errors, but the error doesn't show on the dialog.  I think it's because on submit the dialog resets the userField to initial values so the only error shown is the `required` error.
![create-member-bug](https://user-images.githubusercontent.com/43487134/91329033-874aab00-e77c-11ea-8a1c-ba608d7dc81b.gif)
