### PR TITLE
Refactor form error handling

### DIFF
--- a/src/api/form-error-handling.test.ts
+++ b/src/api/form-error-handling.test.ts
@@ -1,0 +1,130 @@
+import { ApolloError } from '@apollo/client';
+import { FORM_ERROR } from 'final-form';
+import { ErrorHandlers, handleFormError } from './form-error-handling';
+
+describe('handleFormError', () => {
+  let error: ApolloError;
+
+  beforeAll(() => {
+    error = createError({
+      message: 'Not found',
+      codes: ['VerySpecific', 'NotFound', 'SomethingElse', 'Input', 'Client'],
+    });
+  });
+
+  it('forwards to next handler when asked', async () => {
+    const result = await handleFormError(error, {
+      NotFound: (e, next) => next(e),
+      // Ignore error about key not existing - it's only for tests
+      ...{ SomethingElse: 'nexted' },
+    });
+    expect(result).toEqual({ [FORM_ERROR]: 'nexted' });
+  });
+
+  it('skips to first handled code', async () => {
+    const result = await handleFormError(error, {
+      NotFound: 'woot',
+    });
+    expect(result).toEqual({ [FORM_ERROR]: 'woot' });
+  });
+
+  it('input with field uses field error', async () => {
+    const inputError = createError({
+      message: 'You messed up the foo bar',
+      codes: ['Input'],
+      field: 'foo.bar',
+    });
+    const result = await handleFormError(inputError);
+    expect(result).toEqual({ foo: { bar: 'You messed up the foo bar' } });
+  });
+
+  it('input without field uses next', async () => {
+    const inputError = createError({
+      message: 'You messed up the foo bar',
+      codes: ['Input'],
+    });
+    const result = await handleFormError(inputError, {
+      // Default is next handled
+      Default: 'Failed to update X thing',
+    });
+    expect(result).toEqual({ [FORM_ERROR]: 'Failed to update X thing' });
+  });
+
+  it('server errors return failure without message', async () => {
+    const serverError = createError({
+      message: 'Internal Server Error',
+      codes: ['Server'],
+    });
+    const result = await handleFormError(serverError);
+    expect(result).toEqual({});
+  });
+
+  it('default handlers can be skipped with undefined', async () => {
+    const serverError = createError({
+      message: 'Internal Server Error',
+      codes: ['Server'],
+    });
+    const result = await handleFormError(serverError, {
+      Server: undefined,
+      Default: 'new default',
+    });
+    expect(result).toEqual({ [FORM_ERROR]: 'new default' });
+  });
+
+  it('default', async () => {
+    const result = await handleFormError(error, {
+      Default: 'new default',
+    });
+    expect(result).toEqual({ [FORM_ERROR]: 'new default' });
+  });
+
+  it('default default is error message', async () => {
+    const result = await handleFormError(error);
+    expect(result).toEqual({ [FORM_ERROR]: 'Not found' });
+  });
+});
+
+const _testHandlerTypes: ErrorHandlers = {
+  Validation: (e) => {
+    const _msg: string = e.message;
+    const _errors: Record<string, Record<string, string>> = e.errors;
+  },
+  Input: (e) => {
+    const _msg: string = e.message;
+    const _field: string | undefined = e.field;
+  },
+  Duplicate: (e) => {
+    const _msg: string = e.message;
+    const _field: string = e.field;
+  },
+};
+
+const createError = ({
+  message,
+  codes,
+  ...extensions
+}: {
+  message: string;
+  codes: string[];
+  [rest: string]: unknown;
+}) => {
+  return new ApolloError({
+    graphQLErrors: [
+      {
+        message,
+        extensions: {
+          ...extensions,
+          codes,
+        },
+        name: 'Error',
+        locations: undefined,
+        stack: undefined,
+        path: undefined,
+        originalError: undefined,
+        nodes: undefined,
+        positions: undefined,
+        source: undefined,
+      },
+    ],
+  });
+};


### PR DESCRIPTION
## Changes
- Uses `codes` to try for multiple handlers (in order)
- Drops usage of `status` property to determine if Client/Server - these are now just builtin to the codes array
- Handlers now receive a `next` function to forward the handling on to the next one
- Default handlers can be ignored with an `undefined` value
- Tests written for almost all functionality. Examples can be seen there.

All of these changes should not change the current logic in use. This next one does.

- Default handler for `Input` code now forwards on to next handler when a field isn't given.

## Real Impact

Previously the handler would return the error message in this case. This meant you couldn't easily change the error message displayed without loosing the default field functionality.
In practice it now it forwards on the `Default` handler, which by default uses the error message or it can be overridden.
Specifically this is now allowed:
```tsx
const error = {
  message: 'You messed up the foo bar',
  codes: ['Input'],
};
const result = await handleFormError(error, {
  // previously this would be ignored because the (default) Input handler would not forward
  Default: 'Failed to update X thing',
});
result == { [FORM_ERROR]: 'Failed to update X thing' }
```
That same code would handle differently for an `Input` error for a field:
```tsx
const error = {
  message: 'You messed up the name field',
  field: 'name',
  codes: ['Input'],
};
const result = await handleFormError(error, {
  // This is still ignored because the (default) Input handler is handling it
  Default: 'Failed to update X thing',
});
result == { name: 'You messed up the name field' }
```

In the future I would like to expand on the field handling so it's easier to map error messages for individual fields.
Maybe something like:
```tsx
const result = await handleFormError(error, {
  Input: onInputError((e, next) => {
    // Override error message for a specific field
    name: 'You cannot use that name',
    // Treat this field error as a non-field error - fallback to Default handler
    id: next(e),
    // rest un-specified are use error message like default?
  }),
});
```

Something similar could be useful for `Validation` errors as well. Currently we use server message for each of those violations, but it would be nice to be able to provide a custom message for each violation type.