### PR TITLE
Resize Header

### DIFF
--- a/src/scenes/Root/Header/Header.tsx
+++ b/src/scenes/Root/Header/Header.tsx
@@ -6,9 +6,9 @@ import { ProfileToolbar } from './ProfileToolbar';
 
 const useStyles = makeStyles(({ spacing }) => ({
   root: {
-    padding: spacing(4, 4, 0, 4),
+    padding: spacing(4, 4, 1, 4),
     display: 'flex',
-    alignItems: 'baseline',
+    alignItems: 'flex-start',
     justifyContent: 'space-between',
   },
 }));


### PR DESCRIPTION
Give a slight margin to top header so the scroll doesn't touch items.  The original  had a faux header with an empty helper text item but if a helper text did show it would almost touch.
<img width="788" alt="Screen Shot 2020-09-11 at 1 05 41 PM" src="https://user-images.githubusercontent.com/43487134/92968194-85950e80-f42f-11ea-8a05-967885375a4a.png">
