### PR TITLE
Various Form bug fixes & improvements

### DIFF
--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -178,3 +178,4 @@ export function DialogForm<T, R = void>({
     </Form>
   );
 }
+DialogForm.defaultDecorators = defaultDecorators;

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -14,7 +14,13 @@ import { Form, FormProps, RenderableProps } from 'react-final-form';
 import { Promisable } from 'type-fest';
 import { ErrorHandlers, handleFormError } from '../../api';
 import { sleep } from '../../util';
-import { SubmitButton, SubmitButtonProps } from '../form';
+import {
+  blurOnSubmit,
+  focusFirstFieldRegistered,
+  focusFirstFieldWithSubmitError,
+  SubmitButton,
+  SubmitButtonProps,
+} from '../form';
 
 export type DialogFormProps<T, R = void> = Omit<
   FormProps<T>,
@@ -68,6 +74,12 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+const defaultDecorators = [
+  focusFirstFieldRegistered,
+  focusFirstFieldWithSubmitError,
+  blurOnSubmit,
+];
+
 /**
  * An opinionated component to handle dialog forms.
  */
@@ -93,6 +105,7 @@ export function DialogForm<T, R = void>({
 
   return (
     <Form<T>
+      decorators={defaultDecorators}
       {...FormProps}
       onSubmit={async (data, form) => {
         if (onlyDirtySubmit && !form.getState().dirty) {

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -13,7 +13,6 @@ import React, { ReactNode } from 'react';
 import { Form, FormProps, RenderableProps } from 'react-final-form';
 import { Promisable } from 'type-fest';
 import { ErrorHandlers, handleFormError } from '../../api';
-import { sleep } from '../../util';
 import {
   blurOnSubmit,
   focusFirstFieldRegistered,
@@ -123,8 +122,6 @@ export function DialogForm<T, R = void>({
       }}
     >
       {({ handleSubmit, submitting, form }) => {
-        // wait for UI to hide
-        const reset = () => sleep(500).then(() => form.reset());
         return (
           <Dialog
             fullWidth
@@ -132,10 +129,12 @@ export function DialogForm<T, R = void>({
             {...DialogProps}
             open={open}
             onClose={(e, reason) => {
-              void reset();
               onClose?.(reason, form);
             }}
-            onExited={onExited}
+            onExited={() => {
+              onExited?.();
+              form.reset();
+            }}
             disableBackdropClick={
               DialogProps.disableBackdropClick ?? submitting
             }
@@ -157,7 +156,6 @@ export function DialogForm<T, R = void>({
                   color="secondary"
                   {...CloseProps}
                   onClick={() => {
-                    void reset();
                     onClose?.('cancel', form);
                   }}
                 >

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -90,7 +90,7 @@ export function DialogForm<T, R = void>({
   SubmitProps,
   closeLabel,
   CloseProps,
-  onlyDirtySubmit,
+  onlyDirtySubmit = true,
   open,
   onSuccess,
   errorHandlers,
@@ -127,6 +127,8 @@ export function DialogForm<T, R = void>({
         const reset = () => sleep(500).then(() => form.reset());
         return (
           <Dialog
+            fullWidth
+            maxWidth="xs"
             {...DialogProps}
             open={open}
             onClose={(e, reason) => {

--- a/src/components/Filter/FilterButtonDialog.tsx
+++ b/src/components/Filter/FilterButtonDialog.tsx
@@ -24,10 +24,6 @@ export function FilterButtonDialog<T>({
       </Button>
 
       <DialogForm
-        DialogProps={{
-          fullWidth: true,
-          maxWidth: 'xs',
-        }}
         {...state}
         title="Filter Options"
         closeLabel="Reset Filters"

--- a/src/components/Upload/UploadFilesForm.tsx
+++ b/src/components/Upload/UploadFilesForm.tsx
@@ -25,15 +25,7 @@ export const UploadFilesForm = (
   };
 
   return (
-    <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
-      title="Upload Files"
-      {...props}
-      onSubmit={onSubmit}
-    >
+    <DialogForm title="Upload Files" {...props} onSubmit={onSubmit}>
       <SubmitError />
       <DropzoneField multiple={multiple} name="files" />
     </DialogForm>

--- a/src/components/files/FileActions/DeleteFile.tsx
+++ b/src/components/files/FileActions/DeleteFile.tsx
@@ -29,10 +29,6 @@ export const DeleteFile = (props: Except<DeleteFileProps, 'onSubmit'>) => {
 
   return (
     <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={onSubmit}
       title={`Delete ${isDirectory ? 'folder' : type}`}

--- a/src/components/files/FileActions/RenameFile.tsx
+++ b/src/components/files/FileActions/RenameFile.tsx
@@ -50,6 +50,7 @@ export const RenameFile = (props: Except<RenameFileProps, 'onSubmit'>) => {
         name="name"
         label="Name"
         placeholder={`Enter new ${type.toLowerCase()} name`}
+        required
       />
     </DialogForm>
   );

--- a/src/components/files/FileActions/RenameFile.tsx
+++ b/src/components/files/FileActions/RenameFile.tsx
@@ -35,15 +35,7 @@ export const RenameFile = (props: Except<RenameFileProps, 'onSubmit'>) => {
   };
 
   return (
-    <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
-      {...props}
-      onSubmit={onSubmit}
-      title={`Rename ${type}`}
-    >
+    <DialogForm {...props} onSubmit={onSubmit} title={`Rename ${type}`}>
       <SubmitError />
       <TextField
         defaultValue={parseFileNameAndExtension(name).displayName}

--- a/src/components/files/FileActions/RenameFile.tsx
+++ b/src/components/files/FileActions/RenameFile.tsx
@@ -50,7 +50,6 @@ export const RenameFile = (props: Except<RenameFileProps, 'onSubmit'>) => {
         name="name"
         label="Name"
         placeholder={`Enter new ${type.toLowerCase()} name`}
-        autoFocus
       />
     </DialogForm>
   );

--- a/src/components/form/AutocompleteField.tsx
+++ b/src/components/form/AutocompleteField.tsx
@@ -1,7 +1,7 @@
 import { Chip, ChipProps, TextField, TextFieldProps } from '@material-ui/core';
 import { Autocomplete, AutocompleteProps, Value } from '@material-ui/lab';
 import { identity } from 'lodash';
-import React, { useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { Except } from 'type-fest';
 import { useFieldName } from './FieldGroup';
 import { FieldConfig, useField } from './useField';
@@ -91,18 +91,18 @@ export function AutocompleteField<
         : undefined,
   });
   const disabled = disabledProp ?? meta.submitting;
-  const ref = useFocusOnEnabled(meta, disabled);
-  const getOptionLabel = props.getOptionLabel ?? identity;
 
-  const shouldSelect = autoFocus && (props.selectOnFocus ?? !props.freeSolo);
-  useEffect(() => {
-    if (shouldSelect && ref.current) {
-      setTimeout(
-        () => (ref.current as HTMLInputElement | undefined)?.select(),
-        100
-      );
-    }
-  }, [shouldSelect, ref]);
+  const selectOnFocus = props.selectOnFocus ?? !props.freeSolo;
+  const andSelectOnFocus = useCallback((el) => selectOnFocus && el.select(), [
+    selectOnFocus,
+  ]);
+  const ref = useFocusOnEnabled<HTMLInputElement>(
+    meta,
+    disabled,
+    andSelectOnFocus
+  );
+
+  const getOptionLabel = props.getOptionLabel ?? identity;
 
   return (
     <Autocomplete<T, Multiple, typeof required, FreeSolo>

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -131,6 +131,16 @@ export function LookupField<
     string
   >();
 
+  const shouldSelect = autoFocus && (props.selectOnFocus ?? true);
+  useEffect(() => {
+    if (shouldSelect && ref.current) {
+      setTimeout(
+        () => (ref.current as HTMLInputElement | undefined)?.select(),
+        100
+      );
+    }
+  }, [shouldSelect, ref]);
+
   useEffect(() => {
     setInput(selectedText);
   }, [field.value, selectedText]);

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -9,7 +9,7 @@ import {
 import { Autocomplete, AutocompleteProps, Value } from '@material-ui/lab';
 import { camelCase } from 'camel-case';
 import { last, upperFirst } from 'lodash';
-import React, { ComponentType, useEffect, useState } from 'react';
+import React, { ComponentType, useCallback, useEffect, useState } from 'react';
 import { Except, Merge, SetOptional } from 'type-fest';
 import { isNetworkRequestInFlight } from '../../../api';
 import { useDialog } from '../../Dialog';
@@ -109,7 +109,16 @@ export function LookupField<
     ),
   });
   const disabled = disabledProp ?? meta.submitting;
-  const ref = useFocusOnEnabled(meta, disabled);
+
+  const selectOnFocus = props.selectOnFocus ?? true;
+  const andSelectOnFocus = useCallback((el) => selectOnFocus && el.select(), [
+    selectOnFocus,
+  ]);
+  const ref = useFocusOnEnabled<HTMLInputElement>(
+    meta,
+    disabled,
+    andSelectOnFocus
+  );
 
   const getOptionLabel = (val: T | string) =>
     typeof val === 'string' ? val : getOptionLabelProp(val) ?? '';
@@ -130,16 +139,6 @@ export function LookupField<
   const [createDialogState, createDialogItem, createDialogValue] = useDialog<
     string
   >();
-
-  const shouldSelect = autoFocus && (props.selectOnFocus ?? true);
-  useEffect(() => {
-    if (shouldSelect && ref.current) {
-      setTimeout(
-        () => (ref.current as HTMLInputElement | undefined)?.select(),
-        100
-      );
-    }
-  }, [shouldSelect, ref]);
 
   useEffect(() => {
     setInput(selectedText);

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -77,7 +77,7 @@ export function LookupField<
 >({
   name: nameProp,
   multiple,
-  defaultValue,
+  defaultValue: defaultValueProp,
   disabled: disabledProp,
   useLookup,
   ChipProps,
@@ -93,13 +93,15 @@ export function LookupField<
 }: LookupFieldProps<T, Multiple, DisableClearable, CreateFormValues>) {
   const freeSolo = !!CreateDialogForm;
   type Val = Value<T, Multiple, DisableClearable, false>;
+  const defaultValue =
+    defaultValueProp ?? ((multiple ? emptyArray : null) as Val);
 
   const name = useFieldName(nameProp);
   const { input: field, meta, rest: autocompleteProps } = useField<Val>(name, {
     ...props,
     required,
     allowNull: !multiple,
-    defaultValue: (multiple ? emptyArray : null) as Val,
+    defaultValue,
     isEqual: compareNullable((a, b) =>
       multiple
         ? areListsEqual(a.map(getCompareBy), b.map(getCompareBy))
@@ -218,7 +220,8 @@ export function LookupField<
           params.inputValue as T,
         ];
       }}
-      value={field.value}
+      // FF for some reason doesn't handle defaultValue correctly
+      value={(field.value as Val | '') || defaultValue}
       inputValue={input}
       onBlur={field.onBlur}
       onFocus={field.onFocus}

--- a/src/components/form/util.ts
+++ b/src/components/form/util.ts
@@ -33,16 +33,21 @@ export const getHelperText = (
 /**
  * Helper hook to focus element attached to ref
  */
-export const useFocus = <T extends { focus: () => void } = HTMLElement>(): [
-  () => void,
-  MutableRefObject<T | null>
-] => {
+export const useFocus = <T extends { focus: () => void } = HTMLElement>(
+  andDo?: (el: T) => void
+): [() => void, MutableRefObject<T | null>] => {
   const ref = useRef<T | null>(null);
   const focus = useCallback(() => {
     if (ref.current) {
-      setTimeout(() => ref.current?.focus(), 100);
+      setTimeout(() => {
+        if (!ref.current) {
+          return;
+        }
+        ref.current.focus();
+        andDo?.(ref.current);
+      }, 100);
     }
-  }, [ref]);
+  }, [ref, andDo]);
   return [focus, ref];
 };
 
@@ -54,10 +59,11 @@ export const useFocusOnEnabled = <
   T extends { focus: () => void } = HTMLElement
 >(
   meta: FieldMetaState<unknown>,
-  disabled: boolean
+  disabled: boolean,
+  andDoOnFocus?: (el: T) => void
 ) => {
   // Refocus field if it has become re-enabled and is active
-  const [focus, ref] = useFocus<T>();
+  const [focus, ref] = useFocus<T>(andDoOnFocus);
   useEffect(() => {
     if (!disabled && meta.active) {
       focus();

--- a/src/scenes/Engagement/CeremonyCard/CeremonyCard.tsx
+++ b/src/scenes/Engagement/CeremonyCard/CeremonyCard.tsx
@@ -159,7 +159,6 @@ export const CeremonyCard: FC<CeremonyCardProps> = ({
         title={`Update ${type}`}
         closeLabel="Close"
         submitLabel="Save"
-        onlyDirtySubmit
         {...dialogState}
         initialValues={{
           ceremony: {
@@ -173,10 +172,6 @@ export const CeremonyCard: FC<CeremonyCardProps> = ({
         }}
         errorHandlers={{
           Default: `Failed to update ${type?.toLowerCase()}`,
-        }}
-        DialogProps={{
-          maxWidth: 'xs',
-          fullWidth: true,
         }}
       >
         <SubmitError />

--- a/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
@@ -55,6 +55,7 @@ export const CreateInternshipEngagement = ({
         name="intern"
         label="Intern"
         placeholder="Enter person's name"
+        required
       />
     </DialogForm>
   );

--- a/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
@@ -55,7 +55,6 @@ export const CreateInternshipEngagement = ({
         name="intern"
         label="Intern"
         placeholder="Enter person's name"
-        autoFocus
       />
     </DialogForm>
   );

--- a/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
@@ -10,7 +10,9 @@ import { ProjectOverviewDocument as ProjectOverview } from '../../../Projects/Ov
 import { useCreateInternshipEngagementMutation } from './CreateInternshipEngagement.generated';
 
 interface CreateInternshipEngagementFormValues {
-  intern: UserLookupItem;
+  engagement: {
+    internId: UserLookupItem;
+  };
 }
 
 type CreateInternshipEngagementProps = Except<
@@ -25,12 +27,15 @@ export const CreateInternshipEngagement = ({
   ...props
 }: CreateInternshipEngagementProps) => {
   const [createEngagement] = useCreateInternshipEngagementMutation();
-  const submit = async (input: CreateInternshipEngagementFormValues) => {
-    const createInternshipEngagementInput = {
-      engagement: { projectId, internId: input.intern.id },
-    };
+  const submit = async ({
+    engagement,
+  }: CreateInternshipEngagementFormValues) => {
     await createEngagement({
-      variables: { input: createInternshipEngagementInput },
+      variables: {
+        input: {
+          engagement: { projectId, internId: engagement.internId.id },
+        },
+      },
       refetchQueries: [
         {
           query: ProjectOverview,
@@ -48,7 +53,7 @@ export const CreateInternshipEngagement = ({
     >
       <SubmitError />
       <UserField
-        name="intern"
+        name="engagement.internId"
         label="Intern"
         placeholder="Enter person's name"
         required

--- a/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
@@ -42,10 +42,6 @@ export const CreateInternshipEngagement = ({
   };
   return (
     <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={submit}
       title="Create Internship Engagement"

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
@@ -54,7 +54,7 @@ export const CreateLanguageEngagement = ({
       title="Create Language Engagement"
     >
       <SubmitError />
-      <LanguageField name="language" label="Language" />
+      <LanguageField name="language" label="Language" required />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
@@ -44,15 +44,7 @@ export const CreateLanguageEngagement = ({
     });
   };
   return (
-    <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
-      {...props}
-      onSubmit={submit}
-      title="Create Language Engagement"
-    >
+    <DialogForm {...props} onSubmit={submit} title="Create Language Engagement">
       <SubmitError />
       <LanguageField name="language" label="Language" required />
     </DialogForm>

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
@@ -54,7 +54,7 @@ export const CreateLanguageEngagement = ({
       title="Create Language Engagement"
     >
       <SubmitError />
-      <LanguageField name="language" label="Language" autoFocus />
+      <LanguageField name="language" label="Language" />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
@@ -13,7 +13,9 @@ import { ProjectOverviewDocument as ProjectOverview } from '../../../Projects/Ov
 import { useCreateLanguageEngagementMutation } from './CreateLanguageEngagement.generated';
 
 interface CreateLanguageEngagementFormValues {
-  language: LanguageLookupItem;
+  engagement: {
+    languageId: LanguageLookupItem;
+  };
 }
 
 type CreateLanguageEngagementProps = Except<
@@ -28,12 +30,13 @@ export const CreateLanguageEngagement = ({
   ...props
 }: CreateLanguageEngagementProps) => {
   const [createEngagement] = useCreateLanguageEngagementMutation();
-  const submit = async (input: CreateLanguageEngagementFormValues) => {
-    const createLanguageEngagementInput = {
-      engagement: { projectId, languageId: input.language.id },
-    };
+  const submit = async ({ engagement }: CreateLanguageEngagementFormValues) => {
     await createEngagement({
-      variables: { input: createLanguageEngagementInput },
+      variables: {
+        input: {
+          engagement: { projectId, languageId: engagement.languageId.id },
+        },
+      },
       refetchQueries: [
         {
           query: ProjectOverview,
@@ -46,7 +49,7 @@ export const CreateLanguageEngagement = ({
   return (
     <DialogForm {...props} onSubmit={submit} title="Create Language Engagement">
       <SubmitError />
-      <LanguageField name="language" label="Language" required />
+      <LanguageField name="engagement.languageId" label="Language" required />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
@@ -35,7 +35,12 @@ export const CreateFilm = (props: CreateFilmProps) => {
       title="Create Film"
     >
       <SubmitError />
-      <TextField name="film.name" label="Name" placeholder="Enter film name" />
+      <TextField
+        name="film.name"
+        label="Name"
+        placeholder="Enter film name"
+        required
+      />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
@@ -35,12 +35,7 @@ export const CreateFilm = (props: CreateFilmProps) => {
       title="Create Film"
     >
       <SubmitError />
-      <TextField
-        name="film.name"
-        label="Name"
-        placeholder="Enter film name"
-        autoFocus
-      />
+      <TextField name="film.name" label="Name" placeholder="Enter film name" />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
@@ -18,10 +18,6 @@ export const CreateFilm = (props: CreateFilmProps) => {
   const [createFilm] = useCreateFilmMutation();
   return (
     <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={async (input) => {
         const { data } = await createFilm({

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Literacy Material/CreateLiteracyMaterial.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Literacy Material/CreateLiteracyMaterial.tsx
@@ -43,7 +43,6 @@ export const CreateLiteracyMaterial = (props: CreateLiteracyMaterialProps) => {
         name="literacyMaterial.name"
         label="Name"
         placeholder="Enter literacy material name"
-        autoFocus
       />
     </DialogForm>
   );

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Literacy Material/CreateLiteracyMaterial.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Literacy Material/CreateLiteracyMaterial.tsx
@@ -22,10 +22,6 @@ export const CreateLiteracyMaterial = (props: CreateLiteracyMaterialProps) => {
 
   return (
     <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={async (input) => {
         const { data } = await createLiteracyMaterial({

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Literacy Material/CreateLiteracyMaterial.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Literacy Material/CreateLiteracyMaterial.tsx
@@ -43,6 +43,7 @@ export const CreateLiteracyMaterial = (props: CreateLiteracyMaterialProps) => {
         name="literacyMaterial.name"
         label="Name"
         placeholder="Enter literacy material name"
+        required
       />
     </DialogForm>
   );

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Song/CreateSong.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Song/CreateSong.tsx
@@ -36,7 +36,12 @@ export const CreateSong = (props: CreateSongProps) => {
       title="Create Song"
     >
       <SubmitError />
-      <TextField name="song.name" label="Name" placeholder="Enter song name" />
+      <TextField
+        name="song.name"
+        label="Name"
+        placeholder="Enter song name"
+        required
+      />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Song/CreateSong.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Song/CreateSong.tsx
@@ -19,10 +19,6 @@ export const CreateSong = (props: CreateSongProps) => {
 
   return (
     <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={async (input) => {
         const { data } = await createSong({

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Song/CreateSong.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Song/CreateSong.tsx
@@ -36,12 +36,7 @@ export const CreateSong = (props: CreateSongProps) => {
       title="Create Song"
     >
       <SubmitError />
-      <TextField
-        name="song.name"
-        label="Name"
-        placeholder="Enter song name"
-        autoFocus
-      />
+      <TextField name="song.name" label="Name" placeholder="Enter song name" />
     </DialogForm>
   );
 };

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
@@ -40,7 +40,6 @@ export const CreateStory = (props: CreateStoryProps) => {
         name="story.name"
         label="Name"
         placeholder="Enter story name"
-        autoFocus
       />
     </DialogForm>
   );

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
@@ -40,6 +40,7 @@ export const CreateStory = (props: CreateStoryProps) => {
         name="story.name"
         label="Name"
         placeholder="Enter story name"
+        required
       />
     </DialogForm>
   );

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
@@ -19,10 +19,6 @@ export const CreateStory = (props: CreateStoryProps) => {
 
   return (
     <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={async (input) => {
         const { data } = await createStory({

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -6,10 +6,8 @@ import {
   DialogFormProps,
 } from '../../../components/Dialog/DialogForm';
 import {
-  blurOnSubmit,
   CheckboxField,
   FieldGroup,
-  focusFirstFieldWithSubmitError,
   FormattedTextField,
   FormattedTextFieldProps,
   matchFieldIfSame,
@@ -33,8 +31,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 const decorators = [
-  focusFirstFieldWithSubmitError,
-  blurOnSubmit,
+  ...DialogForm.defaultDecorators,
   matchFieldIfSame(`language.name`, `language.displayName`),
 ];
 

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -44,10 +44,8 @@ export const LanguageForm = <T extends any>({
   return (
     <DialogForm<T>
       DialogProps={{
-        fullWidth: true,
         maxWidth: 'lg',
       }}
-      onlyDirtySubmit
       {...rest}
       decorators={decorators}
     >

--- a/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
@@ -11,14 +11,7 @@ export type CreateOrganizationFormProps = DialogFormProps<
 >;
 
 export const CreateOrganizationForm = (props: CreateOrganizationFormProps) => (
-  <DialogForm
-    DialogProps={{
-      fullWidth: true,
-      maxWidth: 'xs',
-    }}
-    {...props}
-    title="Create Partner"
-  >
+  <DialogForm {...props} title="Create Partner">
     <SubmitError />
     <TextField
       name="organization.name"

--- a/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
@@ -24,7 +24,6 @@ export const CreateOrganizationForm = (props: CreateOrganizationFormProps) => (
       name="organization.name"
       label="Name"
       placeholder="Enter partner name"
-      autoFocus
     />
   </DialogForm>
 );

--- a/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
@@ -24,6 +24,7 @@ export const CreateOrganizationForm = (props: CreateOrganizationFormProps) => (
       name="organization.name"
       label="Name"
       placeholder="Enter partner name"
+      required
     />
   </DialogForm>
 );

--- a/src/scenes/Organizations/Edit/EditOrganization.tsx
+++ b/src/scenes/Organizations/Edit/EditOrganization.tsx
@@ -46,7 +46,6 @@ export const EditOrganization = ({ org, ...props }: EditOrganizationProps) => {
         label="Name"
         placeholder="Enter new partner name"
         disabled={!org.name.canEdit}
-        autoFocus
         required
       />
     </DialogForm>

--- a/src/scenes/Organizations/Edit/EditOrganization.tsx
+++ b/src/scenes/Organizations/Edit/EditOrganization.tsx
@@ -21,13 +21,8 @@ export const EditOrganization = ({ org, ...props }: EditOrganizationProps) => {
 
   return (
     <DialogForm<UpdateOrganizationInput>
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       title="Edit Partner"
       {...props}
-      onlyDirtySubmit
       initialValues={{
         organization: {
           id: org.id,

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -84,10 +84,6 @@ export const EditPartnership: FC<EditPartnershipProps> = ({
 
   return (
     <DialogForm<UpdatePartnershipInput & SubmitAction<'delete'>>
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       onSubmit={async (input) => {
         const refetchQueries = [GQLOperations.Query.ProjectPartnerships];

--- a/src/scenes/Projects/Create/CreateProjectForm.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.tsx
@@ -14,14 +14,7 @@ import {
 export type CreateProjectFormProps = DialogFormProps<CreateProjectInput>;
 
 export const CreateProjectForm = (props: CreateProjectFormProps) => (
-  <DialogForm
-    DialogProps={{
-      fullWidth: true,
-      maxWidth: 'xs',
-    }}
-    {...props}
-    title="Create Project"
-  >
+  <DialogForm {...props} title="Create Project">
     <SubmitError />
     <TextField
       name="project.name"

--- a/src/scenes/Projects/Create/CreateProjectForm.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.tsx
@@ -27,7 +27,6 @@ export const CreateProjectForm = (props: CreateProjectFormProps) => (
       name="project.name"
       label="Name"
       placeholder="Enter project name"
-      autoFocus
     />
     <RadioField name="project.type" label="Type">
       <RadioOption label="Translation" value="Translation" />

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -47,15 +47,7 @@ export const CreateProjectDirectory = (
   };
 
   return (
-    <DialogForm
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
-      {...props}
-      onSubmit={onSubmit}
-      title="Create Folder"
-    >
+    <DialogForm {...props} onSubmit={onSubmit} title="Create Folder">
       <SubmitError />
       <TextField
         name="name"

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -57,12 +57,7 @@ export const CreateProjectDirectory = (
       title="Create Folder"
     >
       <SubmitError />
-      <TextField
-        name="name"
-        label="Name"
-        placeholder="Enter folder name"
-        autoFocus
-      />
+      <TextField name="name" label="Name" placeholder="Enter folder name" />
     </DialogForm>
   );
 };

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -57,7 +57,12 @@ export const CreateProjectDirectory = (
       title="Create Folder"
     >
       <SubmitError />
-      <TextField name="name" label="Name" placeholder="Enter folder name" />
+      <TextField
+        name="name"
+        label="Name"
+        placeholder="Enter folder name"
+        required
+      />
     </DialogForm>
   );
 };

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -275,10 +275,6 @@ export const ProjectOverview: FC = () => {
                     onClick={createEngagement}
                   >
                     <Add />
-                    <CreateEngagement
-                      projectId={projectId}
-                      {...createEngagementState}
-                    />
                   </Fab>
                 </Tooltip>
               )}
@@ -305,6 +301,7 @@ export const ProjectOverview: FC = () => {
         {...editProjectDialogState}
         project={data?.project}
       />
+      <CreateEngagement projectId={projectId} {...createEngagementState} />
     </main>
   );
 };

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -33,11 +33,6 @@ export const UpdateProjectDialog = ({
       title="Update Project Step"
       closeLabel="Close"
       submitLabel="Save"
-      onlyDirtySubmit
-      DialogProps={{
-        fullWidth: true,
-        maxWidth: 'xs',
-      }}
       {...props}
       initialValues={{
         project: {

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -57,7 +57,6 @@ export const UpdateProjectDialog = ({
         groupBy={(step) => displayStatus(projectStatusFromStep[step])}
         getOptionLabel={displayProjectStep}
         variant="outlined"
-        autoFocus
         autoComplete
       />
     </DialogForm>

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -34,10 +34,8 @@ export const UserForm = <T extends any>({
 }: UserFormProps<T>) => (
   <DialogForm<T>
     DialogProps={{
-      fullWidth: true,
       maxWidth: 'sm',
     }}
-    onlyDirtySubmit
     {...rest}
     decorators={decorators(prefix)}
   >

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -22,6 +22,7 @@ export type UserFormProps<T> = DialogFormProps<T> & {
 };
 
 const decorators = memoize((prefix: string) => [
+  ...DialogForm.defaultDecorators,
   matchFieldIfSame(`${prefix}.realFirstName`, `${prefix}.displayFirstName`),
   matchFieldIfSame(`${prefix}.realLastName`, `${prefix}.displayLastName`),
 ]);


### PR DESCRIPTION
## Focus 
- Created final form decorator to focus first field registered (546c51fda444e93bb280aad9f1de2cc48fd50328)
- Apply our focus decorators to DialogForm by default (ab604d7169404af9d64302f92136fcca55fb738d)
- Apply default decorators to user & language form (ffc0da44d762097fce76fc7d437a8684763628c0)
- Remove autoFocus which is applied via FF decorator now (1aaf90eb7f0f3e472e1fde26d4a7f75c62aff19f)

## DialogForm
- Change DialogForm default props to match usage everywhere (bdb6c79db636446daba7523a519d6a09c412ff97)
- Reset DialogForm on exit instead of hardcoded 500ms (385cfb75f3f44eb8b310f89734db399415185854)
   This ensures the dialog is out of view before resetting, so the fields won't "flash back" in view.

## Lookup / Autocomplete Fields
- Fix LookupField default value. MUI was warning about `""` in console. (4372a1cca5652ee9b86df70b3a151833af80f662)
- Change how Autocomplete/LookupField applies select on focus to work with FF (64e42226811f4b97a67ff3d0fe48bccc18258ccb)
  Previously of only match the select functionality on `autoFocus` prop on mount.
  Now `form.focus(...)` & `field.active` will apply the select functionality as well.

## Create Engagements
- Fix create engagement dialog backdrop. (e1c4eeef6d3e20a2cba881c6322f4947151a5be2)
  Apparently dialogs do not like being in Tooltips/Fabs.
  Previously the dialog could not be closed. 🤦 
- Fix Create Engagement fields to match API (05bfbb5dcdacdd9f5dd437db58a07d1c00565425)
  Now duplicate errors show correctly

## Other Bug Fixes
- Apply missing `required` flag to fields (a3e1f6c3080eb6157dcd3b8bf99bb65dcbd0930e)
