### PR TITLE
Fix incorrect "directory not in project" error in files scene

### DIFF
--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -148,12 +148,13 @@ const ProjectFilesListWrapped: FC = () => {
     skip: !directoryId,
   });
 
-  const parents = data?.directory.parents ?? [];
-  const breadcrumbsParents = parents.slice(0, -1);
+  const parents = data?.directory.parents;
+  const breadcrumbsParents = parents?.slice(0, -1) ?? [];
 
   const directoryIsNotInProject =
     !directoryLoading &&
     isNotRootDirectory &&
+    parents &&
     !parents.some((parent) => parent.id === rootDirectoryId);
 
   const items = directoryIsNotInProject ? [] : data?.directory.children.items;


### PR DESCRIPTION
Closes #423 

Any directory that was not the root directory of the project would show "This folder does not exist in this project" during loading instead of the loading UI. This fixes a logic error in determining whether a give directory, which we query by route param, is part of the project being queried by route param