### PR TITLE
Progressive download of previews for image, audio, and video files

### DIFF
--- a/src/components/files/FilePreview/NativePreview.tsx
+++ b/src/components/files/FilePreview/NativePreview.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core';
-import React, { FC, useCallback, useEffect, useState } from 'react';
-import { PreviewerProps } from './FilePreview';
+import React, { FC } from 'react';
+import { NativePreviewerProps, NativePreviewType } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 
 const useStyles = makeStyles(() => ({
@@ -9,43 +9,18 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export enum NativePreviewType {
-  Video = 'video',
-  Image = 'image',
-  Audio = 'audio',
-}
-
-type NativePreviewProps = PreviewerProps & {
-  type: NativePreviewType;
-};
-
-export const NativePreview: FC<NativePreviewProps> = (props) => {
+export const NativePreview: FC<NativePreviewerProps> = (props) => {
   const classes = useStyles();
-  const { file, type, previewLoading, setPreviewLoading } = props;
-  const [url, setUrl] = useState('');
-
-  const createUrlForFile = useCallback(
-    (file: File) => {
-      setUrl(URL.createObjectURL(file));
-      setPreviewLoading(false);
-    },
-    [setPreviewLoading]
-  );
-
-  useEffect(() => {
-    if (file) {
-      void createUrlForFile(file);
-    }
-  }, [file, createUrlForFile]);
+  const { file, type, previewLoading } = props;
 
   const unsupportedTypeMessage =
     'Your browser does not support this media type';
 
   const player = (type: NativePreviewType) => {
     return type === NativePreviewType.Image ? (
-      <img src={url} className={classes.media} alt="" />
+      <img src={file} className={classes.media} alt="" />
     ) : type === NativePreviewType.Audio ? (
-      <audio controls autoPlay src={url}>
+      <audio controls autoPlay src={file}>
         {unsupportedTypeMessage}
       </audio>
     ) : (
@@ -55,11 +30,11 @@ export const NativePreview: FC<NativePreviewProps> = (props) => {
         autoPlay
         controlsList="nodownload"
       >
-        <source src={url} />
+        <source src={file} />
         {unsupportedTypeMessage}
       </video>
     );
   };
 
-  return previewLoading ? <PreviewLoading /> : url ? player(type) : null;
+  return previewLoading ? <PreviewLoading /> : file ? player(type) : null;
 };

--- a/src/components/files/fileTypes.ts
+++ b/src/components/files/fileTypes.ts
@@ -827,13 +827,13 @@ const previewableTypes = fileTypes.filter((type) => type.previewSupported);
 export type PreviewableMimeType = typeof previewableTypes[number]['mimeType'];
 
 export const previewableImageTypes = previewableTypes.filter(
-  (type) => type.Icon === ImageIcon
+  (type) => type.Icon === ImageIcon && type.previewSupported
 );
 export const previewableAudioTypes = previewableTypes.filter(
-  (type) => type.Icon === AudioIcon
+  (type) => type.Icon === AudioIcon && type.previewSupported
 );
 export const previewableVideoTypes = previewableTypes.filter(
-  (type) => type.Icon === VideoIcon
+  (type) => type.Icon === VideoIcon && type.previewSupported
 );
 
 export const fileIcon = (mimeType: string) => {


### PR DESCRIPTION
Closes #422 

We'll be letting the HTML tags for these types handle the downloading of the source file from our presigned URL instead of first downloading the file, passing it to the `NativePreview` component, then creating a local URL to feed to the tag. This will let the HTML tag start playback as soon as it's able to, based on download state.

We primarily wanted this for videos, because their large file size can make wait times pretty long if playback can't start until the file is completely downloaded. Unfortunately, results will probably still be mixed. This PR removes the obstacles to progressive playback, but if a video file doesn't put its metadata at the front of the file, the player still won't be able to play right away. This is outside of our control, but it's good to set expectations.

- Add logic to `FilePreview` to skip pre-downloading the file for one of the
      above types, instead letting the rendered HTML tag handle download
- Update props for `NativePreview` to take a `string` value for `file` instead
      of `File`
- Update `NativePreview` component to pass `file` prop directly to HTML tags
- Add stricter logic for returning image, audio, and video types that are previewable by user