### PR TITLE
Update file version list after adding new version

### DIFF
--- a/src/components/files/FileActions/FileActions.graphql
+++ b/src/components/files/FileActions/FileActions.graphql
@@ -13,7 +13,11 @@ query FileVersions($id: ID!) {
 mutation CreateFileVersion($input: CreateFileVersionInput!) {
   createFileVersion(input: $input) {
     id
-    name
+    children {
+      items {
+        ...FileVersionItem
+      }
+    }
   }
 }
 

--- a/src/components/files/updateCachedVersions.ts
+++ b/src/components/files/updateCachedVersions.ts
@@ -1,0 +1,31 @@
+import { ApolloCache } from '@apollo/client';
+import { FileVersionsDocument, FileVersionsQuery } from './FileActions';
+import { FileNodeInfoFragment } from './files.generated';
+
+export const updateCachedVersions = <MutationData>(
+  cache: ApolloCache<MutationData>,
+  existingVersions: readonly FileNodeInfoFragment[],
+  parentId: string
+) => {
+  const response = cache.readQuery<FileVersionsQuery>({
+    query: FileVersionsDocument,
+    variables: { id: parentId },
+  });
+  if (response) {
+    const updatedData = {
+      ...response,
+      file: {
+        ...response.file,
+        children: {
+          ...response.file.children,
+          items: existingVersions,
+        },
+      },
+    };
+    cache.writeQuery<FileVersionsQuery>({
+      query: FileVersionsDocument,
+      variables: { id: parentId },
+      data: updatedData,
+    });
+  }
+};

--- a/src/components/files/updateCachedVersions.ts
+++ b/src/components/files/updateCachedVersions.ts
@@ -7,12 +7,10 @@ export const updateCachedVersions = <MutationData>(
   existingVersions: readonly FileNodeInfoFragment[],
   parentId: string
 ) => {
-  console.log('parentId', parentId);
   const response = cache.readQuery<FileVersionsQuery>({
     query: FileVersionsDocument,
     variables: { id: parentId },
   });
-  console.log('response', response);
   if (response) {
     const updatedData = {
       ...response,

--- a/src/components/files/updateCachedVersions.ts
+++ b/src/components/files/updateCachedVersions.ts
@@ -7,10 +7,12 @@ export const updateCachedVersions = <MutationData>(
   existingVersions: readonly FileNodeInfoFragment[],
   parentId: string
 ) => {
+  console.log('parentId', parentId);
   const response = cache.readQuery<FileVersionsQuery>({
     query: FileVersionsDocument,
     variables: { id: parentId },
   });
+  console.log('response', response);
   if (response) {
     const updatedData = {
       ...response,

--- a/src/components/files/updateCachedVersions.ts
+++ b/src/components/files/updateCachedVersions.ts
@@ -20,6 +20,7 @@ export const updateCachedVersions = <MutationData>(
           children: {
             ...response.file.children,
             items: existingVersions,
+            total: existingVersions.length,
           },
         },
       };

--- a/src/components/files/updateCachedVersions.ts
+++ b/src/components/files/updateCachedVersions.ts
@@ -7,25 +7,35 @@ export const updateCachedVersions = <MutationData>(
   existingVersions: readonly FileNodeInfoFragment[],
   parentId: string
 ) => {
-  const response = cache.readQuery<FileVersionsQuery>({
-    query: FileVersionsDocument,
-    variables: { id: parentId },
-  });
-  if (response) {
-    const updatedData = {
-      ...response,
-      file: {
-        ...response.file,
-        children: {
-          ...response.file.children,
-          items: existingVersions,
-        },
-      },
-    };
-    cache.writeQuery<FileVersionsQuery>({
+  try {
+    const response = cache.readQuery<FileVersionsQuery>({
       query: FileVersionsDocument,
       variables: { id: parentId },
-      data: updatedData,
     });
+    if (response) {
+      const updatedData = {
+        ...response,
+        file: {
+          ...response.file,
+          children: {
+            ...response.file.children,
+            items: existingVersions,
+          },
+        },
+      };
+      cache.writeQuery<FileVersionsQuery>({
+        query: FileVersionsDocument,
+        variables: { id: parentId },
+        data: updatedData,
+      });
+    }
+  } catch {
+    /**
+     * We need this try/catch because if this data has never been fetched
+     * before, `cache.readQuery` will throw an error instead of returning
+     * anything, which is apparently a behavior the Apollo team finds
+     * acceptable.
+     */
+    return;
   }
 };

--- a/src/scenes/Engagement/Files/UploadEngagementFiles.graphql
+++ b/src/scenes/Engagement/Files/UploadEngagementFiles.graphql
@@ -7,8 +7,12 @@ mutation UploadLanguageEngagementPnp(
       id
       pnp {
         value {
-          id
-          name
+          ...FileNodeInfo
+          children {
+            items {
+              ...FileNodeInfo
+            }
+          }
         }
       }
     }
@@ -26,8 +30,12 @@ mutation UploadInternshipEngagementGrowthPlan(
       id
       growthPlan {
         value {
-          id
-          name
+          ...FileNodeInfo
+          children {
+            items {
+              ...FileNodeInfo
+            }
+          }
         }
       }
     }

--- a/src/scenes/Engagement/Files/useUploadEngagementFiles.ts
+++ b/src/scenes/Engagement/Files/useUploadEngagementFiles.ts
@@ -56,7 +56,6 @@ export const useUploadEngagementFile = (
                   const pnp =
                     data.updateLanguageEngagement.engagement.pnp.value;
                   if (pnp) {
-                    console.log('pnp', pnp);
                     const existingVersions = pnp.children.items;
                     updateCachedVersions(cache, existingVersions, pnp.id);
                   }

--- a/src/scenes/Engagement/Files/useUploadEngagementFiles.ts
+++ b/src/scenes/Engagement/Files/useUploadEngagementFiles.ts
@@ -1,27 +1,39 @@
-import { GQLOperations } from '../../../api';
+import { useMutation } from '@apollo/client';
 import {
   HandleUploadCompletedFunction,
   UploadFilesConsumerFunction,
   UploadFilesConsumerInput,
   useUploadFiles,
 } from '../../../components/files/hooks';
+import { updateCachedVersions } from '../../../components/files/updateCachedVersions';
 import {
-  useUploadInternshipEngagementGrowthPlanMutation,
-  useUploadLanguageEngagementPnpMutation,
+  UploadInternshipEngagementGrowthPlanDocument,
+  UploadInternshipEngagementGrowthPlanMutation,
+  UploadLanguageEngagementPnpDocument,
+  UploadLanguageEngagementPnpMutation,
 } from './UploadEngagementFiles.generated';
 
 type EngagementType = 'language' | 'internship';
+
+const isLanguageEngagementMutation = (
+  data:
+    | UploadInternshipEngagementGrowthPlanMutation
+    | UploadLanguageEngagementPnpMutation
+): data is UploadLanguageEngagementPnpMutation =>
+  'updateLanguageEngagement' in data;
 
 export const useUploadEngagementFile = (
   engagementType: EngagementType
 ): UploadFilesConsumerFunction => {
   const uploadFiles = useUploadFiles();
-
-  const [uploadPnp] = useUploadLanguageEngagementPnpMutation();
-  const [uploadGrowthPlan] = useUploadInternshipEngagementGrowthPlanMutation();
-
-  const uploadFile =
-    engagementType === 'language' ? uploadPnp : uploadGrowthPlan;
+  const MutationDocument =
+    engagementType === 'language'
+      ? UploadLanguageEngagementPnpDocument
+      : UploadInternshipEngagementGrowthPlanDocument;
+  const [uploadFile] = useMutation<
+    | UploadLanguageEngagementPnpMutation
+    | UploadInternshipEngagementGrowthPlanMutation
+  >(MutationDocument);
 
   const handleUploadCompleted: HandleUploadCompletedFunction = async ({
     uploadId,
@@ -35,11 +47,33 @@ export const useUploadEngagementFile = (
         pnp: { uploadId, name },
         growthPlan: { uploadId, name },
       },
-      refetchQueries: [
-        action === 'version'
-          ? GQLOperations.Query.FileVersions
-          : GQLOperations.Query.Engagement,
-      ],
+      update:
+        action !== 'version'
+          ? undefined
+          : (cache, { data }) => {
+              if (data) {
+                if (isLanguageEngagementMutation(data)) {
+                  const pnp =
+                    data.updateLanguageEngagement.engagement.pnp.value;
+                  if (pnp) {
+                    console.log('pnp', pnp);
+                    const existingVersions = pnp.children.items;
+                    updateCachedVersions(cache, existingVersions, pnp.id);
+                  }
+                } else {
+                  const growthPlan =
+                    data.updateInternshipEngagement.engagement.growthPlan.value;
+                  if (growthPlan) {
+                    const existingVersions = growthPlan.children.items;
+                    updateCachedVersions(
+                      cache,
+                      existingVersions,
+                      growthPlan.id
+                    );
+                  }
+                }
+              }
+            },
     });
   };
 

--- a/src/scenes/Projects/Budget/ProjectBudget.graphql
+++ b/src/scenes/Projects/Budget/ProjectBudget.graphql
@@ -66,8 +66,12 @@ mutation UpdateProjectBudgetUniversalTemplate(
       id
       universalTemplateFile {
         value {
-          id
-          name
+          ...FileNodeInfo
+          children {
+            items {
+              ...FileNodeInfo
+            }
+          }
         }
       }
     }

--- a/src/scenes/Projects/Budget/ProjectBudget.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudget.tsx
@@ -50,6 +50,7 @@ export const ProjectBudget = () => {
   );
 
   const template = budget?.value?.universalTemplateFile;
+  console.log('template', template);
 
   return (
     <Content>

--- a/src/scenes/Projects/Budget/ProjectBudget.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudget.tsx
@@ -16,7 +16,6 @@ import { ProjectBudgetRecords } from './ProjectBudgetRecords';
 
 const useStyles = makeStyles(({ breakpoints, spacing }) => ({
   header: {
-    margin: spacing(3, 0),
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'flex-end',
@@ -50,7 +49,6 @@ export const ProjectBudget = () => {
   );
 
   const template = budget?.value?.universalTemplateFile;
-  console.log('template', template);
 
   return (
     <Content>

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -360,7 +360,7 @@ const ProjectFilesListWrapped: FC = () => {
 };
 
 export const ProjectFilesList: FC = () => (
-  <FileActionsContextProvider context="project">
+  <FileActionsContextProvider>
     <ProjectFilesListWrapped />
   </FileActionsContextProvider>
 );

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -360,7 +360,7 @@ const ProjectFilesListWrapped: FC = () => {
 };
 
 export const ProjectFilesList: FC = () => (
-  <FileActionsContextProvider>
+  <FileActionsContextProvider context="project">
     <ProjectFilesListWrapped />
   </FileActionsContextProvider>
 );

--- a/src/scenes/Projects/Files/useUploadProjectFiles.ts
+++ b/src/scenes/Projects/Files/useUploadProjectFiles.ts
@@ -69,11 +69,22 @@ export const useUploadBudgetFile = (): UploadFilesConsumerFunction => {
         id,
         universalTemplateFile: { uploadId, name },
       },
-      refetchQueries: [
-        action === 'version'
-          ? GQLOperations.Query.FileVersions
-          : GQLOperations.Query.ProjectBudget,
-      ],
+      refetchQueries:
+        action === 'file' ? [GQLOperations.Query.ProjectBudget] : undefined,
+      update:
+        action !== 'version'
+          ? undefined
+          : (cache, { data }) => {
+              const template =
+                data?.updateBudget.budget.universalTemplateFile.value;
+              if (template) {
+                updateCachedVersions(
+                  cache,
+                  template.children.items,
+                  template.id
+                );
+              }
+            },
     });
   };
 

--- a/src/scenes/Projects/Files/useUploadProjectFiles.ts
+++ b/src/scenes/Projects/Files/useUploadProjectFiles.ts
@@ -1,5 +1,9 @@
 import { GQLOperations } from '../../../api';
-import { useCreateFileVersionMutation } from '../../../components/files/FileActions';
+import {
+  FileVersionsDocument,
+  FileVersionsQuery,
+  useCreateFileVersionMutation,
+} from '../../../components/files/FileActions';
 import {
   HandleUploadCompletedFunction,
   UploadFilesConsumerFunction,
@@ -30,6 +34,31 @@ export const useUploadProjectFiles = (): UploadFilesConsumerFunction => {
           ? GQLOperations.Query.FileVersions
           : GQLOperations.Query.ProjectDirectory,
       ],
+      update: (cache, { data }) => {
+        const response = cache.readQuery<FileVersionsQuery>({
+          query: FileVersionsDocument,
+          variables: { id: parentId },
+        });
+        if (data?.createFileVersion && response) {
+          const updatedVersions = data.createFileVersion.children.items;
+          const updatedData = {
+            ...response,
+            file: {
+              ...response.file,
+              children: {
+                ...response.file.children,
+                items: updatedVersions,
+              },
+            },
+          };
+          console.log('updatedData', updatedData);
+          cache.writeQuery<FileVersionsQuery>({
+            query: FileVersionsDocument,
+            variables: { id: parentId },
+            data: updatedData,
+          });
+        }
+      },
     });
   };
 


### PR DESCRIPTION
When adding a new version of a Project File or Defined File, the list of file versions was not refreshing in the UI until after a page reload because we were relying on `refetchQueries`. But `refetchQueries` only refreshes "live" queries, meaning those currently being used in mounted components. Since the `FileVersions` component is not mounted when a new version is added, `refetchQueries` did not serve our purpose.

Instead, we now call the `update` method of all mutations that add new file versions. This creates an `updateCachedVersions` function that can be passed the Apollo `cache` instance provided by the `update` method, the new array of `FileVersion`s, and the `id` of the file whose versions need to be updated. We also update all relevant mutations to use this function.