### PR TITLE
Fix non-vertically centered Engagements Total in Project summary card

### DIFF
--- a/src/components/ProjectListItemCard/ProjectListItemCard.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles(({ breakpoints, spacing }) => {
       padding: spacing(2, 3),
       display: 'flex',
       justifyContent: 'space-between',
+      alignItems: 'center',
     },
     leftContent: {
       flex: 2,
@@ -49,6 +50,7 @@ const useStyles = makeStyles(({ breakpoints, spacing }) => {
     rightContent: {
       flex: 1,
       textAlign: 'right',
+      marginBottom: spacing(2),
       marginLeft: spacing(2),
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
Closes #426 

Add `alignItems: 'center'` to `cardContent` class and `marginBottom: spacing(2)` to `rightContent` class in `ProjectListItemCard` to fix display issue where UI showing total engagements was not vertically centered