### PR TITLE
Form Fixes & Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clsx": "^1.1.1",
     "constate": "^2.0.0",
     "final-form": "patch:final-form@4.20.1#./patches/final-form.patch",
+    "final-form-calculate": "patch:final-form-calculate@1.3.2#./patches/final-form-calculate.patch",
     "history": "^5.0.0",
     "html-react-parser": "^0.13.0",
     "lodash": "^4.17.19",

--- a/patches/final-form-calculate.patch
+++ b/patches/final-form-calculate.patch
@@ -1,0 +1,41 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index a4c76ad06d0d80d9ede2373f7502f5340b70e87c..57ca07af05e9c5e9904db998849f0f1bcf40a7ec 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -4,25 +4,25 @@ export type FieldName = string
+ 
+ export type FieldPattern = FieldName | RegExp | FieldName[]
+ 
+-export type UpdatesByName = {
+-  [FieldName: string]: (value: any, allValues?: Object, prevValues?: Object) => any
++export type UpdatesByName<FormValues> = {
++  [FieldName: string]: (value: any, allValues: FormValues, prevValues: FormValues) => any
+ }
+ 
+-export type UpdatesForAll = (
++export type UpdatesForAll<FormValues> = (
+   value: any,
+   field: string,
+-  allValues?: Object,
+-  prevValues?: Object,
++  allValues?: FormValues,
++  prevValues?: FormValues,
+ ) => { [FieldName: string]: any }
+ 
+-export type Updates = UpdatesByName | UpdatesForAll
++export type Updates<FormValues> = UpdatesByName<FormValues> | UpdatesForAll<FormValues>
+ 
+-export type Calculation = {
++export type Calculation<FormValues> = {
+   field: FieldPattern,
+-  updates: Updates,
++  updates: Updates<FormValues>,
+   isEqual?: (a: any, b: any) => boolean,
+ }
+ 
+-export default function createDecorator(
+-  ...calculations: Calculation[]
+-): Decorator
++export default function createDecorator<FormValues, InitialFormValues = Partial<FormValues>>(
++  ...calculations: Calculation<FormValues>[]
++): Decorator<FormValues, InitialFormValues>

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -10,8 +10,13 @@ import {
 } from '@material-ui/core';
 import { FormApi } from 'final-form';
 import React, { ReactNode } from 'react';
-import { Form, FormProps, RenderableProps } from 'react-final-form';
-import { Promisable } from 'type-fest';
+import {
+  Form,
+  FormProps,
+  FormRenderProps,
+  RenderableProps,
+} from 'react-final-form';
+import { Except, Promisable } from 'type-fest';
 import { ErrorHandlers, handleFormError } from '../../api';
 import {
   blurOnSubmit,
@@ -64,7 +69,9 @@ export type DialogFormProps<T, R = void> = Omit<
   ) => void;
   onExited?: () => void;
   DialogProps?: Omit<DialogProps, 'open' | 'onClose' | 'onExited'>;
-  children?: ReactNode;
+  children?:
+    | ReactNode
+    | ((props: Except<FormRenderProps<T>, 'handleSubmit'>) => ReactNode);
 };
 
 const useStyles = makeStyles(() => ({
@@ -121,7 +128,7 @@ export function DialogForm<T, R = void>({
         }
       }}
     >
-      {({ handleSubmit, submitting, form }) => {
+      {({ handleSubmit, submitting, form, ...rest }) => {
         return (
           <Dialog
             fullWidth
@@ -144,7 +151,11 @@ export function DialogForm<T, R = void>({
               {title ? (
                 <DialogTitle id="dialog-form">{title}</DialogTitle>
               ) : null}
-              <DialogContent>{children}</DialogContent>
+              <DialogContent>
+                {typeof children === 'function'
+                  ? children({ form, submitting, ...rest })
+                  : children}
+              </DialogContent>
               <DialogActions>
                 {leftAction ? (
                   <>

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -20,6 +20,7 @@ import { Except, Promisable } from 'type-fest';
 import { ErrorHandlers, handleFormError } from '../../api';
 import {
   blurOnSubmit,
+  FieldGroup,
   focusFirstFieldRegistered,
   focusFirstFieldWithSubmitError,
   SubmitButton,
@@ -41,6 +42,9 @@ export type DialogFormProps<T, R = void> = Omit<
 
   /** Only call onSubmit if form is dirty, else just close dialog. */
   onlyDirtySubmit?: boolean;
+
+  /** A prefix for all form fields */
+  fieldsPrefix?: string;
 
   /**
    * A bit different than Final Form's onSubmit.
@@ -102,6 +106,7 @@ export function DialogForm<T, R = void>({
   errorHandlers,
   onClose,
   onExited,
+  fieldsPrefix,
   children,
   DialogProps = {},
   onSubmit,
@@ -129,7 +134,7 @@ export function DialogForm<T, R = void>({
       }}
     >
       {({ handleSubmit, submitting, form, ...rest }) => {
-        return (
+        const renderedForm = (
           <Dialog
             fullWidth
             maxWidth="xs"
@@ -184,6 +189,12 @@ export function DialogForm<T, R = void>({
               </DialogActions>
             </form>
           </Dialog>
+        );
+
+        return fieldsPrefix ? (
+          <FieldGroup prefix={fieldsPrefix}>{renderedForm}</FieldGroup>
+        ) : (
+          renderedForm
         );
       }}
     </Form>

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -106,7 +106,7 @@ export function DialogForm<T, R = void>({
   errorHandlers,
   onClose,
   onExited,
-  fieldsPrefix,
+  fieldsPrefix = '',
   children,
   DialogProps = {},
   onSubmit,
@@ -191,10 +191,10 @@ export function DialogForm<T, R = void>({
           </Dialog>
         );
 
-        return fieldsPrefix ? (
-          <FieldGroup prefix={fieldsPrefix}>{renderedForm}</FieldGroup>
-        ) : (
-          renderedForm
+        return (
+          <FieldGroup replace prefix={fieldsPrefix}>
+            {renderedForm}
+          </FieldGroup>
         );
       }}
     </Form>

--- a/src/components/form/FieldGroup.tsx
+++ b/src/components/form/FieldGroup.tsx
@@ -4,11 +4,18 @@ import React, { createContext, FC, useContext } from 'react';
 export const FieldGroupContext = createContext('');
 FieldGroupContext.displayName = 'FieldGroupContext';
 
-export const FieldGroup: FC<{ prefix: string }> = ({ prefix, children }) => (
-  <FieldGroupContext.Provider value={useFieldName(prefix)}>
-    {children}
-  </FieldGroupContext.Provider>
-);
+export const FieldGroup: FC<{ prefix: string; replace?: boolean }> = ({
+  prefix,
+  children,
+  replace,
+}) => {
+  const nested = useFieldName(prefix);
+  return (
+    <FieldGroupContext.Provider value={replace ? prefix : nested}>
+      {children}
+    </FieldGroupContext.Provider>
+  );
+};
 
 export const useFieldName = (name: string) => {
   const prefix = useContext(FieldGroupContext);

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -148,8 +148,8 @@ export function LookupField<
   // Not just for first load, but every network request
   const loading = isNetworkRequestInFlight(networkStatus);
 
-  const [createDialogState, createDialogItem, createDialogValue] = useDialog<
-    string
+  const [createDialogState, createDialogItem, createInitialValues] = useDialog<
+    Partial<CreateFormValues>
   >();
 
   useEffect(() => {
@@ -276,7 +276,10 @@ export function LookupField<
             // Prevent creating while loading
             return;
           }
-          createDialogItem(lastItem);
+          const initialValues: Partial<CreateFormValues> = getInitialValues
+            ? getInitialValues(lastItem)
+            : {};
+          createDialogItem(initialValues);
           // Don't store the new value as a string in FF.
           // Wait till it's successfully created and returned from the API.
           return;
@@ -309,11 +312,7 @@ export function LookupField<
       {CreateDialogForm && (
         <CreateDialogForm
           {...createDialogState}
-          initialValues={
-            getInitialValues && createDialogValue
-              ? getInitialValues(createDialogValue)
-              : undefined
-          }
+          initialValues={createInitialValues}
           onSuccess={(newItem: T) => {
             field.onChange(
               multiple ? [...(field.value as T[]), newItem] : newItem

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -171,7 +171,7 @@ export function LookupField<
     ...(data?.search.items ?? []),
     // Add currently selected items to options so prevent MUI warning
     // They will be hidden via filterSelectedOptions
-    ...((multiple ? field.value : []) as T[]),
+    ...((field.value as T | null) ? [field.value] : []),
   ];
   const autocomplete = (
     <Autocomplete<T, Multiple, DisableClearable, typeof freeSolo>

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -6,10 +6,21 @@ import {
   TextField,
   TextFieldProps,
 } from '@material-ui/core';
-import { Autocomplete, AutocompleteProps, Value } from '@material-ui/lab';
+import {
+  Autocomplete,
+  AutocompleteProps,
+  createFilterOptions,
+  Value,
+} from '@material-ui/lab';
 import { camelCase } from 'camel-case';
-import { last, upperFirst } from 'lodash';
-import React, { ComponentType, useCallback, useEffect, useState } from 'react';
+import { last, uniqBy, upperFirst } from 'lodash';
+import React, {
+  ComponentType,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { Except, SetOptional } from 'type-fest';
 import { isNetworkRequestInFlight } from '../../../api';
 import { useDialog } from '../../Dialog';
@@ -163,12 +174,24 @@ export function LookupField<
   // Only open popup if searching for item & focused
   const open = Boolean(input) && input !== selectedText && meta.active;
 
-  const options = [
-    ...(data?.search.items ?? []),
-    // Add currently selected items to options so prevent MUI warning
-    // They will be hidden via filterSelectedOptions
-    ...((field.value as T | null) ? [field.value] : []),
-  ];
+  // Augment results with currently selected items to indicate that
+  // they are still valid (and to prevent MUI warning)
+  const options = useMemo(() => {
+    const selected = multiple
+      ? (field.value as T[])
+      : (field.value as T | null)
+      ? [field.value as T]
+      : [];
+    if (!data?.search.items.length) {
+      return selected; // optimization for no results
+    }
+
+    const resultsWithCurrent = [...data.search.items, ...selected];
+
+    // Filter out duplicates caused by selected items also appearing in search results.
+    return uniqBy(resultsWithCurrent, getCompareBy);
+  }, [data?.search.items, field.value, getCompareBy, multiple]);
+
   const autocomplete = (
     <Autocomplete<T, Multiple, DisableClearable, typeof freeSolo>
       getOptionSelected={(a, b) => getCompareBy(a) === getCompareBy(b)}
@@ -185,9 +208,6 @@ export function LookupField<
       disabled={disabled}
       // FF also has multiple and defaultValue
       multiple={multiple}
-      // if we only have one value that can and has been selected, we don't
-      // want to hide it in the dropdown if we start deleting characters
-      filterSelectedOptions={multiple || input === selectedText}
       renderTags={(values: T[], getTagProps) =>
         values.map((option: T, index: number) => (
           <Chip
@@ -208,25 +228,31 @@ export function LookupField<
         return getOptionLabel(option);
       }}
       filterOptions={(options, params) => {
-        // If freeSolo we can add new options i.e. 'Add "X"'.
-        if (!freeSolo || loading) return options;
+        // Apply default filtering. Even though the API filters for us, we add
+        // the currently selected options back in because they are still valid
+        // but we don't want to show these options if the don't match the
+        // current input text.
+        // Note: `filterSelectedOptions` could still make sense either way
+        // separate from this code below. It could be thought of as a "stricter"
+        // filter that not only removes unrelated results but also related
+        // results that have already been selected.
+        const filtered = createFilterOptions<T>()(options, params);
 
-        const allOptions = [
-          ...options,
-          // selected option(s)
-          ...(multiple ? (field.value as T[]) : []),
-        ];
-
-        const allLabels = allOptions.map(getOptionLabel);
-
-        if (params.inputValue === '' || allLabels.includes(params.inputValue)) {
-          return options;
+        if (
+          !freeSolo ||
+          loading || // item could be returned with request in flight
+          params.inputValue === '' ||
+          filtered.map(getOptionLabel).includes(params.inputValue)
+        ) {
+          return filtered;
         }
-        // If the freeSolo value doesn't match an existing or previously selected option, add it to the list.
+
+        // If freeSolo is enabled and the input value doesn't match an existing
+        // or previously selected option, add it to the list. i.e. 'Add "X"'.
         return [
-          ...options,
-          // @ts-expect-error We want to allow strings for new options, which may differ from T.
-          // We handle them in renderOption.
+          ...filtered,
+          // @ts-expect-error We want to allow strings for new options,
+          // which may differ from T. We handle them in renderOption.
           params.inputValue as T,
         ];
       }}

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -42,7 +42,10 @@ export type LookupFieldProps<
   FieldConfig<Value<T, Multiple, DisableClearable, false>>,
   'multiple' | 'allowNull' | 'parse' | 'format'
 > &
-  Pick<TextFieldProps, 'helperText' | 'label' | 'required' | 'autoFocus'> & {
+  Pick<
+    TextFieldProps,
+    'helperText' | 'label' | 'required' | 'autoFocus' | 'variant'
+  > & {
     name: string;
     useLookup: LookupQueryHook<T>;
     getCompareBy: (item: T) => any;
@@ -90,6 +93,7 @@ export function LookupField<
   getInitialValues,
   getCompareBy,
   getOptionLabel: getOptionLabelProp,
+  variant,
   ...props
 }: LookupFieldProps<T, Multiple, DisableClearable, CreateFormValues>) {
   const freeSolo = !!CreateDialogForm;
@@ -272,7 +276,7 @@ export function LookupField<
           inputRef={ref}
           error={showError(meta)}
           autoFocus={autoFocus}
-          // variant="outlined" TODO maybe for multiple?
+          variant={variant}
         />
       )}
     />

--- a/src/components/form/util.ts
+++ b/src/components/form/util.ts
@@ -7,6 +7,7 @@ import {
   useRef,
 } from 'react';
 import { FieldMetaState, useFormState } from 'react-final-form';
+import { Nullable } from '../../util';
 
 export const useIsSubmitting = () => {
   const { submitting } = useFormState({ subscription: { submitting: true } });
@@ -72,12 +73,20 @@ export const useFocusOnEnabled = <
   return ref;
 };
 
+export const isEqualBy = <T>(compareBy: (item: T) => any) =>
+  compareNullable<T>((a, b) => compareBy(a) === compareBy(b));
+
+export const isListEqualBy = <T>(compareBy: (item: T) => any) =>
+  compareNullable<T[]>((a, b) =>
+    areListsEqual(a.map(compareBy), b.map(compareBy))
+  );
+
 export const areListsEqual = (a: any, b: any) =>
   isEmpty(difference(a, b)) && isEmpty(difference(b, a));
 
 export const compareNullable = <T>(fn: (a: T, b: T) => boolean) => (
-  a: T,
-  b: T
+  a: Nullable<T>,
+  b: Nullable<T>
 ) => {
   if (a == null && b == null) {
     return true;
@@ -85,5 +94,5 @@ export const compareNullable = <T>(fn: (a: T, b: T) => boolean) => (
   if ((a == null && b) || (a && b == null)) {
     return false;
   }
-  return fn(a, b);
+  return fn(a!, b!);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7372,6 +7372,7 @@ __metadata:
     customize-cra: ^1.0.0
     eslint: ^7.6.0
     final-form: "patch:final-form@4.20.1#./patches/final-form.patch"
+    final-form-calculate: "patch:final-form-calculate@1.3.2#./patches/final-form-calculate.patch"
     graphql: ^15.3.0
     history: ^5.0.0
     html-react-parser: ^0.13.0
@@ -9979,6 +9980,24 @@ __metadata:
   dependencies:
     to-regex-range: ^5.0.1
   checksum: efca43d59b487ad4bc0b2b1cb9e51617c75a7b0159db51fa190c75c3d634ea5fad1ff4750d7c14346add4cd065e3c46e8f99af333edf2b4ec2a424f87e491a85
+  languageName: node
+  linkType: hard
+
+final-form-calculate@1.3.2:
+  version: 1.3.2
+  resolution: "final-form-calculate@npm:1.3.2"
+  peerDependencies:
+    final-form: ">=1.3.0"
+  checksum: 0187994e07cd09585beb08e4be6b97568c3a1e53f24de0bd66ebfa5b843addf514181a5b3e24fda50f64970b59b30492afc39fa3d7d5c5b30122309a7abc8ed7
+  languageName: node
+  linkType: hard
+
+"final-form-calculate@patch:final-form-calculate@1.3.2#./patches/final-form-calculate.patch::locator=cord-field%40workspace%3A.":
+  version: 1.3.2
+  resolution: "final-form-calculate@patch:final-form-calculate@npm%3A1.3.2#./patches/final-form-calculate.patch::version=1.3.2&hash=476077&locator=cord-field%40workspace%3A."
+  peerDependencies:
+    final-form: ">=1.3.0"
+  checksum: 8706985b7b0cbb92327c2aeb24e5324ded59e84ddaa2c23b8f6caf09ee1d189181c2472881b08c932aa61bbd1922aa9860eb9ac097c1fe76e5e6197b8c56f164
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## `DialogForm`

### Now has a `fieldsPrefix` shortcut (2456708)
Instead of
```tsx
<DialogForm>
  <FieldGroup prefix="user">
    ...
  </FieldGroup>
</DialogForm>
```

You can just
```tsx
<DialogForm fieldsPrefix="user">
  ...
</DialogForm>
```

### You can give a render function to children to access form instance & current state (00cce42)
This just like how Final Form's `Form` normally works, except `handleSubmit` is still handled internally.
```tsx
<DialogForm>
  {({ values, form }) => (
    <>
      <TextFIeld name="a" />
      <TextFIeld name="b" disabled={!values.a} />
      <Button onClick={form.reset}>Reset</Button>
    </>
  )}
</DialogForm>
```

### Fixed `FieldGroup` prefixes applying to nested DialogForms (20fe0c4)

Best example right now is the lookup fields which produce another dialog to create items.
i.e. CreateLanguageEngagementDialogForm > LanguageField > CreateLanguageDialogForm
The outer dialog would probably have a prefix of "engagement".
We want the inner form's prefix to be "language" not "engagement.language".

This is achieved by adding a `replace` flag to `FieldGroup`, which might be useful other places.

## LookupField

### variant can be passed through (thanks @frankyma) (8682d6c)

```tsx
<LookupField variant="outlined" />
```

### `isEqual`/`isListEqual` helper functions (468a196)

Each wrapped lookup field already specifies (or defaults) a `getCompareBy` callback. This wraps that into a compare functions and exposes them as static properties for other Final Form needs (i.e. `final-form-calculate` package - more later).

```tsx
UserField.isEqual(userLookupedItemA, userLookupedItemB)
```

### Fixed handling selected & filtered items (1cc9a60)

- Now we always add the currently selected options to `options` list regardless of `multiple` or not.
  This indicates they are still valid and suppresses MUI warning.
- Doing so causes duplicates in list because results from API could have items that are already selected.
  So these are now filtered out with a `uniqBy` call.
- Re-applied the default filtering logic (via `filterOptions`) that was omitted to support our free solo addition.
  This is needed to filter out the currently selected option(s) that don't apply to the current input value.
- `filterSelectedOptions`
  - We were trying to do similar filtering logic conditionally with `filterSelectedOptions`.
  - This was ultimately incorrect, and now that `filterOptions` behaves as expected it's not needed.
  - This flag could still make sense in certain cases, but it should not be based on the current input values.
  - This was previously applied for `multiple` and maybe it still makes sense for this case.
     For multiple=false, if you click on the current selected option in the dropdown nothing happens except the dropdown closing.
     For multiple=true, if you click on a currently selected option, the option is removed which felt bad.
     It could be that we just need to make the selected state more pronounced or just filter them out.
     It's still kinda weird to see "no options" because the thing I'm looking for is already selected.
     @blakekrammes You've done the most work here. Thoughts?

### Fixed create dialog's `initialValues` changing between renders

This is the same bug as noted in #421 
Solved by calculating and storing the `initialValues` as the dialog item state instead of storing the input string and calculating initial values on render.

## Added `final-form-calculate`

Added this library and patched the types to work better with new Final Form generics.

### Situation (Need)
We have a need to make fields respond to other field changes.
Sometimes these are easy. For example, field _b_ is disabled when field _a_ is empty is easy because it always uses the current state.
Other times we need to do side effects - sometime one time in response to another event/effect.
For example, when field _a_ changes reset field _b_ to an empty value. This can't happen on every render.
Our fields are also already _controlled_ by Final Form so hooking into an `onChange` callback isn't possible.

### Solution (for now)

Continuing with the previous example, here's how it could be solved with the calculate library
```tsx
import onFieldChange from 'final-form-calculate';

const decorator = onFieldChange({
  field: 'a',
  updates: {
    'b': (aValue) => null
  },
});

<Form decorators={[decorator]}>
  <Field name="a" />
  <Field name="b" />
</Form>
```

What I like about this is the "form logic" is separate from rendering/styling. And it works well with our current form abstractions.

### Why not hooks?

Great question. This library's solution is native to Final Form but not necessarily to React (Final Form is agnostic to React).
React hooks could be a more performant way or at least more familiar than Final Form decorators for this sort of thing. However, with the way we current do forms, wrapping both Form and Fields, hooks are hard since they aren't available at the component level.
```tsx
useFormAndDoX(); // Form context is not available here as it's not a child of `Form`.
return (
  <Form>
    <Field />
  </Form>
);
```

We could pursue solutions that are more react-y, but that would just be more work and code in this repo. So for now, this library is the best bet. Open to discussion or to revisit in the future though.
