### PR TITLE
Create partnership dialog

### DIFF
--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -41,7 +41,7 @@ export type DialogFormProps<T, R = void> = Omit<
   CloseProps?: ButtonProps;
 
   /** Only call onSubmit if form is dirty, else just close dialog. */
-  onlyDirtySubmit?: boolean | string;
+  sendIfClean?: boolean | string;
 
   /** A prefix for all form fields */
   fieldsPrefix?: string;
@@ -100,7 +100,7 @@ export function DialogForm<T, R = void>({
   SubmitProps,
   closeLabel,
   CloseProps,
-  onlyDirtySubmit = true,
+  sendIfClean,
   open,
   onSuccess,
   errorHandlers,
@@ -121,14 +121,13 @@ export function DialogForm<T, R = void>({
       onSubmit={async (data, form) => {
         const submitAction = (data as any).submitAction;
         if (
-          (onlyDirtySubmit === true && !form.getState().dirty) ||
-          (typeof onlyDirtySubmit === 'string' &&
-            onlyDirtySubmit !== submitAction)
+          (!sendIfClean && !form.getState().dirty) ||
+          (typeof sendIfClean === 'string' && sendIfClean !== submitAction)
         ) {
           onClose?.('cleanSubmit', form);
           return null;
         }
-        if (!onlyDirtySubmit || onlyDirtySubmit === submitAction) {
+        if (sendIfClean || sendIfClean === submitAction) {
           try {
             const res = await onSubmit(data, form);
             onSuccess?.(res);

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -131,15 +131,13 @@ export function DialogForm<T, R = void>({
           onClose?.('cleanSubmit', form);
           return null;
         }
-        if (sendIfClean === true || sendIfClean === submitAction) {
-          try {
-            const res = await onSubmit(data, form);
-            onSuccess?.(res);
-            onClose?.('success', form);
-            return null;
-          } catch (e) {
-            return await handleFormError(e, errorHandlers);
-          }
+        try {
+          const res = await onSubmit(data, form);
+          onSuccess?.(res);
+          onClose?.('success', form);
+          return null;
+        } catch (e) {
+          return await handleFormError(e, errorHandlers);
         }
       }}
     >

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -40,7 +40,11 @@ export type DialogFormProps<T, R = void> = Omit<
   closeLabel?: ReactNode;
   CloseProps?: ButtonProps;
 
-  /** Only call onSubmit if form is dirty, else just close dialog. */
+  /**
+   * Optionally call onSubmit even if form is clean,
+   * OR, when a string value, if `sendIfClean === data.submitAction`.
+   * Else just close dialog.
+   */
   sendIfClean?: boolean | string;
 
   /** A prefix for all form fields */

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -131,7 +131,7 @@ export function DialogForm<T, R = void>({
           onClose?.('cleanSubmit', form);
           return null;
         }
-        if (sendIfClean || sendIfClean === submitAction) {
+        if (sendIfClean === true || sendIfClean === submitAction) {
           try {
             const res = await onSubmit(data, form);
             onSuccess?.(res);

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -313,7 +313,7 @@ export function LookupField<
         <CreateDialogForm
           {...createDialogState}
           initialValues={createInitialValues}
-          onlyDirtySubmit={false}
+          sendIfClean={true}
           onSuccess={(newItem: T) => {
             field.onChange(
               multiple ? [...(field.value as T[]), newItem] : newItem

--- a/src/scenes/Partnerships/Create/CreatePartnership.graphql
+++ b/src/scenes/Partnerships/Create/CreatePartnership.graphql
@@ -1,0 +1,7 @@
+mutation CreatePartnership($input: CreatePartnershipInput!) {
+  createPartnership(input: $input) {
+    partnership {
+      ...PartnershipForm
+    }
+  }
+}

--- a/src/scenes/Partnerships/Create/CreatePartnership.tsx
+++ b/src/scenes/Partnerships/Create/CreatePartnership.tsx
@@ -31,7 +31,7 @@ export const CreatePartnership = ({
 
   return (
     <PartnershipForm<CreatePartnershipFormInput>
-      title="Create Language"
+      title="Create Partnership"
       {...props}
       onSubmit={async ({ partnership }) => {
         const input = {

--- a/src/scenes/Partnerships/Create/CreatePartnership.tsx
+++ b/src/scenes/Partnerships/Create/CreatePartnership.tsx
@@ -1,0 +1,43 @@
+import { useSnackbar } from 'notistack';
+import React from 'react';
+import { Except } from 'type-fest';
+import { CreatePartnershipInput, GQLOperations } from '../../../api';
+import { ButtonLink } from '../../../components/Routing';
+import { PartnershipForm, PartnershipFormProps } from '../PartnershipForm';
+import { useCreatePartnershipMutation } from './CreatePartnership.generated';
+
+export type CreatePartnershipProps = Except<
+  PartnershipFormProps<CreatePartnershipInput>,
+  'onSubmit'
+>;
+export const CreatePartnership = (props: CreatePartnershipProps) => {
+  const [createLang] = useCreatePartnershipMutation();
+  const { enqueueSnackbar } = useSnackbar();
+
+  return (
+    <PartnershipForm<CreatePartnershipInput>
+      title="Create Language"
+      {...props}
+      onSubmit={async (input) => {
+        const res = await createLang({
+          variables: { input },
+          refetchQueries: [GQLOperations.Query.Languages],
+        });
+
+        const { partnership } = res.data!.createPartnership;
+
+        enqueueSnackbar(
+          `Created partnership with organization: ${partnership.organization.name.value}`,
+          {
+            variant: 'success',
+            action: () => (
+              <ButtonLink color="inherit" to={`/languages/${partnership.id}`}>
+                View
+              </ButtonLink>
+            ),
+          }
+        );
+      }}
+    />
+  );
+};

--- a/src/scenes/Partnerships/Create/CreatePartnership.tsx
+++ b/src/scenes/Partnerships/Create/CreatePartnership.tsx
@@ -11,7 +11,7 @@ import { useCreatePartnershipMutation } from './CreatePartnership.generated';
 export interface CreatePartnershipFormInput {
   partnership: Pick<
     CreatePartnershipType,
-    'projectId' | 'types' | 'fundingType'
+    'projectId' | 'types' | 'financialReportingType'
   > & {
     organizationId: OrganizationLookupItem;
   };

--- a/src/scenes/Partnerships/Create/index.ts
+++ b/src/scenes/Partnerships/Create/index.ts
@@ -1,0 +1,2 @@
+export * from './CreatePartnership';
+export * from './CreatePartnership.generated';

--- a/src/scenes/Partnerships/Edit/EditPartnership.graphql
+++ b/src/scenes/Partnerships/Edit/EditPartnership.graphql
@@ -1,35 +1,11 @@
 mutation UpdatePartnership($input: UpdatePartnershipInput!) {
   updatePartnership(input: $input) {
     partnership {
-      ...PartnershipCard
+      ...PartnershipForm
     }
   }
 }
 
 mutation DeletePartnership($input: ID!) {
   deletePartnership(id: $input)
-}
-
-fragment EditPartnership on Partnership {
-  id
-  types {
-    value
-    canEdit
-  }
-  agreementStatus {
-    value
-    canEdit
-  }
-  mouStatus {
-    value
-    canEdit
-  }
-  organization {
-    name {
-      value
-    }
-  }
-  financialReportingType {
-    value
-  }
 }

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -78,7 +78,7 @@ export const EditPartnership: FC<EditPartnershipProps> = (props) => {
   return (
     <PartnershipForm<EditPartnershipFormInput>
       {...props}
-      onlyDirtySubmit={false} // Lets us delete without changing any fields
+      onlyDirtySubmit="delete" // Lets us delete without changing any fields
       onSubmit={async ({ submitAction, partnership }) => {
         const refetchQueries = [GQLOperations.Query.ProjectPartnerships];
         if (submitAction === 'delete') {

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -78,7 +78,7 @@ export const EditPartnership: FC<EditPartnershipProps> = (props) => {
   return (
     <PartnershipForm<EditPartnershipFormInput>
       {...props}
-      onlyDirtySubmit="delete" // Lets us delete without changing any fields
+      sendIfClean="delete" // Lets us delete without changing any fields
       onSubmit={async ({ submitAction, partnership }) => {
         const refetchQueries = [GQLOperations.Query.ProjectPartnerships];
         if (submitAction === 'delete') {

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -14,17 +14,20 @@ import {
   useUpdatePartnershipMutation,
 } from './EditPartnership.generated';
 
+export type EditPartnershipFormInput = UpdatePartnershipInput &
+  SubmitAction<'delete'>;
+
 type EditPartnershipProps = Except<
-  PartnershipFormProps<UpdatePartnershipInput>,
+  PartnershipFormProps<EditPartnershipFormInput>,
   'onSubmit' | 'initialValues'
 > & {
   partnership: PartnershipFormFragment;
 };
 
-const clearFinancialReportingType: Decorator<UpdatePartnershipInput> = (
+const clearFinancialReportingType: Decorator<EditPartnershipFormInput> = (
   form
 ) => {
-  let prevValues: Partial<UpdatePartnershipInput> | undefined;
+  let prevValues: Partial<EditPartnershipFormInput> | undefined;
   return form.subscribe(
     ({ initialValues, values }) => {
       if (prevValues === undefined || prevValues !== initialValues) {
@@ -73,7 +76,7 @@ export const EditPartnership: FC<EditPartnershipProps> = (props) => {
   );
 
   return (
-    <PartnershipForm<UpdatePartnershipInput & SubmitAction<'delete'>>
+    <PartnershipForm<EditPartnershipFormInput>
       {...props}
       onSubmit={async (input) => {
         const refetchQueries = [GQLOperations.Query.ProjectPartnerships];

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -78,17 +78,18 @@ export const EditPartnership: FC<EditPartnershipProps> = (props) => {
   return (
     <PartnershipForm<EditPartnershipFormInput>
       {...props}
-      onSubmit={async (input) => {
+      onlyDirtySubmit={false} // Lets us delete without changing any fields
+      onSubmit={async ({ submitAction, partnership }) => {
         const refetchQueries = [GQLOperations.Query.ProjectPartnerships];
-        if (input.submitAction === 'delete') {
+        if (submitAction === 'delete') {
           await deletePartnership({
-            variables: { input: input.partnership.id },
+            variables: { input: partnership.id },
             refetchQueries,
           });
           return;
         }
         await updatePartnership({
-          variables: { input },
+          variables: { input: { partnership } },
           refetchQueries,
         });
       }}

--- a/src/scenes/Partnerships/Edit/index.ts
+++ b/src/scenes/Partnerships/Edit/index.ts
@@ -1,1 +1,2 @@
 export * from './EditPartnership';
+export * from './EditPartnership.generated';

--- a/src/scenes/Partnerships/List/PartnershipList.graphql
+++ b/src/scenes/Partnerships/List/PartnershipList.graphql
@@ -6,7 +6,7 @@ query ProjectPartnerships($input: ID!) {
       total
       items {
         ...PartnershipCard
-        ...EditPartnership
+        ...PartnershipForm
       }
     }
   }

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -7,12 +7,10 @@ import {
 import { Add } from '@material-ui/icons';
 import React, { FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { Merge } from 'type-fest';
 import { Breadcrumb } from '../../../components/Breadcrumb';
 import { useDialog } from '../../../components/Dialog';
 import { Fab } from '../../../components/Fab';
 import { PartnershipCard } from '../../../components/PartnershipCard';
-import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { listOrPlaceholders } from '../../../util';
 import { CreatePartnership } from '../Create';
@@ -51,7 +49,7 @@ export const PartnershipList: FC = () => {
 
   const [createDialogState, openCreateDialog] = useDialog();
   const [editDialogState, openEditDialog, partnership] = useDialog<
-    Merge<PartnershipCardFragment, PartnershipFormFragment>
+    PartnershipFormFragment
   >();
 
   return (

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -16,7 +16,7 @@ import { PartnershipCardFragment } from '../../../components/PartnershipCard/Par
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { listOrPlaceholders } from '../../../util';
 import { EditPartnership } from '../Edit';
-import { EditPartnershipFragment } from '../Edit/EditPartnership.generated';
+import { PartnershipFormFragment } from '../PartnershipForm';
 import { useProjectPartnershipsQuery } from './PartnershipList.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
@@ -49,7 +49,7 @@ export const PartnershipList: FC = () => {
   const partnerships = project?.partnerships;
 
   const [dialogState, openDialog, partnership] = useDialog<
-    Merge<PartnershipCardFragment, EditPartnershipFragment>
+    Merge<PartnershipCardFragment, PartnershipFormFragment>
   >();
 
   return (

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -15,6 +15,7 @@ import { PartnershipCard } from '../../../components/PartnershipCard';
 import { PartnershipCardFragment } from '../../../components/PartnershipCard/PartnershipCard.generated';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { listOrPlaceholders } from '../../../util';
+import { CreatePartnership } from '../Create';
 import { EditPartnership } from '../Edit';
 import { PartnershipFormFragment } from '../PartnershipForm';
 import { useProjectPartnershipsQuery } from './PartnershipList.generated';
@@ -48,7 +49,8 @@ export const PartnershipList: FC = () => {
   const project = data?.project;
   const partnerships = project?.partnerships;
 
-  const [dialogState, openDialog, partnership] = useDialog<
+  const [createDialogState, openCreateDialog] = useDialog();
+  const [editDialogState, openEditDialog, partnership] = useDialog<
     Merge<PartnershipCardFragment, PartnershipFormFragment>
   >();
 
@@ -66,7 +68,11 @@ export const PartnershipList: FC = () => {
         </Typography>
         {partnerships?.canCreate && (
           <Tooltip title="Add Partnership">
-            <Fab color="error" aria-label="add partnership">
+            <Fab
+              color="error"
+              aria-label="add partnership"
+              onClick={openCreateDialog}
+            >
               <Add />
             </Fab>
           </Tooltip>
@@ -76,13 +82,14 @@ export const PartnershipList: FC = () => {
         <PartnershipCard
           key={item?.id ?? index}
           partnership={item}
-          onEdit={() => item && openDialog(item)}
+          onEdit={() => item && openEditDialog(item)}
           className={classes.item}
         />
       ))}
       {partnership && (
-        <EditPartnership {...dialogState} partnership={partnership} />
+        <EditPartnership {...editDialogState} partnership={partnership} />
       )}
+      <CreatePartnership {...createDialogState} projectId={projectId} />
     </div>
   );
 };

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
@@ -20,7 +20,7 @@ fragment PartnershipForm on Partnership {
       value
     }
   }
-  fundingType {
+  financialReportingType {
     value
     canEdit
     canRead

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
@@ -1,0 +1,23 @@
+fragment PartnershipForm on Partnership {
+  id
+  types {
+    value
+    canEdit
+  }
+  agreementStatus {
+    value
+    canEdit
+  }
+  mouStatus {
+    value
+    canEdit
+  }
+  organization {
+    name {
+      value
+    }
+  }
+  fundingType {
+    value
+  }
+}

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
@@ -3,14 +3,17 @@ fragment PartnershipForm on Partnership {
   types {
     value
     canEdit
+    canRead
   }
   agreementStatus {
     value
     canEdit
+    canRead
   }
   mouStatus {
     value
     canEdit
+    canRead
   }
   organization {
     name {
@@ -19,5 +22,7 @@ fragment PartnershipForm on Partnership {
   }
   fundingType {
     value
+    canEdit
+    canRead
   }
 }

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -1,0 +1,105 @@
+import { Box } from '@material-ui/core';
+import React from 'react';
+import { useFormState } from 'react-final-form';
+import {
+  displayPartnershipFundingType,
+  displayPartnershipStatus,
+  PartnershipFundingTypeList,
+  PartnershipStatuses,
+  PartnershipType,
+  UpdatePartnershipInput,
+} from '../../../api';
+import {
+  DialogForm,
+  DialogFormProps,
+} from '../../../components/Dialog/DialogForm';
+import {
+  CheckboxesField,
+  CheckboxOption,
+  RadioField,
+  RadioOption,
+  SubmitError,
+} from '../../../components/form';
+import { Nullable } from '../../../util';
+import { PartnershipFormFragment } from './PartnershipForm.generated';
+
+export type PartnershipFormProps<T> = DialogFormProps<T> & {
+  partnership?: PartnershipFormFragment;
+};
+
+export const hasManagingType = (types: Nullable<readonly PartnershipType[]>) =>
+  types?.includes('Managing') ?? false;
+
+export const PartnershipForm = <T extends any>({
+  partnership,
+  ...rest
+}: PartnershipFormProps<T>) => {
+  const radioOptions = PartnershipStatuses.map((status) => (
+    <RadioOption
+      key={status}
+      label={displayPartnershipStatus(status)}
+      value={status}
+    />
+  ));
+
+  return (
+    <DialogForm<T> {...rest}>
+      <SubmitError />
+      <CheckboxesField
+        name="partnership.types"
+        label="Types"
+        row
+        disabled={!partnership?.types.canEdit}
+      >
+        {([
+          'Managing',
+          'Funding',
+          'Impact',
+          'Technical',
+          'Resource',
+        ] as PartnershipType[]).map((type: PartnershipType) => (
+          <Box width="50%" key={type}>
+            <CheckboxOption key={type} label={type} value={type} />
+          </Box>
+        ))}
+      </CheckboxesField>
+      <FundingType />
+      <RadioField
+        name="partnership.agreementStatus"
+        label="Agreement Status"
+        disabled={!partnership?.agreementStatus.canEdit}
+      >
+        {radioOptions}
+      </RadioField>
+      <RadioField
+        name="partnership.mouStatus"
+        label="Mou Status"
+        disabled={!partnership?.mouStatus.canEdit}
+      >
+        {radioOptions}
+      </RadioField>
+    </DialogForm>
+  );
+};
+
+const FundingType = () => {
+  const { values } = useFormState<UpdatePartnershipInput>();
+  const managingTypeSelected = hasManagingType(values.partnership.types);
+
+  return managingTypeSelected ? (
+    <RadioField
+      name="partnership.fundingType"
+      label="Funding Type"
+      fullWidth
+      row
+    >
+      {PartnershipFundingTypeList.map((type) => (
+        <RadioOption
+          key={type}
+          value={type}
+          label={displayPartnershipFundingType(type)}
+        />
+      ))}
+    </RadioField>
+  ) : null;
+};

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -47,7 +47,7 @@ export const PartnershipForm = <
   ));
 
   return (
-    <DialogForm<T> {...rest}>
+    <DialogForm<T> {...rest} fieldsPrefix="partnership">
       <SubmitError />
       {!partnership && (
         <OrganizationField

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -3,9 +3,10 @@ import { useFormState } from 'react-final-form';
 import {
   displayPartnershipFundingType,
   displayPartnershipStatus,
+  PartnershipAgreementStatusList,
   PartnershipFundingTypeList,
-  PartnershipStatuses,
   PartnershipType,
+  PartnershipTypeList,
 } from '../../../api';
 import {
   DialogForm,
@@ -37,7 +38,8 @@ export const PartnershipForm = <
   partnership,
   ...rest
 }: PartnershipFormProps<T>) => {
-  const radioOptions = PartnershipStatuses.map((status) => (
+  console.log('partnership', partnership);
+  const radioOptions = PartnershipAgreementStatusList.map((status) => (
     <RadioOption
       key={status}
       label={displayPartnershipStatus(status)}
@@ -49,10 +51,7 @@ export const PartnershipForm = <
     <DialogForm<T> {...rest} fieldsPrefix="partnership">
       <SubmitError />
       {!partnership && (
-        <OrganizationField
-          name="partnership.organizationId"
-          required
-        />
+        <OrganizationField name="partnership.organizationId" required />
       )}
       <CheckboxesField
         name="partnership.types"
@@ -60,13 +59,7 @@ export const PartnershipForm = <
         row
         disabled={partnership ? !partnership.types.canEdit : false}
       >
-        {([
-          'Managing',
-          'Funding',
-          'Impact',
-          'Technical',
-          'Resource',
-        ] as PartnershipType[]).map((type: PartnershipType) => (
+        {PartnershipTypeList.map((type: PartnershipType) => (
           <div style={{ width: '50%' }} key={type}>
             <CheckboxOption key={type} label={type} value={type} />
           </div>

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -52,7 +52,6 @@ export const PartnershipForm = <
       {!partnership && (
         <OrganizationField
           name="partnership.organizationId"
-          label="Organization"
           required
         />
       )}

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -20,7 +20,9 @@ import {
   RadioOption,
   SubmitError,
 } from '../../../components/form';
+import { OrganizationField } from '../../../components/form/Lookup';
 import { Nullable } from '../../../util';
+import { CreatePartnershipFormInput } from '../Create';
 import { PartnershipFormFragment } from './PartnershipForm.generated';
 
 export type PartnershipFormProps<T> = DialogFormProps<T> & {
@@ -30,7 +32,9 @@ export type PartnershipFormProps<T> = DialogFormProps<T> & {
 export const hasManagingType = (types: Nullable<readonly PartnershipType[]>) =>
   types?.includes('Managing') ?? false;
 
-export const PartnershipForm = <T extends any>({
+export const PartnershipForm = <
+  T extends CreatePartnershipFormInput | UpdatePartnershipInput
+>({
   partnership,
   ...rest
 }: PartnershipFormProps<T>) => {
@@ -45,11 +49,18 @@ export const PartnershipForm = <T extends any>({
   return (
     <DialogForm<T> {...rest}>
       <SubmitError />
+      {!partnership && (
+        <OrganizationField
+          name="partnership.organizationId"
+          label="Organization"
+          required
+        />
+      )}
       <CheckboxesField
         name="partnership.types"
         label="Types"
         row
-        disabled={!partnership?.types.canEdit}
+        disabled={partnership ? !partnership.types.canEdit : false}
       >
         {([
           'Managing',
@@ -63,27 +74,33 @@ export const PartnershipForm = <T extends any>({
           </Box>
         ))}
       </CheckboxesField>
-      <FundingType />
-      <RadioField
-        name="partnership.agreementStatus"
-        label="Agreement Status"
-        disabled={!partnership?.agreementStatus.canEdit}
-      >
-        {radioOptions}
-      </RadioField>
-      <RadioField
-        name="partnership.mouStatus"
-        label="Mou Status"
-        disabled={!partnership?.mouStatus.canEdit}
-      >
-        {radioOptions}
-      </RadioField>
+      <FundingType<T> />
+      {partnership && (
+        <>
+          <RadioField
+            name="partnership.agreementStatus"
+            label="Agreement Status"
+            disabled={!partnership.agreementStatus.canEdit}
+          >
+            {radioOptions}
+          </RadioField>
+          <RadioField
+            name="partnership.mouStatus"
+            label="Mou Status"
+            disabled={!partnership.mouStatus.canEdit}
+          >
+            {radioOptions}
+          </RadioField>
+        </>
+      )}
     </DialogForm>
   );
 };
 
-const FundingType = () => {
-  const { values } = useFormState<UpdatePartnershipInput>();
+const FundingType = <
+  InputType extends CreatePartnershipFormInput | UpdatePartnershipInput
+>() => {
+  const { values } = useFormState<InputType>();
   const managingTypeSelected = hasManagingType(values.partnership.types);
 
   return managingTypeSelected ? (

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -7,7 +7,6 @@ import {
   PartnershipFundingTypeList,
   PartnershipStatuses,
   PartnershipType,
-  UpdatePartnershipInput,
 } from '../../../api';
 import {
   DialogForm,
@@ -23,6 +22,7 @@ import {
 import { OrganizationField } from '../../../components/form/Lookup';
 import { Nullable } from '../../../util';
 import { CreatePartnershipFormInput } from '../Create';
+import { EditPartnershipFormInput } from '../Edit';
 import { PartnershipFormFragment } from './PartnershipForm.generated';
 
 export type PartnershipFormProps<T> = DialogFormProps<T> & {
@@ -33,7 +33,7 @@ export const hasManagingType = (types: Nullable<readonly PartnershipType[]>) =>
   types?.includes('Managing') ?? false;
 
 export const PartnershipForm = <
-  T extends CreatePartnershipFormInput | UpdatePartnershipInput
+  T extends CreatePartnershipFormInput | EditPartnershipFormInput
 >({
   partnership,
   ...rest
@@ -98,7 +98,7 @@ export const PartnershipForm = <
 };
 
 const FundingType = <
-  InputType extends CreatePartnershipFormInput | UpdatePartnershipInput
+  InputType extends CreatePartnershipFormInput | EditPartnershipFormInput
 >() => {
   const { values } = useFormState<InputType>();
   const managingTypeSelected = hasManagingType(values.partnership.types);

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@material-ui/core';
 import React from 'react';
 import { useFormState } from 'react-final-form';
 import {
@@ -68,9 +67,9 @@ export const PartnershipForm = <
           'Technical',
           'Resource',
         ] as PartnershipType[]).map((type: PartnershipType) => (
-          <Box width="50%" key={type}>
+          <div style={{ width: '50%' }} key={type}>
             <CheckboxOption key={type} label={type} value={type} />
-          </Box>
+          </div>
         ))}
       </CheckboxesField>
       <FundingType<T> />

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -17,6 +17,7 @@ import {
   CheckboxOption,
   RadioField,
   RadioOption,
+  SecuredField,
   SubmitError,
 } from '../../../components/form';
 import { OrganizationField } from '../../../components/form/Lookup';
@@ -47,41 +48,46 @@ export const PartnershipForm = <
     />
   ));
 
+  const typesCheckboxes = PartnershipTypeList.map((type: PartnershipType) => (
+    <div style={{ width: '50%' }} key={type}>
+      <CheckboxOption key={type} label={type} value={type} />
+    </div>
+  ));
+
   return (
     <DialogForm<T> {...rest} fieldsPrefix="partnership">
       <SubmitError />
-      {!partnership && (
-        <OrganizationField name="partnership.organizationId" required />
+      {!partnership && <OrganizationField name="organizationId" required />}
+      {partnership ? (
+        <SecuredField obj={partnership} name="types">
+          {(props) => (
+            <CheckboxesField label="Types" row {...props}>
+              {typesCheckboxes}
+            </CheckboxesField>
+          )}
+        </SecuredField>
+      ) : (
+        <CheckboxesField label="Types" row name="types">
+          {typesCheckboxes}
+        </CheckboxesField>
       )}
-      <CheckboxesField
-        name="partnership.types"
-        label="Types"
-        row
-        disabled={partnership ? !partnership.types.canEdit : false}
-      >
-        {PartnershipTypeList.map((type: PartnershipType) => (
-          <div style={{ width: '50%' }} key={type}>
-            <CheckboxOption key={type} label={type} value={type} />
-          </div>
-        ))}
-      </CheckboxesField>
-      <FundingType<T> />
+      <FundingType<T> partnership={partnership} />
       {partnership && (
         <>
-          <RadioField
-            name="partnership.agreementStatus"
-            label="Agreement Status"
-            disabled={!partnership.agreementStatus.canEdit}
-          >
-            {radioOptions}
-          </RadioField>
-          <RadioField
-            name="partnership.mouStatus"
-            label="Mou Status"
-            disabled={!partnership.mouStatus.canEdit}
-          >
-            {radioOptions}
-          </RadioField>
+          <SecuredField obj={partnership} name="agreementStatus">
+            {(props) => (
+              <RadioField label="Agreement Status" {...props}>
+                {radioOptions}
+              </RadioField>
+            )}
+          </SecuredField>
+          <SecuredField obj={partnership} name="mouStatus">
+            {(props) => (
+              <RadioField label="Mou Status" {...props}>
+                {radioOptions}
+              </RadioField>
+            )}
+          </SecuredField>
         </>
       )}
     </DialogForm>
@@ -90,24 +96,35 @@ export const PartnershipForm = <
 
 const FundingType = <
   InputType extends CreatePartnershipFormInput | EditPartnershipFormInput
->() => {
+>({
+  partnership,
+}: {
+  partnership: PartnershipFormProps<InputType>['partnership'];
+}) => {
   const { values } = useFormState<InputType>();
   const managingTypeSelected = hasManagingType(values.partnership.types);
 
+  const radioOptions = PartnershipFundingTypeList.map((type) => (
+    <RadioOption
+      key={type}
+      value={type}
+      label={displayPartnershipFundingType(type)}
+    />
+  ));
+
   return managingTypeSelected ? (
-    <RadioField
-      name="partnership.fundingType"
-      label="Funding Type"
-      fullWidth
-      row
-    >
-      {PartnershipFundingTypeList.map((type) => (
-        <RadioOption
-          key={type}
-          value={type}
-          label={displayPartnershipFundingType(type)}
-        />
-      ))}
-    </RadioField>
+    partnership ? (
+      <SecuredField obj={partnership} name="fundingType">
+        {(props) => (
+          <RadioField label="Funding Type" fullWidth row {...props}>
+            {radioOptions}
+          </RadioField>
+        )}
+      </SecuredField>
+    ) : (
+      <RadioField name="fundingType" label="Funding Type" fullWidth row>
+        {radioOptions}
+      </RadioField>
+    )
   ) : null;
 };

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useFormState } from 'react-final-form';
 import {
-  displayPartnershipFundingType,
+  displayFinancialReportingType,
   displayPartnershipStatus,
+  FinancialReportingTypeList,
   PartnershipAgreementStatusList,
-  PartnershipFundingTypeList,
   PartnershipType,
   PartnershipTypeList,
 } from '../../../api';
@@ -104,17 +104,17 @@ const FundingType = <
   const { values } = useFormState<InputType>();
   const managingTypeSelected = hasManagingType(values.partnership.types);
 
-  const radioOptions = PartnershipFundingTypeList.map((type) => (
+  const radioOptions = FinancialReportingTypeList.map((type) => (
     <RadioOption
       key={type}
       value={type}
-      label={displayPartnershipFundingType(type)}
+      label={displayFinancialReportingType(type)}
     />
   ));
 
   return managingTypeSelected ? (
     partnership ? (
-      <SecuredField obj={partnership} name="fundingType">
+      <SecuredField obj={partnership} name="financialReportingType">
         {(props) => (
           <RadioField label="Funding Type" fullWidth row {...props}>
             {radioOptions}
@@ -122,7 +122,12 @@ const FundingType = <
         )}
       </SecuredField>
     ) : (
-      <RadioField name="fundingType" label="Funding Type" fullWidth row>
+      <RadioField
+        name="financialReportingType"
+        label="Funding Type"
+        fullWidth
+        row
+      >
         {radioOptions}
       </RadioField>
     )

--- a/src/scenes/Partnerships/PartnershipForm/index.ts
+++ b/src/scenes/Partnerships/PartnershipForm/index.ts
@@ -1,0 +1,2 @@
+export * from './PartnershipForm';
+export * from './PartnershipForm.generated';


### PR DESCRIPTION
Close #405 

- Create a `PartnershipForm` that can be used to either create or update a partnership
- Refactor `EditPartnership` component to consume `PartnershipForm`
- Create `CreatePartnership` component that also consumes `PartnershipForm
- Wire up `CreatePartnership` to "Add" button on `/projects/:projectId/partnerships`
- Add `onlyDirtySubmit={false}` prop to `PartnershipForm` in `EditPartnership` to fix bug preventing partnership from being deleted when no fields in the form have been changed