### PR TITLE
Spreadsheet preview merged cells

### DIFF
--- a/src/components/files/FilePreview/CsvPreview.tsx
+++ b/src/components/files/FilePreview/CsvPreview.tsx
@@ -36,11 +36,21 @@ export const CsvPreview: FC<PreviewerProps> = (props) => {
         []
       )
     : [];
-  const rows = hasParsed ? csvData.slice(1) : [];
+  const rows = hasParsed
+    ? csvData.slice(1).map((row) =>
+        row.map((cell, index) => ({
+          index,
+          spanned: false,
+          rowspan: 1,
+          colspan: 1,
+          content: cell,
+        }))
+      )
+    : [];
 
   return previewLoading ? (
     <PreviewLoading />
   ) : !hasParsed ? null : (
-    <SpreadsheetView data={[{ name: 'Sheet1', rows, columns, spans: [] }]} />
+    <SpreadsheetView data={[{ name: 'Sheet1', rows, columns }]} />
   );
 };

--- a/src/components/files/FilePreview/CsvPreview.tsx
+++ b/src/components/files/FilePreview/CsvPreview.tsx
@@ -2,7 +2,11 @@ import Papa, { ParseResult } from 'papaparse';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
-import { ColumnData, SpreadsheetView } from './SpreadsheetView';
+import {
+  ColumnData,
+  jsonToTableRows,
+  SpreadsheetView,
+} from './SpreadsheetView';
 
 export const CsvPreview: FC<PreviewerProps> = (props) => {
   const { file, previewLoading, setPreviewLoading, setPreviewError } = props;
@@ -36,17 +40,7 @@ export const CsvPreview: FC<PreviewerProps> = (props) => {
         []
       )
     : [];
-  const rows = hasParsed
-    ? csvData.slice(1).map((row) =>
-        row.map((cell, index) => ({
-          index,
-          spanned: false,
-          rowspan: 1,
-          colspan: 1,
-          content: cell,
-        }))
-      )
-    : [];
+  const rows = hasParsed ? jsonToTableRows(csvData.slice(1)) : [];
 
   return previewLoading ? (
     <PreviewLoading />

--- a/src/components/files/FilePreview/CsvPreview.tsx
+++ b/src/components/files/FilePreview/CsvPreview.tsx
@@ -41,6 +41,6 @@ export const CsvPreview: FC<PreviewerProps> = (props) => {
   return previewLoading ? (
     <PreviewLoading />
   ) : !hasParsed ? null : (
-    <SpreadsheetView data={[{ name: 'Sheet1', rows, columns }]} />
+    <SpreadsheetView data={[{ name: 'Sheet1', rows, columns, spans: [] }]} />
   );
 };

--- a/src/components/files/FilePreview/ExcelPreview.tsx
+++ b/src/components/files/FilePreview/ExcelPreview.tsx
@@ -118,7 +118,6 @@ async function extractExcelData(
         const convertedRows = jsonToTableRows(parsedRows);
         const rows = calculateMergedCells(convertedRows, spans);
         const columns = formatColumns(usedCellRange);
-        console.log('columns', columns);
         const newSheet = {
           name: worksheetName,
           rows,

--- a/src/components/files/FilePreview/ExcelPreview.tsx
+++ b/src/components/files/FilePreview/ExcelPreview.tsx
@@ -2,13 +2,7 @@ import React, { FC, useCallback, useEffect, useState } from 'react';
 import XLSX from 'xlsx';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
-import { ColumnData, RowData, SpreadsheetView } from './SpreadsheetView';
-
-interface SheetData {
-  name: string;
-  rows: RowData;
-  columns: ColumnData;
-}
+import { SheetData, SpreadsheetView, TableSpan } from './SpreadsheetView';
 
 export const ExcelPreview: FC<PreviewerProps> = (props) => {
   const { file, previewLoading, setPreviewLoading, setPreviewError } = props;
@@ -56,12 +50,59 @@ async function extractExcelData(
         const worksheet = workbook.Sheets[worksheetName];
         // '!ref' is a special key that gives the used cell range
         const usedCellRange = worksheet['!ref'];
+        if (!usedCellRange) {
+          return sheets.concat({
+            name: worksheetName,
+            rows: [],
+            columns: [],
+            spans: [],
+          });
+        }
+
+        const mergedCells = worksheet['!merges'];
+
+        /* `!merges` gives us the values in absolute terms, from column A
+          and row 1. But `sheet_to_json` uses the `usedCellRange`, which
+          trims off empty rows and columns. So we need to figure out an
+          offset to use when calculating where the merged cells actually
+          occur in the resulting JSON. */
+        const rangeStart = usedCellRange.split(':')[0].split(/[A-Z]+/);
+        const rangeStartColumn = Array.from(rangeStart[0]);
+
+        const columnOffset =
+          rangeStartColumn.reduce(
+            (offset: number, component, index) => {
+              // 41 is 'A', and we want an `indexValue` for 'A' to be 1
+              const indexValue = component.charCodeAt(0) - 40;
+              /* For a `rangeStartColumn` value of 'AAA' and an `index` of 0,
+            we want `power` to be 2. */
+              const power = rangeStartColumn.length - index - 1;
+              const componentValue = 26 ** power + indexValue;
+              return componentValue + offset;
+            },
+            0
+            // We subtract 1 because spreadsheets start at 1 but we start at 0.
+          ) - 1;
+        const rowOffset = Number(rangeStart[1]) - 1;
+        const spans =
+          mergedCells?.reduce((spans: TableSpan[], merge) => {
+            const startColumn = merge.s.c - columnOffset;
+            const startRow = merge.s.r - rowOffset;
+            const colspan = merge.e.c - merge.s.c + 1;
+            const rowspan = merge.e.r - merge.s.r + 1;
+            const span: TableSpan = {
+              startColumn,
+              startRow,
+              colspan,
+              rowspan,
+            };
+            return spans.concat(span);
+          }, []) ?? [];
         const newSheet = {
           name: worksheetName,
-          rows: usedCellRange
-            ? XLSX.utils.sheet_to_json(worksheet, { header: 1 })
-            : [],
-          columns: usedCellRange ? formatColumns(usedCellRange) : [],
+          rows: XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' }),
+          columns: formatColumns(usedCellRange),
+          spans,
         };
         return sheets.concat(newSheet);
       },

--- a/src/components/files/FilePreview/ExcelPreview.tsx
+++ b/src/components/files/FilePreview/ExcelPreview.tsx
@@ -3,7 +3,7 @@ import XLSX from 'xlsx';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 import {
-  RowData,
+  jsonToTableRows,
   SheetData,
   SpreadsheetView,
   TableRow,
@@ -111,11 +111,12 @@ async function extractExcelData(
             };
             return spans.concat(span);
           }, []) ?? [];
-        const convertedRows = XLSX.utils.sheet_to_json(worksheet, {
+        const parsedRows = XLSX.utils.sheet_to_json(worksheet, {
           header: 1,
           defval: '',
         });
-        const rows = calculateMergedRows(convertedRows, spans);
+        const convertedRows = jsonToTableRows(parsedRows);
+        const rows = calculateMergedCells(convertedRows, spans);
         const columns = formatColumns(usedCellRange);
         const newSheet = {
           name: worksheetName,
@@ -148,100 +149,341 @@ function formatColumns(usedCellRange: string) {
   return columns;
 }
 
-function calculateMergedRows(rows: RowData, spans: TableSpan[]): TableRow[] {
+function calculateMergedCells(
+  rows: TableRow[],
+  spans: TableSpan[]
+): TableRow[] {
   return rows.reduce((mergedRows: TableRow[], currentRow, rowIndex) => {
+    /**
+     * If this row already exists, that means somewhere lower down we
+     * have processed it completely, so it should be returned as-is.
+     */
     if (mergedRows[rowIndex]) {
       return mergedRows;
     }
-    const rowMerges: TableSpan[] = currentRow.reduce(
-      (merges: TableSpan[], _: any, ci: number) => {
-        const cellMerge = spans.find(
-          (span) =>
-            span.startColumn === ci &&
-            span.startRow === rowIndex &&
-            span.rowspan > 1
-        );
-        return !cellMerge ? merges : merges.concat(cellMerge);
-      },
-      []
+
+    // Mark any column-spanned cells in this row as `spanned`
+    const mergedRow = getMergedColumns(currentRow, rowIndex, spans);
+
+    /**
+     * Now we need a snapshot of all the rows we've modified
+     * up until now, together with all remaining unprocessed
+     * rows. We're going to pass that snapshot recursively
+     * back, in case any of the cells we've already processed
+     * have their own merged rows that need to be processed
+     * in
+     */
+    const rowsSnapshot = [
+      ...mergedRows.slice(0, rowIndex),
+      mergedRow,
+      ...mergedRows.slice(rowIndex + 1),
+      ...rows.slice(mergedRows.length + 1),
+    ];
+
+    // Find cells in this row that have `rowspan` > 1
+    console.log(`Getting merged rows for row ${rowIndex + 1}`);
+    const rowMergesForCurrentRow = findRowMergesForCurrentRow(
+      currentRow,
+      rowIndex,
+      spans
     );
 
-    const subsequentMergedRows = rowMerges.map((rowMerge) => {
+    const subsequentMergedRows = getSubsequentMergedRows(
+      rowMergesForCurrentRow,
+      rowIndex,
+      rowsSnapshot,
+      spans
+    );
+
+    return [
+      ...mergedRows.slice(0, rowIndex),
+      mergedRow,
+      ...subsequentMergedRows,
+      ...mergedRows.slice(rowIndex + 1 + subsequentMergedRows.length),
+    ];
+  }, []);
+}
+
+/**
+ * Whether we're calling it from the main loop or later while
+ * processing merged rows, we need to process the "current" row
+ * for column merges.
+ */
+function getMergedColumns(
+  currentRow: TableRow,
+  rowIndex: number,
+  spans: TableSpan[]
+): TableRow {
+  return currentRow.reduce((mergedColumns: TableRow, column, columnIndex) => {
+    /**
+     * Some function already decided this cell would be spanned;
+     * return it still spanned.
+     * */
+    if (mergedColumns[columnIndex]?.spanned || column.spanned) {
+      return [
+        ...mergedColumns.slice(0, columnIndex),
+        {
+          index: columnIndex,
+          spanned: true as const,
+        },
+        ...mergedColumns.slice(columnIndex + 1),
+      ];
+    }
+
+    const columnMerge = spans.find(
+      (span) => span.startColumn === columnIndex && span.startRow === rowIndex
+    );
+
+    if (!columnMerge) {
+      return [
+        ...mergedColumns.slice(0, columnIndex),
+        {
+          index: columnIndex,
+          spanned: false as const,
+          rowspan: 1,
+          colspan: 1,
+          content: column.content,
+        },
+        ...mergedColumns.slice(columnIndex + 1),
+      ];
+    }
+
+    const { colspan, rowspan } = columnMerge;
+    const currentColumnData = {
+      index: columnIndex,
+      spanned: false as const,
+      rowspan,
+      colspan,
+      content: column.content,
+    };
+    const spannedColumns = Array(colspan - 1)
+      .fill(undefined)
+      .map((_, index) => ({
+        index,
+        spanned: true as const,
+      }));
+    return [...mergedColumns, currentColumnData, ...spannedColumns];
+  }, []);
+}
+
+/**
+ * We need to find any cell with `rowspan` > 1. We'll feed the list
+ * of such row merges into a function that evaluates subsequent rows
+ * and processes all of **their** merges, recursively.
+ */
+function findRowMergesForCurrentRow(
+  row: TableRow,
+  rowIndex: number,
+  spans: TableSpan[]
+): TableSpan[] {
+  return row.reduce((merges: TableSpan[], _, ci) => {
+    const cellMerge = spans.find(
+      (span) =>
+        span.startColumn === ci &&
+        span.startRow === rowIndex &&
+        span.rowspan > 1
+    );
+    return !cellMerge ? merges : merges.concat(cellMerge);
+  }, []);
+}
+
+/**
+ * This could really have been one function together with
+ * `findRowMergesForCurrentRow`, but we're keeping them separate
+ * for readability.
+ *
+ * The output of `findRowMergesForCurrentRow` is an array of cells
+ * in the "current" row (whether the row from the main
+ * `calculateMergedCells` function, or one of the subsequent rows
+ * being evaluated in the loop of this function that called it
+ * recursively) that have `rowspan` > 1. For each of those cells,
+ * we need to evaluate any subsequent rows affected by the merged
+ * row. They may, in turn, have cells with merged rows, requiring
+ * us to call this function again.
+ *
+ * An example might be useful. Let us say we have a spreadsheet
+ * that looks like this:
+ *
+ *  ┌───────────┬─────────────────┬─────┐
+ *  │           │      C1-E1      │ F1  │
+ *  │           │                 │     │
+ *  │           ├───────────┬─────┴─────┤
+ *  │   A1-B3   │           │   E2-F2   │
+ *  │           │           │           │
+ *  │           │   C2-D3   ├─────┬─────┤
+ *  │           │           │     │ F3  │
+ *  │           │           │     │     │
+ *  ├─────┬─────┼─────┬─────┤E3-E4├─────┤
+ *  │ A4  │ B4  │ C4  │ D4  │     │ F4  │
+ *  │     │     │     │     │     │     │
+ *  └─────┴─────┴─────┴─────┴─────┴─────┘
+ *
+ * We run `calculateMergedCells`. While processing row 1, it runs
+ * `rowMergesForCurrentRow` and finds the merged rows of A1-B3
+ * (which also includes merged columns). It passes the information
+ * about that merge to `getSubsequentMergedRows`, which identifies
+ * the rows below row 1 that need to be processed so their cells
+ * that are merged into row 1 can be marked as spanned.
+ *
+ * While we are doing this processing, we also check for merged rows
+ * in a recursive process. So when `getSubsequentMergedRows`
+ * processes row 2, it calls `rowMergesForCurrentRow` and finds the
+ * merged rows of C2-D3. This means it needs to process row 3, and
+ * then it finds E3-E4.
+ *
+ * ALSO! When processing each row, `getSubsequentMergedRows` calls
+ * `getMergedColumns` to make sure all column merges are evaluated.
+ * This way, when a given row is finally handed all the way back
+ * up to `calculateMergedCells`, it can be added to the accumulator
+ * value without further modification. But this means that we always
+ * need to be working with the most recently modified version of a row,
+ * passing our recent edits forward with each recursive call to
+ * `getSubsequentMergedRows` instead of constantly pulling from the
+ * original rows passed in to `calculateMergedCells`.
+ */
+function getSubsequentMergedRows(
+  rowMerges: TableSpan[],
+  rowIndex: number,
+  rowsSnapshot: TableRow[],
+  spans: TableSpan[]
+): TableRow[] {
+  console.log(`row merges for row ${rowIndex + 1}`, rowMerges);
+  const subsequentMergedRows = rowMerges.reduce(
+    (subsequentRows: TableRow[], rowMerge) => {
       const { rowspan, startColumn, colspan } = rowMerge;
+      /**
+       * Which columns in this row merge extend beyond this
+       * row into subsequent rows?
+       */
       const columnsToMerge = Array(colspan)
         .fill(undefined)
         .reduce(
           (columns: number[], __, i) => columns.concat(startColumn + i),
           []
         );
-      return Array(rowspan - 1)
+      /**
+       * We might have already made a pass through this `.reduce`
+       * function and have new information that should replace
+       * some of what we originally received in `rowsSnapshot`
+       */
+      const subsequentRowsSnapshot = [
+        ...rowsSnapshot.slice(0, rowIndex + 1),
+        ...subsequentRows,
+        ...rowsSnapshot.slice(rowIndex + 1 + subsequentRows.length),
+      ];
+      const populatedRows = Array(rowspan - 1)
         .fill(undefined)
-        .reduce((mergedRows, _, newRowIndex) => {
-          const originalRowData = rows[rowIndex + newRowIndex + 1];
-          const mergedRow = originalRowData.reduce(
-            (mergedRow: TableRow, cell: RowData[0], cellIndex: number) => {
+        .reduce((populatedMergedRows: TableRow[], _, newRowIndex) => {
+          console.log(
+            `Populating row ${
+              rowIndex + 1 + newRowIndex + 1
+            } from merge in row ${rowIndex + 1}`
+          );
+          /**
+           * We need to know how to find the current row (`newRowIndex`
+           * inside this block) in our `rowsSnapshot` so we can retrieve
+           * its values from whichever place has the more recently
+           * modified data.
+           */
+          const originalIndex = rowIndex + newRowIndex + 1;
+
+          /**
+           * If we already processed a row directly from `rows` in a
+           * previous pass but it contains more than one merged row, we
+           * want to modify our previous modification, not the original.
+           */
+          const currentRowData =
+            subsequentRows[newRowIndex] ??
+            subsequentRowsSnapshot[originalIndex];
+          // Calculate all the column merges isolated to this row
+          const mergedColumnsCurrentRowData = getMergedColumns(
+            currentRowData,
+            originalIndex,
+            spans
+          );
+
+          /**
+           * Now that we have the column merges calculated, we need to
+           * identify any cells in this row that are affected by a row
+           * merge from higher up. Some of those cells may already be
+           * marked as `spanned` from a previous pass; if so, our work is
+           * done! Otherwise we'll check against our list of columns in
+           * this row that ought to be merged.
+           */
+          const mergedRow = mergedColumnsCurrentRowData.reduce(
+            (mergedRow: TableRow, cell: TableRow[0], cellIndex: number) => {
               const mergedCell = columnsToMerge.includes(cellIndex)
                 ? {
                     index: cellIndex,
                     spanned: true as const,
                   }
-                : {
-                    index: cellIndex,
-                    spanned: false as const,
-                    rowspan: 1,
-                    colspan: 1,
-                    content: String(cell),
-                  };
-              return mergedRow.concat(mergedCell);
+                : cell;
+              const newMergedRow = mergedRow.concat(mergedCell);
+              return newMergedRow;
             },
             []
           );
-          return [...mergedRows, mergedRow];
-        }, []);
-    });
 
-    const mergedColumns = currentRow.reduce(
-      (mergedColumns: TableRow, column: any, columnIndex: number) => {
-        if (mergedColumns[columnIndex]?.spanned) {
-          return mergedColumns;
-        }
-
-        const columnMerge = spans.find(
-          (span) =>
-            span.startColumn === columnIndex && span.startRow === rowIndex
-        );
-
-        if (!columnMerge) {
-          return [
-            ...mergedColumns,
-            {
-              index: columnIndex,
-              spanned: false as const,
-              rowspan: 1,
-              colspan: 1,
-              content: column,
-            },
+          /**
+           * Now that all necessary cells in this row have been marked
+           * as spanned, we need to check for any row merges in it that
+           * require the processing of rows below it. This is where we
+           * make our recursive call to `getSubsequentMergedRows`, so we
+           * need the same kind of data here that we made from the top-
+           * level function that calls it: a snapshot of all currently
+           * processed rows, the current row we want to evalaute for
+           * row merges, and the index of that row in the full list of
+           * rows.
+           */
+          const mergedRowsSnapshot = [
+            ...subsequentRowsSnapshot.slice(0, rowIndex + 1),
+            ...populatedMergedRows.slice(0, newRowIndex),
+            mergedRow,
+            ...populatedMergedRows.slice(newRowIndex + 1),
+            ...subsequentRowsSnapshot.slice(
+              rowIndex + 1 + populatedMergedRows.length + 1
+            ),
           ];
-        }
+          console.log(
+            `Getting merged rows for row ${originalIndex + 1} from row ${
+              rowIndex + 1
+            }`,
+            mergedRow
+          );
+          const mergesForSubsequentRow = findRowMergesForCurrentRow(
+            mergedRow,
+            originalIndex,
+            spans
+          );
 
-        const { colspan, rowspan } = columnMerge;
-        const currentColumnData = {
-          index: columnIndex,
-          spanned: false as const,
-          rowspan,
-          colspan,
-          content: column,
-        };
-        const spannedColumns = Array(colspan - 1)
-          .fill(undefined)
-          .map((_, index) => ({
-            index,
-            spanned: true as const,
-          }));
-        return [...mergedColumns, currentColumnData, ...spannedColumns];
-      },
-      []
-    );
-    return [...mergedRows, mergedColumns, ...subsequentMergedRows.flat()];
-  }, []);
+          const subSubsequentRows = getSubsequentMergedRows(
+            mergesForSubsequentRow,
+            originalIndex,
+            mergedRowsSnapshot,
+            spans
+          );
+          const newPopulatedRows = [
+            ...populatedMergedRows.slice(0, newRowIndex),
+            mergedRow,
+            ...subSubsequentRows,
+            ...populatedMergedRows.slice(
+              newRowIndex + 1 + subSubsequentRows.length
+            ),
+          ];
+          return newPopulatedRows;
+        }, []);
+      const populatedSubsequentRows = [
+        // ...subsequentRows.slice(0, rowMergeIndex),
+        ...populatedRows,
+        // ...subsequentRows.slice(rowMergeIndex + 1 + populatedRows.length),
+      ];
+      console.log(
+        `populatedSubsequentRows from row ${rowIndex + 1}`,
+        populatedSubsequentRows
+      );
+      return populatedSubsequentRows;
+    },
+    []
+  );
+  return subsequentMergedRows;
 }

--- a/src/components/files/FilePreview/ExcelPreview.tsx
+++ b/src/components/files/FilePreview/ExcelPreview.tsx
@@ -43,9 +43,7 @@ export const ExcelPreview: FC<PreviewerProps> = (props) => {
 
 interface TableSpan {
   startColumn: number;
-  endColumn: number;
   startRow: number;
-  endRow: number;
   colspan: number;
   rowspan: number;
 }
@@ -105,12 +103,8 @@ async function extractExcelData(
             const startRow = merge.s.r - rowOffset;
             const colspan = merge.e.c - merge.s.c + 1;
             const rowspan = merge.e.r - merge.s.r + 1;
-            const endColumn = startColumn + colspan - 1;
-            const endRow = startRow + rowspan - 1;
             const span: TableSpan = {
               startColumn,
-              endColumn,
-              endRow,
               startRow,
               colspan,
               rowspan,

--- a/src/components/files/FilePreview/SpreadsheetView.tsx
+++ b/src/components/files/FilePreview/SpreadsheetView.tsx
@@ -54,18 +54,25 @@ export type ColumnData = Array<{
 }>;
 export type RowData = ReturnType<XLSX$Utils['sheet_to_json']>;
 
-export interface TableSpan {
-  startColumn: number;
-  startRow: number;
-  colspan: number;
-  rowspan: number;
+export interface TableCellSpanned {
+  index: number;
+  spanned: true;
 }
+
+export interface TableCellData {
+  index: number;
+  spanned: false;
+  rowspan: number;
+  colspan: number;
+  content: string | number;
+}
+
+export type TableRow = Array<TableCellSpanned | TableCellData>;
 
 export interface SheetData {
   name: string;
-  rows: RowData;
+  rows: TableRow[];
   columns: ColumnData;
-  spans: TableSpan[];
 }
 
 interface SpreadSheetViewProps {
@@ -73,10 +80,7 @@ interface SpreadSheetViewProps {
 }
 
 const RenderedSheet: FC<Omit<SheetData, 'name'>> = (props) => {
-  const { rows, columns, spans } = props;
-  console.log('rows', rows);
-  console.log('columns', columns);
-  console.log('spans', spans);
+  const { rows, columns } = props;
   return (
     <table>
       <tbody>
@@ -87,22 +91,22 @@ const RenderedSheet: FC<Omit<SheetData, 'name'>> = (props) => {
             return <th key={key}>{name}</th>;
           })}
         </tr>
-        {rows.map((row, rowIndex) => (
-          <tr key={rowIndex}>
-            <td key={rowIndex} className="table-header">
-              {rowIndex}
-            </td>
-            {columns.map((column, columnIndex) => {
-              console.log('columnIndex', columnIndex);
-              // const span = spans.find(
-              //   (span) =>
-              //     span.startColumn === columnIndex && span.startRow === rowIndex
-              // );
-              // const { rowspan, colspan } = span ?? { rowspan: 1, colspan: 1 };
-              return <td key={column.key}>{row[column.key]}</td>;
-            })}
-          </tr>
-        ))}
+        {rows.map((cells, rowIndex) => {
+          return (
+            <tr key={rowIndex}>
+              <th className="table-header">{rowIndex + 1}</th>
+              {cells.map((cell) => {
+                if (cell.spanned) return null;
+                const { index, rowspan, colspan, content } = cell;
+                return (
+                  <td key={index} rowSpan={rowspan} colSpan={colspan}>
+                    {content}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );
@@ -131,11 +135,7 @@ export const SpreadsheetView: FC<SpreadSheetViewProps> = (props) => {
   const activeTab = previewPage - 1;
   return data.length === 1 ? (
     <div className={classes.container}>
-      <RenderedSheet
-        rows={data[0].rows}
-        columns={data[0].columns}
-        spans={data[0].spans}
-      />
+      <RenderedSheet rows={data[0].rows} columns={data[0].columns} />
     </div>
   ) : (
     <>
@@ -149,7 +149,7 @@ export const SpreadsheetView: FC<SpreadSheetViewProps> = (props) => {
         ))}
       </Tabs>
       {data.map((sheet, index) => {
-        const { name, rows, columns, spans } = sheet;
+        const { name, rows, columns } = sheet;
         return (
           <div
             key={name}
@@ -160,7 +160,7 @@ export const SpreadsheetView: FC<SpreadSheetViewProps> = (props) => {
             role="tabpanel"
           >
             {activeTab === index && columns.length > 0 ? (
-              <RenderedSheet rows={rows} columns={columns} spans={spans} />
+              <RenderedSheet rows={rows} columns={columns} />
             ) : null}
           </div>
         );

--- a/src/components/files/FilePreview/SpreadsheetView.tsx
+++ b/src/components/files/FilePreview/SpreadsheetView.tsx
@@ -79,6 +79,18 @@ interface SpreadSheetViewProps {
   data: SheetData[];
 }
 
+export function jsonToTableRows(rows: RowData): TableRow[] {
+  return rows.map((row: RowData[0]) =>
+    row.map((cell: any, index: number) => ({
+      index,
+      spanned: false,
+      rowspan: 1,
+      colspan: 1,
+      content: typeof cell === 'number' ? cell : String(cell),
+    }))
+  );
+}
+
 const RenderedSheet: FC<Omit<SheetData, 'name'>> = (props) => {
   const { rows, columns } = props;
   return (

--- a/src/components/files/FilePreview/SpreadsheetView.tsx
+++ b/src/components/files/FilePreview/SpreadsheetView.tsx
@@ -79,7 +79,7 @@ interface SpreadSheetViewProps {
   data: SheetData[];
 }
 
-export function jsonToTableRows(rows: RowData): TableRow[] {
+export function jsonToTableRows(rows: RowData): TableCellData[][] {
   return rows.map((row: RowData[0]) =>
     row.map((cell: any, index: number) => ({
       index,

--- a/src/components/files/FilePreview/SpreadsheetView.tsx
+++ b/src/components/files/FilePreview/SpreadsheetView.tsx
@@ -54,10 +54,18 @@ export type ColumnData = Array<{
 }>;
 export type RowData = ReturnType<XLSX$Utils['sheet_to_json']>;
 
+export interface TableSpan {
+  startColumn: number;
+  startRow: number;
+  colspan: number;
+  rowspan: number;
+}
+
 export interface SheetData {
   name: string;
   rows: RowData;
   columns: ColumnData;
+  spans: TableSpan[];
 }
 
 interface SpreadSheetViewProps {
@@ -65,7 +73,10 @@ interface SpreadSheetViewProps {
 }
 
 const RenderedSheet: FC<Omit<SheetData, 'name'>> = (props) => {
-  const { rows, columns } = props;
+  const { rows, columns, spans } = props;
+  console.log('rows', rows);
+  console.log('columns', columns);
+  console.log('spans', spans);
   return (
     <table>
       <tbody>
@@ -76,14 +87,20 @@ const RenderedSheet: FC<Omit<SheetData, 'name'>> = (props) => {
             return <th key={key}>{name}</th>;
           })}
         </tr>
-        {rows.map((row, index) => (
-          <tr key={index}>
-            <td key={index} className="table-header">
-              {index}
+        {rows.map((row, rowIndex) => (
+          <tr key={rowIndex}>
+            <td key={rowIndex} className="table-header">
+              {rowIndex}
             </td>
-            {columns.map((column) => (
-              <td key={column.key}>{row[column.key]}</td>
-            ))}
+            {columns.map((column, columnIndex) => {
+              console.log('columnIndex', columnIndex);
+              // const span = spans.find(
+              //   (span) =>
+              //     span.startColumn === columnIndex && span.startRow === rowIndex
+              // );
+              // const { rowspan, colspan } = span ?? { rowspan: 1, colspan: 1 };
+              return <td key={column.key}>{row[column.key]}</td>;
+            })}
           </tr>
         ))}
       </tbody>
@@ -114,7 +131,11 @@ export const SpreadsheetView: FC<SpreadSheetViewProps> = (props) => {
   const activeTab = previewPage - 1;
   return data.length === 1 ? (
     <div className={classes.container}>
-      <RenderedSheet rows={data[0].rows} columns={data[0].columns} />
+      <RenderedSheet
+        rows={data[0].rows}
+        columns={data[0].columns}
+        spans={data[0].spans}
+      />
     </div>
   ) : (
     <>
@@ -128,7 +149,7 @@ export const SpreadsheetView: FC<SpreadSheetViewProps> = (props) => {
         ))}
       </Tabs>
       {data.map((sheet, index) => {
-        const { name, rows, columns } = sheet;
+        const { name, rows, columns, spans } = sheet;
         return (
           <div
             key={name}
@@ -139,7 +160,7 @@ export const SpreadsheetView: FC<SpreadSheetViewProps> = (props) => {
             role="tabpanel"
           >
             {activeTab === index && columns.length > 0 ? (
-              <RenderedSheet rows={rows} columns={columns} />
+              <RenderedSheet rows={rows} columns={columns} spans={spans} />
             ) : null}
           </div>
         );


### PR DESCRIPTION
SheetJS provides a list of merged cells in the parsed spreadsheet, but it will only integrate this data with the actual cell contents if using the `sheet_to_html` utility, which we'd rather not use for other reasons. This PR does two things, primarily:

1. Update the `SpreadsheetView` component to take the individual cell data not as a string or number but as this:

```
{
  index: number;
  spanned: false;
  rowspan: number;
  colspan: number;
  content: string | number;
}
```

2. Add a function to `ExcelPreview` to read through the list of cell merges then feed the row data provided by the `sheet_to_json` util through it to output the above type of data

We also update `CsvPreview` to provide row data in this format and do some general tidying up of typings between the three components, centralizing anything consumed by both `CsvPreview` and `ExcelPreview` in `SpreadsheetView`.