### PR TITLE
Secured directory query update

### DIFF
--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.stories.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.stories.tsx
@@ -8,7 +8,11 @@ export default { title: 'components' };
 export const FilesOverviewCard = () => {
   return (
     <Box display="flex" width={400}>
-      <Card loading={boolean('loading', false)} total={number('total', 1)} />
+      <Card
+        loading={boolean('loading', false)}
+        total={number('total', 1)}
+        canReadFiles={boolean('canReadFiles', true)}
+      />
     </Box>
   );
 };

--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
@@ -21,24 +21,14 @@ export const FilesOverviewCard: FC<BudgetOverviewCardProps> = ({
     <FieldOverviewCard
       className={className}
       title="Files"
-      viewLabel={
-        !canReadFiles
-          ? 'You do not have permission to view files for this project'
-          : 'View Files'
-      }
-      data={
-        loading
-          ? undefined
-          : !canReadFiles
-          ? {
-              to: '',
-              value: '—',
-            }
-          : {
-              to: 'files',
-              value: total ? String(formatNumber(total)) : '∞',
-            }
-      }
+      redactedText="You do not have permission to view files for this project"
+      viewLabel="View Files"
+      loading={loading}
+      redacted={!canReadFiles}
+      data={{
+        to: 'files',
+        value: total ? String(formatNumber(total)) : '∞',
+      }}
       icon={LibraryBooksOutlined}
     />
   );

--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
@@ -4,12 +4,14 @@ import { FieldOverviewCard } from '../../FieldOverviewCard';
 import { useNumberFormatter } from '../../Formatters';
 
 export interface BudgetOverviewCardProps {
+  canReadFiles: boolean;
   className?: string;
   loading?: boolean;
   total?: number;
 }
 
 export const FilesOverviewCard: FC<BudgetOverviewCardProps> = ({
+  canReadFiles,
   className,
   loading,
   total,
@@ -19,10 +21,19 @@ export const FilesOverviewCard: FC<BudgetOverviewCardProps> = ({
     <FieldOverviewCard
       className={className}
       title="Files"
-      viewLabel="View Files"
+      viewLabel={
+        !canReadFiles
+          ? 'You do not have permission to view files for this project'
+          : 'View Files'
+      }
       data={
         loading
           ? undefined
+          : !canReadFiles
+          ? {
+              to: '',
+              value: '—',
+            }
           : {
               to: 'files',
               value: total ? String(formatNumber(total)) : '∞',

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -17,7 +17,7 @@ export const CreateProjectDirectory = (
   props: Except<CreateProjectDirectoryProps, 'onSubmit'>
 ) => {
   const [createDirectory] = useCreateProjectDirectoryMutation();
-  const { project, directoryId, loading } = useProjectCurrentDirectory();
+  const { project, directoryId } = useProjectCurrentDirectory();
   const { enqueueSnackbar } = useSnackbar();
 
   const onSubmit: CreateProjectDirectoryProps['onSubmit'] = async (

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -17,24 +17,8 @@ export const CreateProjectDirectory = (
   props: Except<CreateProjectDirectoryProps, 'onSubmit'>
 ) => {
   const [createDirectory] = useCreateProjectDirectoryMutation();
-  const {
-    project,
-    directoryId,
-    loading,
-    canRead,
-  } = useProjectCurrentDirectory();
+  const { project, directoryId, loading } = useProjectCurrentDirectory();
   const { enqueueSnackbar } = useSnackbar();
-
-  if (canRead === false) {
-    enqueueSnackbar(
-      `You don't have permission to add folders in this project`,
-      {
-        preventDuplicate: true,
-        variant: 'error',
-        autoHideDuration: 3000,
-      }
-    );
-  }
 
   const onSubmit: CreateProjectDirectoryProps['onSubmit'] = async (
     nameInput

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -17,8 +17,24 @@ export const CreateProjectDirectory = (
   props: Except<CreateProjectDirectoryProps, 'onSubmit'>
 ) => {
   const [createDirectory] = useCreateProjectDirectoryMutation();
-  const { project, directoryId } = useProjectCurrentDirectory();
+  const {
+    project,
+    directoryId,
+    loading,
+    canRead,
+  } = useProjectCurrentDirectory();
   const { enqueueSnackbar } = useSnackbar();
+
+  if (!loading && !canRead) {
+    enqueueSnackbar(
+      `You don't have permission to add folders in this project`,
+      {
+        preventDuplicate: true,
+        variant: 'error',
+        autoHideDuration: 3000,
+      }
+    );
+  }
 
   const onSubmit: CreateProjectDirectoryProps['onSubmit'] = async (
     nameInput

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -25,7 +25,7 @@ export const CreateProjectDirectory = (
   } = useProjectCurrentDirectory();
   const { enqueueSnackbar } = useSnackbar();
 
-  if (!loading && !canRead) {
+  if (canRead === false) {
     enqueueSnackbar(
       `You don't have permission to add folders in this project`,
       {

--- a/src/scenes/Projects/Files/ProjectFiles.graphql
+++ b/src/scenes/Projects/Files/ProjectFiles.graphql
@@ -2,7 +2,11 @@ query ProjectRootDirectory($id: ID!) {
   project(id: $id) {
     ...ProjectBreadcrumb
     rootDirectory {
-      id
+      canEdit
+      canRead
+      value {
+        id
+      }
     }
   }
 }

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -272,7 +272,7 @@ const ProjectFilesListWrapped: FC = () => {
 
   return directoryLoading ? null : canReadRootDirectory === false ? (
     <Typography color="textSecondary">
-      You don't have permission to see the projects this language is engaged in
+      You do not have permission to see files for this project
     </Typography>
   ) : (
     <div className={classes.dropzone} {...getRootProps()}>

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -119,6 +119,7 @@ const ProjectFilesListWrapped: FC = () => {
 
   const {
     loading: directoryLoading,
+    canRead: canReadRootDirectory,
     project,
     directoryId,
     rootDirectoryId,
@@ -137,6 +138,7 @@ const ProjectFilesListWrapped: FC = () => {
     onDrop: handleFilesDrop,
     noClick: true,
     noKeyboard: true,
+    disabled: !directoryId,
   });
 
   const isNotRootDirectory = directoryId !== rootDirectoryId;
@@ -268,7 +270,11 @@ const ProjectFilesListWrapped: FC = () => {
     }
   };
 
-  return directoryLoading ? null : (
+  return directoryLoading ? null : !canReadRootDirectory ? (
+    <Typography variant="h4">
+      You do not have permission to view this project's files
+    </Typography>
+  ) : (
     <div className={classes.dropzone} {...getRootProps()}>
       <input {...getInputProps()} name="files_list_uploader" />
       {isDragActive && (

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -7,6 +7,7 @@ import {
 } from '@material-ui/core';
 import { CreateNewFolder, Publish } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
+import { useSnackbar } from 'notistack';
 import React, { FC } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -114,6 +115,7 @@ const ProjectFilesListWrapped: FC = () => {
   const navigate = useNavigate();
   const { projectId } = useParams();
   const formatDate = useDateTimeFormatter();
+  const { enqueueSnackbar } = useSnackbar();
 
   const { openFilePreview } = useFileActions();
 
@@ -124,6 +126,17 @@ const ProjectFilesListWrapped: FC = () => {
     directoryId,
     rootDirectoryId,
   } = useProjectCurrentDirectory();
+
+  if (canReadRootDirectory === false) {
+    enqueueSnackbar(
+      `You don't have permission to view files for this project`,
+      {
+        preventDuplicate: true,
+        variant: 'error',
+        autoHideDuration: 3000,
+      }
+    );
+  }
 
   const handleFilesDrop = useUploadProjectFiles(directoryId);
 
@@ -270,11 +283,7 @@ const ProjectFilesListWrapped: FC = () => {
     }
   };
 
-  return directoryLoading ? null : !canReadRootDirectory ? (
-    <Typography variant="h4">
-      You do not have permission to view this project's files
-    </Typography>
-  ) : (
+  return directoryLoading || !canReadRootDirectory ? null : (
     <div className={classes.dropzone} {...getRootProps()}>
       <input {...getInputProps()} name="files_list_uploader" />
       {isDragActive && (

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -7,7 +7,6 @@ import {
 } from '@material-ui/core';
 import { CreateNewFolder, Publish } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import { useSnackbar } from 'notistack';
 import React, { FC } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -115,7 +114,6 @@ const ProjectFilesListWrapped: FC = () => {
   const navigate = useNavigate();
   const { projectId } = useParams();
   const formatDate = useDateTimeFormatter();
-  const { enqueueSnackbar } = useSnackbar();
 
   const { openFilePreview } = useFileActions();
 
@@ -126,17 +124,6 @@ const ProjectFilesListWrapped: FC = () => {
     directoryId,
     rootDirectoryId,
   } = useProjectCurrentDirectory();
-
-  if (canReadRootDirectory === false) {
-    enqueueSnackbar(
-      `You don't have permission to view files for this project`,
-      {
-        preventDuplicate: true,
-        variant: 'error',
-        autoHideDuration: 3000,
-      }
-    );
-  }
 
   const handleFilesDrop = useUploadProjectFiles(directoryId);
 
@@ -283,7 +270,11 @@ const ProjectFilesListWrapped: FC = () => {
     }
   };
 
-  return directoryLoading || !canReadRootDirectory ? null : (
+  return directoryLoading ? null : canReadRootDirectory === false ? (
+    <Typography color="textSecondary">
+      You don't have permission to see the projects this language is engaged in
+    </Typography>
+  ) : (
     <div className={classes.dropzone} {...getRootProps()}>
       <input {...getInputProps()} name="files_list_uploader" />
       {isDragActive && (

--- a/src/scenes/Projects/Files/useProjectCurrentDirectory.ts
+++ b/src/scenes/Projects/Files/useProjectCurrentDirectory.ts
@@ -12,7 +12,8 @@ export const useProjectCurrentDirectory = () => {
     },
   });
   const project = data?.project;
-  const rootDirectoryId = data?.project.rootDirectory.id;
+  const canRead = data?.project.rootDirectory.canRead;
+  const rootDirectoryId = data?.project.rootDirectory.value?.id;
   const directoryId = folderId ?? rootDirectoryId ?? '';
-  return { loading, project, directoryId, rootDirectoryId };
+  return { loading, canRead, project, directoryId, rootDirectoryId };
 };

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -72,12 +72,17 @@ export const ProjectOverview: FC = () => {
     Many<EditableProjectField>
   >();
 
-  const { directoryId } = useProjectCurrentDirectory();
+  const {
+    directoryId,
+    loading: directoryIdLoading,
+    canRead: canReadDirectoryId,
+  } = useProjectCurrentDirectory();
   const handleFilesDrop = useUploadProjectFiles(directoryId);
 
   const { getRootProps, getInputProps, open: openFileBrowser } = useDropzone({
     onDrop: handleFilesDrop,
     noClick: true,
+    disabled: !directoryId,
   });
 
   const [createEngagementState, createEngagement] = useDialog();
@@ -219,26 +224,28 @@ export const ProjectOverview: FC = () => {
             </Grid>
           </Grid>
 
-          <Grid container spacing={1} alignItems="center">
-            <Grid item>
-              <span {...getRootProps()}>
-                <input {...getInputProps()} />
-                <Fab
-                  loading={!data}
-                  onClick={openFileBrowser}
-                  color="primary"
-                  aria-label="Upload Files"
-                >
-                  <Publish />
-                </Fab>
-              </span>
+          {directoryIdLoading || !canReadDirectoryId ? null : (
+            <Grid container spacing={1} alignItems="center">
+              <Grid item>
+                <span {...getRootProps()}>
+                  <input {...getInputProps()} />
+                  <Fab
+                    loading={!data}
+                    onClick={openFileBrowser}
+                    color="primary"
+                    aria-label="Upload Files"
+                  >
+                    <Publish />
+                  </Fab>
+                </span>
+              </Grid>
+              <Grid item>
+                <Typography variant="h4">
+                  {data ? 'Upload Files' : <Skeleton width="12ch" />}
+                </Typography>
+              </Grid>
             </Grid>
-            <Grid item>
-              <Typography variant="h4">
-                {data ? 'Upload Files' : <Skeleton width="12ch" />}
-              </Typography>
-            </Grid>
-          </Grid>
+          )}
 
           <div className={classes.container}>
             <BudgetOverviewCard

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -253,7 +253,11 @@ export const ProjectOverview: FC = () => {
               budget={data?.project.budget.value}
             />
             {/* TODO When file api is finished need to update query and pass in file information */}
-            <FilesOverviewCard loading={!data} total={undefined} />
+            <FilesOverviewCard
+              loading={!data}
+              total={undefined}
+              canReadFiles={canReadDirectoryId === true}
+            />
           </div>
           <CardGroup>
             <ProjectMembersSummary members={data?.project.team} />


### PR DESCRIPTION
**NOTE:** Will fail GQL type generation until API #1070 ([https://github.com/SeedCompany/cord-api-v3/pull/1070](https://github.com/SeedCompany/cord-api-v3/pull/1070)) is merged

The API is changing the type of value returned for `rootDirectory` in the `project` query from `Directory`, to `SecuredDirectory`, which follows the pattern of other "Secured" types. 

- Update `ProjectRootDirectory` query to retrieve correct fields based on API change
- Update `FilesOverviewCard`, `ProjectOverview`, `ProjectFilesList`, and `CreateProjectDirectory` components to handle the new `canRead` value, displaying different UI and potentially displaying errors if `canRead` is `false`
- Updates `FieldOverviewCard` to accept `loading`, `redacted`, and `redactedText` props, in order to handle loading and redacted states. Because this component renders several different pieces of data, we aren't using individual `Redacted` components for each of those pieces of data. Instead, if `redacted` is `true`, we're rendering static `Skeleton` components or no data, and wrapping the entire card in a `Tooltip` with the `redactedText`