### PR TITLE
Bugfix:forms reverting to initial values

### DIFF
--- a/src/scenes/Engagement/CeremonyCard/CeremonyCard.tsx
+++ b/src/scenes/Engagement/CeremonyCard/CeremonyCard.tsx
@@ -10,8 +10,7 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
-import { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { canEditAny, UpdateCeremonyInput } from '../../../api';
 import { useDialog } from '../../../components/Dialog';
 import { DialogForm } from '../../../components/Dialog/DialogForm';
@@ -78,6 +77,17 @@ export const CeremonyCard: FC<CeremonyCardProps> = ({
     >
       Edit dates
     </Button>
+  );
+
+  const initialValues = useMemo(
+    () => ({
+      ceremony: {
+        id: id || '',
+        estimatedDate: estimatedDate?.value,
+        actualDate: actualDate?.value,
+      },
+    }),
+    [actualDate?.value, estimatedDate?.value, id]
   );
 
   return (
@@ -160,13 +170,7 @@ export const CeremonyCard: FC<CeremonyCardProps> = ({
         closeLabel="Close"
         submitLabel="Save"
         {...dialogState}
-        initialValues={{
-          ceremony: {
-            id: id || '',
-            estimatedDate: estimatedDate?.value,
-            actualDate: actualDate?.value,
-          },
-        }}
+        initialValues={initialValues}
         onSubmit={async (input) => {
           await updateCeremony({ variables: { input } });
         }}

--- a/src/scenes/Languages/Edit/EditLanguage.tsx
+++ b/src/scenes/Languages/Edit/EditLanguage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdateLanguageInput } from '../../../api';
 import { LanguageForm, LanguageFormProps } from '../LanguageForm';
@@ -13,35 +13,38 @@ export const EditLanguage = (props: EditLanguageProps) => {
   const [updateLanguage] = useUpdateLanguageMutation();
   const language = props.language;
 
+  const initialValues = useMemo(
+    () =>
+      language
+        ? {
+            language: {
+              id: language.id,
+              name: language.name.value,
+              displayName: language.displayName.value,
+              displayNamePronunciation: language.displayNamePronunciation.value,
+              isDialect: language.isDialect.value,
+              ethnologue: {
+                id: language.ethnologue.id.value,
+                code: language.ethnologue.code.value,
+                provisionalCode: language.ethnologue.provisionalCode.value,
+                name: language.ethnologue.name.value,
+                population: language.ethnologue.population.value,
+              },
+              populationOverride: language.populationOverride.value,
+              registryOfDialectsCode: language.registryOfDialectsCode.value,
+              leastOfThese: language.leastOfThese.value,
+              leastOfTheseReason: language.leastOfTheseReason.value,
+            },
+          }
+        : undefined,
+    [language]
+  );
+
   return (
     <LanguageForm<UpdateLanguageInput>
       title="Edit Language"
       {...props}
-      initialValues={
-        language
-          ? {
-              language: {
-                id: language.id,
-                name: language.name.value,
-                displayName: language.displayName.value,
-                displayNamePronunciation:
-                  language.displayNamePronunciation.value,
-                isDialect: language.isDialect.value,
-                ethnologue: {
-                  id: language.ethnologue.id.value,
-                  code: language.ethnologue.code.value,
-                  provisionalCode: language.ethnologue.provisionalCode.value,
-                  name: language.ethnologue.name.value,
-                  population: language.ethnologue.population.value,
-                },
-                populationOverride: language.populationOverride.value,
-                registryOfDialectsCode: language.registryOfDialectsCode.value,
-                leastOfThese: language.leastOfThese.value,
-                leastOfTheseReason: language.leastOfTheseReason.value,
-              },
-            }
-          : undefined
-      }
+      initialValues={initialValues}
       onSubmit={async (input) => {
         await updateLanguage({
           variables: { input },

--- a/src/scenes/Organizations/Edit/EditOrganization.tsx
+++ b/src/scenes/Organizations/Edit/EditOrganization.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdateOrganizationInput } from '../../../api';
 import {
@@ -19,16 +19,21 @@ export type EditOrganizationProps = Except<
 export const EditOrganization = ({ org, ...props }: EditOrganizationProps) => {
   const [updateOrg] = useUpdateOrganizationMutation();
 
+  const initialValues = useMemo(
+    () => ({
+      organization: {
+        id: org.id,
+        name: org.name.value,
+      },
+    }),
+    [org.id, org.name.value]
+  );
+
   return (
     <DialogForm<UpdateOrganizationInput>
       title="Edit Partner"
       {...props}
-      initialValues={{
-        organization: {
-          id: org.id,
-          name: org.name.value,
-        },
-      }}
+      initialValues={initialValues}
       onSubmit={async (input) => {
         await updateOrg({
           variables: { input },

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@material-ui/core';
 import { Decorator } from 'final-form';
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useFormState } from 'react-final-form';
 import { Except } from 'type-fest';
 import {
@@ -82,6 +82,25 @@ export const EditPartnership: FC<EditPartnershipProps> = ({
     />
   ));
 
+  const initialValues = useMemo(
+    () => ({
+      partnership: {
+        id: partnership.id,
+        agreementStatus: partnership.agreementStatus.value ?? 'NotAttached',
+        mouStatus: partnership.mouStatus.value ?? 'NotAttached',
+        types: partnership.types.value,
+        fundingType: partnership.fundingType.value,
+      },
+    }),
+    [
+      partnership.agreementStatus.value,
+      partnership.fundingType.value,
+      partnership.id,
+      partnership.mouStatus.value,
+      partnership.types.value,
+    ]
+  );
+
   return (
     <DialogForm<UpdatePartnershipInput & SubmitAction<'delete'>>
       {...props}
@@ -110,15 +129,7 @@ export const EditPartnership: FC<EditPartnershipProps> = ({
           Delete
         </SubmitButton>
       }
-      initialValues={{
-        partnership: {
-          id: partnership.id,
-          agreementStatus: partnership.agreementStatus.value ?? 'NotAttached',
-          mouStatus: partnership.mouStatus.value ?? 'NotAttached',
-          types: partnership.types.value,
-          fundingType: partnership.fundingType.value,
-        },
-      }}
+      initialValues={initialValues}
       decorators={decorators}
     >
       <SubmitError />

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { Maybe, UpdateUserInput } from '../../../api';
 import { UserForm, UserFormProps } from '../UserForm';
@@ -13,28 +13,32 @@ export const EditUser = (props: EditUserProps) => {
   const [updateUser] = useUpdateUserMutation();
   const user = props.user;
 
+  const initialValues = useMemo(
+    () =>
+      user
+        ? {
+            user: {
+              id: user.id,
+              realFirstName: user.realFirstName.value,
+              realLastName: user.realLastName.value,
+              displayFirstName: user.displayFirstName.value,
+              displayLastName: user.displayLastName.value,
+              phone: user.phone.value,
+              timezone: user.timezone.value?.name,
+              bio: user.bio.value,
+              email: user.email.value,
+            },
+          }
+        : undefined,
+    [user]
+  );
+
   return (
     <UserForm<UpdateUserInput & { user: { email?: Maybe<string> } }>
       title="Edit Person"
       {...props}
       prefix="user"
-      initialValues={
-        user
-          ? {
-              user: {
-                id: user.id,
-                realFirstName: user.realFirstName.value,
-                realLastName: user.realLastName.value,
-                displayFirstName: user.displayFirstName.value,
-                displayLastName: user.displayLastName.value,
-                phone: user.phone.value,
-                timezone: user.timezone.value?.name,
-                bio: user.bio.value,
-                email: user.email.value,
-              },
-            }
-          : undefined
-      }
+      initialValues={initialValues}
       onSubmit={async ({ user: { email, ...user } }) => {
         await updateUser({
           variables: {


### PR DESCRIPTION
Memoize all initialValues in final form with `useMemo`

**Testing**
When updating a field, click submit and the field shouldn't flash back its initial value

Fixes #421 