### PR TITLE
Refactor session handling to use plain Apollo cache

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,9 @@
 import { addDecorator, addParameters } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { HashRouter } from 'react-router-dom';
-import React, { createElement, Fragment } from 'react';
+import { createElement, Fragment } from 'react';
 import { appProviders } from '../src/App';
 import { Nest } from '../src/components/Nest';
-import { SessionProvider } from '../src/components/Session';
 
 // Do hacking to show dates easier
 import '../src/util/CalenderDate';
@@ -12,13 +11,9 @@ import '../src/util/hacky-inspect-dates';
 
 addDecorator(withInfo);
 
-const storybookProviders = [
-  createElement(HashRouter),
-  ...appProviders,
-  createElement(SessionProvider, { user: null }),
-];
+const storybookProviders = [createElement(HashRouter), ...appProviders];
 
-addDecorator(story => {
+addDecorator((story) => {
   // render story with contexts provided here.
   // if story fn is called directly it won't be a child the providers
   // defined here and thus contexts will not be provided.
@@ -27,7 +22,7 @@ addDecorator(story => {
   return createElement(
     Nest,
     { elements: storybookProviders },
-    createElement(Story),
+    createElement(Story)
   );
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ApolloProvider } from './api';
 import { Nest } from './components/Nest';
-import { SessionProvider } from './components/Session';
 import { SnackbarProvider } from './components/Snackbar';
 import { TitleProvider } from './components/title';
 import { UploadManagerProvider, UploadProvider } from './components/Upload';
@@ -27,7 +26,6 @@ export const appProviders = [
   <LocalizationProvider dateAdapter={LuxonUtils} children={<></>} />,
   <SnackbarProvider />,
   <ApolloProvider />,
-  <SessionProvider />,
   <UploadManagerProvider />,
   <UploadProvider />,
 ];

--- a/src/components/Upload/UploadManager.tsx
+++ b/src/components/Upload/UploadManager.tsx
@@ -119,7 +119,7 @@ interface UploadManagerProps {
 
 const UploadManagerImpl = (props: UploadManagerProps) => {
   const { children, removeCompletedUploads } = props;
-  const [session] = useSession();
+  const { session } = useSession();
   const { isManagerOpen, setIsManagerOpen } = useUploadManager();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const classes = useStyles();

--- a/src/scenes/Authentication/Authentication.tsx
+++ b/src/scenes/Authentication/Authentication.tsx
@@ -44,7 +44,7 @@ export const Authentication: FC = ({ children }) => {
   const classes = useStyles();
   const location = useLocation();
   const navigate = useNavigate();
-  const [session, sessionLoading] = useSession();
+  const { session, sessionLoading } = useSession();
 
   const matched = useRoutes([
     {

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Except } from 'type-fest';
 import { handleFormError } from '../../../api';
-import { useSession } from '../../../components/Session';
+import { updateSessionCache, useSession } from '../../../components/Session';
 import { useLoginMutation } from './Login.generated';
 import { LoginForm, LoginFormProps as Props } from './LoginForm';
 
@@ -11,7 +11,7 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
   const [login] = useLoginMutation();
   const navigate = useNavigate();
   const [query] = useSearchParams();
-  const [session, sessionLoading, setUserSession] = useSession();
+  const { session, sessionLoading } = useSession();
   const [success, setSuccess] = useState(false);
 
   // Redirect to homepage if already logged in (and not from successful login)
@@ -23,11 +23,16 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
 
   const submit: Props['onSubmit'] = async (input) => {
     try {
-      const { data } = await login({
+      await login({
         variables: { input },
+        update: (cache, { data }) => {
+          const user = data?.login.user;
+          if (user) {
+            updateSessionCache(cache, user);
+          }
+        },
       });
       setSuccess(true);
-      setUserSession(data!.login.user);
       const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
       navigate(returnTo, { replace: true });
     } catch (e) {

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -28,11 +28,11 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
         update: (cache, { data }) => {
           const user = data?.login.user;
           if (user) {
+            setSuccess(true);
             updateSessionCache(cache, user);
           }
         },
       });
-      setSuccess(true);
       const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
       navigate(returnTo, { replace: true });
     } catch (e) {

--- a/src/scenes/Authentication/Logout/Logout.tsx
+++ b/src/scenes/Authentication/Logout/Logout.tsx
@@ -11,11 +11,11 @@ export const Logout = () => {
   const [logout] = useLogoutMutation();
 
   useEffect(() => {
-    void logout().then(() =>
-      client.resetStore().then(() => {
+    void logout()
+      .then(() => client.resetStore())
+      .then(() => {
         navigate('/login', { replace: true });
-      })
-    );
+      });
   }, [logout, client, navigate]);
 
   return <CircularProgress />;

--- a/src/scenes/Authentication/Logout/Logout.tsx
+++ b/src/scenes/Authentication/Logout/Logout.tsx
@@ -3,23 +3,20 @@ import { CircularProgress } from '@material-ui/core';
 import * as React from 'react';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSession } from '../../../components/Session';
 import { useLogoutMutation } from './logout.generated';
 
 export const Logout = () => {
   const navigate = useNavigate();
   const client = useApolloClient();
   const [logout] = useLogoutMutation();
-  const [, , setCurrentUser] = useSession();
 
   useEffect(() => {
-    void logout()
-      .then(() => client.resetStore())
-      .then(() => {
-        setCurrentUser(null);
+    void logout().then(() =>
+      client.resetStore().then(() => {
         navigate('/login', { replace: true });
-      });
-  }, [logout, client, setCurrentUser, navigate]);
+      })
+    );
+  }, [logout, client, navigate]);
 
   return <CircularProgress />;
 };

--- a/src/scenes/Authentication/Register/Register.tsx
+++ b/src/scenes/Authentication/Register/Register.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Except } from 'type-fest';
 import { handleFormError } from '../../../api';
-import { useSession } from '../../../components/Session';
+import { updateSessionCache, useSession } from '../../../components/Session';
 import { useRegisterMutation } from './register.generated';
 import { RegisterFormProps as Props, RegisterForm } from './RegisterForm';
 
@@ -11,7 +11,7 @@ export const Register = (props: Except<Props, 'onSubmit'>) => {
   const [register] = useRegisterMutation();
   const navigate = useNavigate();
   const [query] = useSearchParams();
-  const [session, sessionLoading, setUserSession] = useSession();
+  const { session, sessionLoading } = useSession();
   const [success, setSuccess] = useState(false);
 
   // Redirect to homepage if already logged in (and not from successful login)
@@ -23,16 +23,21 @@ export const Register = (props: Except<Props, 'onSubmit'>) => {
 
   const submit: Props['onSubmit'] = async ({ confirmPassword, ...input }) => {
     try {
-      const { data } = await register({
+      await register({
         variables: {
           input: {
             ...input,
             timezone: DateTime.local().zone.name,
           },
         },
+        update: (cache, { data }) => {
+          const user = data?.register.user;
+          if (user) {
+            updateSessionCache(cache, user);
+          }
+        },
       });
       setSuccess(true);
-      setUserSession(data!.register.user);
       const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
       navigate(returnTo, { replace: true });
     } catch (e) {

--- a/src/scenes/Authentication/Register/Register.tsx
+++ b/src/scenes/Authentication/Register/Register.tsx
@@ -33,11 +33,11 @@ export const Register = (props: Except<Props, 'onSubmit'>) => {
         update: (cache, { data }) => {
           const user = data?.register.user;
           if (user) {
+            setSuccess(true);
             updateSessionCache(cache, user);
           }
         },
       });
-      setSuccess(true);
       const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
       navigate(returnTo, { replace: true });
     } catch (e) {

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles(({ typography, spacing }) => ({
 
 export const ProfileToolbar: FC = () => {
   const classes = useStyles();
-  const [session] = useSession();
+  const { session } = useSession();
   const [profileAnchor, setProfileAnchor] = useState<MenuProps['anchorEl']>();
   const [actionsAnchor, setActionsAnchor] = useState<MenuProps['anchorEl']>();
 


### PR DESCRIPTION
We were creating a local-state context in which to keep the `user` values returned on login or registration, which meant that we were using a combination of `useEffect` and `useLazyQuery` to fire the `session` query and load its values into state. This turned out to have some undiagnosed synchronicity issues that affected our login redirects.

Using the `update` method of the `login` or `register` mutations, we can instead just load the returned `user` values directly into the cache and then pull those values from cache henceforward. Here we simplify the `useSession` hook to do that, as well as adding a function to perform the cache update with the `user` values.

**Update:** This does **not** address the bug that causes the call to `client.resetStore()` to throw an error when the user logs out from the Project Files view. We **could** solve that by calling `client.clearStore()`, which doesn't refetch all live queries, but that seems like a hack. Instead, we should figure out why one query in that one scene is staying live when others are not.

Closes #349 #356