### PR TITLE
Refactor Edit Engagement

### DIFF
--- a/src/scenes/Engagement/EditEngagement/EditEngagement.graphql
+++ b/src/scenes/Engagement/EditEngagement/EditEngagement.graphql
@@ -1,0 +1,12 @@
+fragment EditEngagement on Engagement {
+  startDateOverride {
+    value
+    canRead
+    canEdit
+  }
+  endDateOverride {
+    value
+    canRead
+    canEdit
+  }
+}

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -1,12 +1,12 @@
 import { pick, startCase } from 'lodash';
-import React, { FC } from 'react';
-import { Except } from 'type-fest';
+import React, { ComponentType, FC } from 'react';
+import { Except, Merge } from 'type-fest';
 import {
   displayInternPosition,
   InternshipEngagementPositionList,
   MethodologyToApproach,
-  UpdateInternshipEngagementInput,
-  UpdateLanguageEngagementInput,
+  UpdateInternshipEngagement,
+  UpdateLanguageEngagement,
 } from '../../../api';
 import { DisplayCountryFragment } from '../../../api/fragments/location.generated';
 import {
@@ -25,151 +25,155 @@ import {
 } from '../../../components/form';
 import { CountryField, UserField } from '../../../components/form/Lookup';
 import { UserLookupItemFragment } from '../../../components/form/Lookup/User/UserLookup.generated';
-import { InternshipEngagementDetailFragment } from '../InternshipEngagement/InternshipEngagement.generated';
-import { LanguageEngagementDetailFragment } from '../LanguageEngagement/LanguageEngagementDetail.generated';
+import { many, Many } from '../../../util';
+import { InternshipEngagementDetailFragment as InternshipEngagement } from '../InternshipEngagement/InternshipEngagement.generated';
+import { LanguageEngagementDetailFragment as LanguageEngagement } from '../LanguageEngagement/LanguageEngagementDetail.generated';
 import {
   useUpdateInternshipEngagementMutation,
   useUpdateLanguageEngagementMutation,
 } from './EditEngagementDialog.generated';
 
-type EditEngagementDialogProps = Except<
-  DialogFormProps<
-    UpdateLanguageEngagementInput | UpdateInternshipEngagementInput
-  >,
-  'onSubmit' | 'initialValues'
-> & {
-  engagement:
-    | InternshipEngagementDetailFragment
-    | LanguageEngagementDetailFragment;
-  editValue?: string;
+type Engagement = InternshipEngagement | LanguageEngagement;
+type EngagementKeys = keyof InternshipEngagement | keyof LanguageEngagement;
+
+interface EngagementFieldProps {
+  engagement: Engagement;
+}
+
+const fieldMapping = {
+  startDate: () => <DateField name="startDate" label="Start Date" />,
+  endDate: () => <DateField name="endDate" label="End Date" />,
+  completeDate: ({ engagement }: EngagementFieldProps) => (
+    <DateField
+      name="completeDate"
+      label={
+        engagement.__typename === 'InternshipEngagement'
+          ? 'Growth Plan Complete Date'
+          : 'Translation Complete Date'
+      }
+    />
+  ),
+  disbursementCompleteDate: () => (
+    <DateField
+      name="disbursementCompleteDate"
+      label="Disbursement Complete Date"
+    />
+  ),
+  communicationsCompleteDate: () => (
+    <DateField
+      name="communicationsCompleteDate"
+      label="Communications Complete Date"
+    />
+  ),
+  methodologies: () => (
+    <CheckboxesField name="methodologies" label="Methodologies">
+      {Object.keys(MethodologyToApproach).map((group) => (
+        <CheckboxOption key={group} label={startCase(group)} value={group} />
+      ))}
+    </CheckboxesField>
+  ),
+  position: () => (
+    <RadioField name="position" label="Intern Position">
+      {InternshipEngagementPositionList.map((position) => (
+        <RadioOption
+          key={position}
+          label={displayInternPosition(position)}
+          value={position}
+        />
+      ))}
+    </RadioField>
+  ),
+  countryOfOrigin: () => (
+    <CountryField name="countryOfOriginId" label="Country of Origin" />
+  ),
+  mentor: () => <UserField name="mentorId" label="Mentor" />,
+  firstScripture: () => (
+    <CheckboxField name="firstScripture" label="First Scripture" />
+  ),
+  lukePartnership: () => (
+    <CheckboxField name="lukePartnership" label="Luke Partnership" />
+  ),
 };
 
-type DialogFormInput = UpdateInternshipEngagementInput &
-  UpdateLanguageEngagementInput & {
-    engagement: {
-      mentor?: UserLookupItemFragment;
-      country?: DisplayCountryFragment;
-    };
-  };
+export type EditableEngagementField = keyof typeof fieldMapping;
+
+// Asserts the above mapping's keys & values are valid fields & components
+// By not declaring/enforcing the type on field mapping TS infers the type,
+// which allows us to define EditableEngagementField. Doing so we can strictly
+// define which fields are editable without having to duplicate the field keys.
+// I spent hours trying to get TS both enforce/constrain the shape while also
+// inferring the actual result with no success. The above solution isn't the best
+// DX either, keys are not autocompleted, props have to be explicitly defined,
+// but at least the strict typing works.
+const _assertMapping: Partial<
+  Record<EngagementKeys, ComponentType<EngagementFieldProps>>
+> &
+  Record<
+    Exclude<EditableEngagementField, EngagementKeys>,
+    never
+  > = fieldMapping;
+
+interface EngagementFormValues {
+  engagement: Merge<
+    UpdateLanguageEngagement & UpdateInternshipEngagement,
+    {
+      mentorId?: UserLookupItemFragment;
+      countryOfOriginId?: DisplayCountryFragment;
+    }
+  >;
+}
+
+export type EditEngagementDialogProps = Except<
+  DialogFormProps<EngagementFormValues>,
+  'onSubmit' | 'initialValues'
+> & {
+  engagement: Engagement;
+  editFields?: Many<EditableEngagementField>;
+};
 
 export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
   engagement,
-  editValue,
+  editFields: editFieldsProp,
   ...props
 }) => {
+  const editFields = many(editFieldsProp ?? []);
+
+  const fields = editFields.map((field) => {
+    const Field = fieldMapping[field];
+    return <Field engagement={engagement} key={field} />;
+  });
+
   const [updateInternshipEngagement] = useUpdateInternshipEngagementMutation();
   const [updateLanguageEngagement] = useUpdateLanguageEngagementMutation();
-
   const updateEngagement =
     engagement.__typename === 'InternshipEngagement'
       ? updateInternshipEngagement
       : updateLanguageEngagement;
 
-  const fields =
-    editValue &&
-    (editValue === 'startEndDate' ? (
-      <>
-        <DateField name="startDate" label="Start Date" />
-        <DateField name="endDate" label="End Date" />
-      </>
-    ) : editValue === 'completeDate' ? (
-      <DateField
-        name="completeDate"
-        label={
-          engagement.__typename === 'InternshipEngagement'
-            ? 'Growth Plan Complete Date'
-            : 'Translation Complete Date'
-        }
-      />
-    ) : editValue === 'disbursementCompleteDate' ? (
-      <DateField
-        name="disbursementCompleteDate"
-        label="Disbursement Complete Date"
-      />
-    ) : editValue === 'communicationsCompleteDate' ? (
-      <DateField
-        name="communicationsCompleteDate"
-        label="Communications Complete Date"
-      />
-    ) : editValue === 'methodologies' ? (
-      <>
-        <CheckboxesField name="methodologies" label="Methodologies">
-          {Object.keys(MethodologyToApproach).map((group) => (
-            <CheckboxOption
-              key={group}
-              label={startCase(group)}
-              value={group}
-            />
-          ))}
-        </CheckboxesField>
-      </>
-    ) : editValue === 'position' ? (
-      <RadioField name="position" label="Intern Position">
-        {InternshipEngagementPositionList.map((position) => (
-          <RadioOption
-            key={position}
-            label={displayInternPosition(position)}
-            value={position}
-          />
-        ))}
-      </RadioField>
-    ) : editValue === 'countryOfOrigin' ? (
-      <CountryField name="country" label="Country of Origin" />
-    ) : editValue === 'mentor' ? (
-      <UserField name="mentor" label="Mentor" />
-    ) : editValue === 'firstScriptureAndLukePartnership' ? (
-      <>
-        <CheckboxField
-          name="firstScripture"
-          label="First Scripture"
-          defaultValue={
-            engagement.__typename === 'LanguageEngagement' &&
-            Boolean(engagement.firstScripture.value)
-          }
-        />
-        <CheckboxField
-          name="lukePartnership"
-          label="Luke Partnership"
-          defaultValue={
-            engagement.__typename === 'LanguageEngagement' &&
-            Boolean(engagement.lukePartnership.value)
-          }
-        />
-      </>
-    ) : null);
-
-  // Filter out relevant initial values so the other values don't get added to the mutation
-  const sharedInitialValues = {
+  const fullInitialValues = {
     startDate: engagement.startDate.value,
     endDate: engagement.endDate.value,
     completeDate: engagement.completeDate.value,
     disbursementCompleteDate: engagement.disbursementCompleteDate.value,
     communicationsCompleteDate: engagement.communicationsCompleteDate.value,
-  };
-
-  const fullInitialValues =
-    engagement.__typename === 'InternshipEngagement'
+    ...(engagement.__typename === 'LanguageEngagement'
       ? {
-          ...sharedInitialValues,
+          lukePartnership: engagement.lukePartnership.value,
+          firstScripture: engagement.firstScripture.value,
+        }
+      : engagement.__typename === 'InternshipEngagement'
+      ? {
           methodologies: engagement.methodologies.value,
           position: engagement.position.value,
         }
-      : sharedInitialValues;
-
-  const pickKeys =
-    editValue === 'startEndDate'
-      ? ['id', 'startDate', 'endDate']
-      : ['id', editValue || ''];
-
-  const filteredInitialValues = {
-    engagement: {
-      id: engagement.id,
-      ...pick(fullInitialValues, pickKeys),
-    },
+      : {}),
   };
 
+  // Filter out irrelevant initial values so they don't get added to the mutation
+  const filteredInitialValues = pick(fullInitialValues, editFields);
+
   return (
-    <DialogForm<DialogFormInput>
+    <DialogForm
       title="Update Engagement"
       closeLabel="Close"
       submitLabel="Save"
@@ -178,8 +182,15 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
         fullWidth: true,
       }}
       {...props}
-      initialValues={filteredInitialValues}
-      onSubmit={async ({ engagement: { mentor, country, ...rest } }) => {
+      initialValues={{
+        engagement: {
+          id: engagement.id,
+          ...filteredInitialValues,
+        },
+      }}
+      onSubmit={async ({
+        engagement: { mentorId: mentor, countryOfOriginId: country, ...rest },
+      }) => {
         const mentorId = mentor?.id;
         const countryOfOriginId = country?.id;
         const input = {

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react';
 import { Except } from 'type-fest';
 import {
   displayInternPosition,
-  InternshipEngagementPosition,
+  InternshipEngagementPositionList,
   MethodologyToApproach,
   UpdateInternshipEngagementInput,
   UpdateLanguageEngagementInput,
@@ -52,28 +52,6 @@ type DialogFormInput = UpdateInternshipEngagementInput &
       country?: DisplayCountryFragment;
     };
   };
-
-const internshipEngagementPositions: InternshipEngagementPosition[] = [
-  'ExegeticalFacilitator',
-  'TranslationConsultantInTraining',
-  'AdministrativeSupportSpecialist',
-  'BusinessSupportSpecialist',
-  'CommunicationSpecialistInternal',
-  'CommunicationSpecialistMarketing',
-  'LanguageProgramManager',
-  'LanguageProgramManagerOrFieldOperations',
-  'LanguageSoftwareSupportSpecialist',
-  'LeadershipDevelopment',
-  'LiteracySpecialist',
-  'LukePartnershipFacilitatorOrSpecialist',
-  'MobilizerOrPartnershipSupportSpecialist',
-  'OralFacilitatorOrSpecialist',
-  'PersonnelOrHrSpecialist',
-  'ScriptureUseSpecialist',
-  'TechnicalSupportSpecialist',
-  'TranslationFacilitator',
-  'Translator',
-];
 
 const useStyles = makeStyles(() => ({
   dialog: {
@@ -135,7 +113,7 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
       </>
     ) : editValue === 'position' ? (
       <RadioField name="position" label="Intern Position">
-        {internshipEngagementPositions.map((position) => (
+        {InternshipEngagementPositionList.map((position) => (
           <RadioOption
             key={position}
             label={displayInternPosition(position)}

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -52,6 +52,9 @@ export type EditableEngagementField = ExtractStrict<
 >;
 
 interface EngagementFieldProps {
+  props: {
+    name: string;
+  };
   engagement: Engagement;
 }
 
@@ -59,13 +62,23 @@ const fieldMapping: Record<
   EditableEngagementField,
   ComponentType<EngagementFieldProps>
 > = {
-  startDateOverride: () => (
-    <DateField name="startDateOverride" label="Start Date" />
-  ),
-  endDateOverride: () => <DateField name="endDateOverride" label="End Date" />,
-  completeDate: ({ engagement }: EngagementFieldProps) => (
+  startDateOverride: ({ props }) => (
     <DateField
-      name="completeDate"
+      {...props}
+      label="Start Date"
+      helperText="Leave blank to use project's start date"
+    />
+  ),
+  endDateOverride: ({ props }) => (
+    <DateField
+      {...props}
+      label="End Date"
+      helperText="Leave blank to use project's end date"
+    />
+  ),
+  completeDate: ({ props, engagement }) => (
+    <DateField
+      {...props}
       label={
         engagement.__typename === 'InternshipEngagement'
           ? 'Growth Plan Complete Date'
@@ -73,27 +86,21 @@ const fieldMapping: Record<
       }
     />
   ),
-  disbursementCompleteDate: () => (
-    <DateField
-      name="disbursementCompleteDate"
-      label="Disbursement Complete Date"
-    />
+  disbursementCompleteDate: ({ props }) => (
+    <DateField {...props} label="Disbursement Complete Date" />
   ),
-  communicationsCompleteDate: () => (
-    <DateField
-      name="communicationsCompleteDate"
-      label="Communications Complete Date"
-    />
+  communicationsCompleteDate: ({ props }) => (
+    <DateField {...props} label="Communications Complete Date" />
   ),
-  methodologies: () => (
-    <CheckboxesField name="methodologies" label="Methodologies">
+  methodologies: ({ props }) => (
+    <CheckboxesField {...props} label="Methodologies">
       {Object.keys(MethodologyToApproach).map((group) => (
         <CheckboxOption key={group} label={startCase(group)} value={group} />
       ))}
     </CheckboxesField>
   ),
-  position: () => (
-    <RadioField name="position" label="Intern Position">
+  position: ({ props }) => (
+    <RadioField {...props} label="Intern Position">
       {InternshipEngagementPositionList.map((position) => (
         <RadioOption
           key={position}
@@ -103,15 +110,15 @@ const fieldMapping: Record<
       ))}
     </RadioField>
   ),
-  countryOfOriginId: () => (
-    <CountryField name="countryOfOriginId" label="Country of Origin" />
+  countryOfOriginId: ({ props }) => (
+    <CountryField {...props} label="Country of Origin" />
   ),
-  mentorId: () => <UserField name="mentorId" label="Mentor" />,
-  firstScripture: () => (
-    <CheckboxField name="firstScripture" label="First Scripture" />
+  mentorId: ({ props }) => <UserField {...props} label="Mentor" />,
+  firstScripture: ({ props }) => (
+    <CheckboxField {...props} label="First Scripture" />
   ),
-  lukePartnership: () => (
-    <CheckboxField name="lukePartnership" label="Luke Partnership" />
+  lukePartnership: ({ props }) => (
+    <CheckboxField {...props} label="Luke Partnership" />
   ),
 };
 
@@ -140,9 +147,9 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
 }) => {
   const editFields = many(editFieldsProp ?? []);
 
-  const fields = editFields.map((field) => {
-    const Field = fieldMapping[field];
-    return <Field engagement={engagement} key={field} />;
+  const fields = editFields.map((name) => {
+    const Field = fieldMapping[name];
+    return <Field props={{ name }} engagement={engagement} key={name} />;
   });
 
   const [updateInternshipEngagement] = useUpdateInternshipEngagementMutation();

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -35,7 +35,7 @@ import {
 
 type EditEngagementDialogProps = Except<
   DialogFormProps<
-    UpdateInternshipEngagementInput | UpdateInternshipEngagementInput
+    UpdateLanguageEngagementInput | UpdateInternshipEngagementInput
   >,
   'onSubmit' | 'initialValues'
 > & {

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -1,4 +1,3 @@
-import { makeStyles } from '@material-ui/core';
 import { pick, startCase } from 'lodash';
 import React, { FC } from 'react';
 import { Except } from 'type-fest';
@@ -53,18 +52,11 @@ type DialogFormInput = UpdateInternshipEngagementInput &
     };
   };
 
-const useStyles = makeStyles(() => ({
-  dialog: {
-    width: 400,
-  },
-}));
-
 export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
   engagement,
   editValue,
   ...props
 }) => {
-  const classes = useStyles();
   const [updateInternshipEngagement] = useUpdateInternshipEngagementMutation();
   const [updateLanguageEngagement] = useUpdateLanguageEngagementMutation();
 
@@ -181,6 +173,10 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
       title="Update Engagement"
       closeLabel="Close"
       submitLabel="Save"
+      DialogProps={{
+        maxWidth: 'xs',
+        fullWidth: true,
+      }}
       {...props}
       initialValues={filteredInitialValues}
       onSubmit={async ({ engagement: { mentor, country, ...rest } }) => {
@@ -195,11 +191,6 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
         };
 
         await updateEngagement({ variables: { input } });
-      }}
-      DialogProps={{
-        classes: {
-          paper: classes.dialog,
-        },
       }}
     >
       <SubmitError />

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagement.graphql
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagement.graphql
@@ -55,4 +55,5 @@ fragment InternshipEngagementDetail on InternshipEngagement {
   methodologies {
     ...MethodologiesCard
   }
+  ...EditEngagement
 }

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -20,8 +20,12 @@ import { MethodologiesCard } from '../../../components/MethodologiesCard';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { Redacted } from '../../../components/Redacted';
 import { Link } from '../../../components/Routing';
+import { Many } from '../../../util';
 import { CeremonyCard } from '../CeremonyCard';
-import { EditEngagementDialog } from '../EditEngagement/EditEngagementDialog';
+import {
+  EditableEngagementField,
+  EditEngagementDialog,
+} from '../EditEngagement/EditEngagementDialog';
 import { EngagementQuery } from '../Engagement.generated';
 import { MentorCard } from './MentorCard';
 
@@ -47,7 +51,9 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
   engagement,
 }) => {
   const classes = useStyles();
-  const [state, show, editValue] = useDialog<string>();
+  const [editState, show, editField] = useDialog<
+    Many<EditableEngagementField>
+  >();
 
   const date = securedDateRange(engagement.startDate, engagement.endDate);
   const formatDate = useDateFormatter();
@@ -139,7 +145,7 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
               redacted="You do not have permission to view start/end dates"
               children={formatDate.range}
               empty="Start - End"
-              onClick={() => show('startEndDate')}
+              onClick={() => show(['startDate', 'endDate'])}
             />
           </Grid>
           <Grid item>
@@ -205,9 +211,9 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
         </Grid>
       </Grid>
       <EditEngagementDialog
-        {...state}
+        {...editState}
         engagement={engagement}
-        editValue={editValue}
+        editFields={editField}
       />
     </div>
   );

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -135,7 +135,7 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
               empty="Enter Country of Origin"
               redacted="You do not have permission to view country of origin"
               children={displayLocation}
-              onClick={() => show('countryOfOrigin')}
+              onClick={() => show('countryOfOriginId')}
             />
           </Grid>
           <Grid item>
@@ -145,7 +145,7 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
               redacted="You do not have permission to view start/end dates"
               children={formatDate.range}
               empty="Start - End"
-              onClick={() => show(['startDate', 'endDate'])}
+              onClick={() => show(['startDateOverride', 'endDateOverride'])}
             />
           </Grid>
           <Grid item>
@@ -206,7 +206,7 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
                 {node}
               </Grid>
             )}
-            onEdit={() => show('mentor')}
+            onEdit={() => show('mentorId')}
           />
         </Grid>
       </Grid>

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.graphql
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.graphql
@@ -52,4 +52,5 @@ fragment LanguageEngagementDetail on LanguageEngagement {
   ceremony {
     ...CeremonyCard
   }
+  ...EditEngagement
 }

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -26,8 +26,12 @@ import { OptionsIcon, PlantIcon } from '../../../components/Icons';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { Redacted } from '../../../components/Redacted';
 import { Link } from '../../../components/Routing';
+import { Many } from '../../../util';
 import { CeremonyCard } from '../CeremonyCard';
-import { EditEngagementDialog } from '../EditEngagement/EditEngagementDialog';
+import {
+  EditableEngagementField,
+  EditEngagementDialog,
+} from '../EditEngagement/EditEngagementDialog';
 import { EngagementQuery } from '../Engagement.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints, palette }) => ({
@@ -53,7 +57,9 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
 }) => {
   const classes = useStyles();
 
-  const [state, show, editValue] = useDialog<string>();
+  const [editState, show, editField] = useDialog<
+    Many<EditableEngagementField>
+  >();
 
   const date = securedDateRange(engagement.startDate, engagement.endDate);
   const formatDate = useDateFormatter();
@@ -113,7 +119,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
                 <Fab
                   color="primary"
                   aria-label="Update language engagement"
-                  onClick={() => show('firstScriptureAndLukePartnership')}
+                  onClick={() => show(['firstScripture', 'lukePartnership'])}
                 >
                   <Edit />
                 </Fab>
@@ -140,7 +146,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
               redacted="You do not have permission to view start/end dates"
               children={formatDate.range}
               empty="Start - End"
-              onClick={() => show('startEndDate')}
+              onClick={() => show(['startDate', 'endDate'])}
             />
           </Grid>
           <Grid item>
@@ -203,9 +209,9 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
         </Grid>
       </Grid>
       <EditEngagementDialog
-        {...state}
+        {...editState}
         engagement={engagement}
-        editValue={editValue}
+        editFields={editField}
       />
     </div>
   );

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -146,7 +146,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
               redacted="You do not have permission to view start/end dates"
               children={formatDate.range}
               empty="Start - End"
-              onClick={() => show(['startDate', 'endDate'])}
+              onClick={() => show(['startDateOverride', 'endDateOverride'])}
             />
           </Grid>
           <Grid item>

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,1 +1,3 @@
 export type Nullable<T> = T | null | undefined;
+
+export type ExtractStrict<T, U extends T> = T extends U ? T : never;


### PR DESCRIPTION
- Fields are defined as a static mapping outside of the component
  instead of a bunch if/else statements inside it
- Edit field(s) are now strict keys instead of any/magic string
- Fixed missing initial values for language engagements.
  Previously they were added manually on the defaultValue of firstScripture & lukePartnership fields.
