### PR TITLE
Fix Project Detail Card Size

### DIFF
--- a/src/components/BudgetOverviewCard/BudgetOverviewCard.tsx
+++ b/src/components/BudgetOverviewCard/BudgetOverviewCard.tsx
@@ -1,18 +1,21 @@
 import { AccountBalance } from '@material-ui/icons';
 import * as React from 'react';
 import { FC } from 'react';
-import { FieldOverviewCard } from '../FieldOverviewCard';
+import {
+  FieldOverviewCard,
+  FieldOverviewCardProps,
+} from '../FieldOverviewCard';
 import { useCurrencyFormatter } from '../Formatters/useCurrencyFormatter';
 import { BudgetOverviewFragment } from './BudgetOverview.generated';
 
-export interface BudgetOverviewCardProps {
+export interface BudgetOverviewCardProps extends FieldOverviewCardProps {
   budget?: BudgetOverviewFragment | null;
-  className?: string;
 }
 
 export const BudgetOverviewCard: FC<BudgetOverviewCardProps> = ({
   className,
   budget,
+  loading,
 }) => {
   const formatCurrency = useCurrencyFormatter();
 
@@ -21,6 +24,7 @@ export const BudgetOverviewCard: FC<BudgetOverviewCardProps> = ({
       className={className}
       title="Project Budget"
       viewLabel="Budget Details"
+      loading={loading}
       data={
         budget
           ? {

--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.stories.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.stories.tsx
@@ -11,7 +11,7 @@ export const FilesOverviewCard = () => {
       <Card
         loading={boolean('loading', false)}
         total={number('total', 1)}
-        canReadFiles={boolean('canReadFiles', true)}
+        redacted={boolean('canReadFiles', true)}
       />
     </Box>
   );

--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
@@ -1,17 +1,17 @@
 import { LibraryBooksOutlined } from '@material-ui/icons';
 import React, { FC } from 'react';
-import { FieldOverviewCard } from '../../FieldOverviewCard';
+import {
+  FieldOverviewCard,
+  FieldOverviewCardProps,
+} from '../../FieldOverviewCard';
 import { useNumberFormatter } from '../../Formatters';
 
-export interface BudgetOverviewCardProps {
-  canReadFiles: boolean;
-  className?: string;
-  loading?: boolean;
+export interface BudgetOverviewCardProps extends FieldOverviewCardProps {
   total?: number;
 }
 
 export const FilesOverviewCard: FC<BudgetOverviewCardProps> = ({
-  canReadFiles,
+  redacted,
   className,
   loading,
   total,
@@ -24,7 +24,7 @@ export const FilesOverviewCard: FC<BudgetOverviewCardProps> = ({
       redactedText="You do not have permission to view files for this project"
       viewLabel="View Files"
       loading={loading}
-      redacted={!canReadFiles}
+      redacted={!redacted}
       data={{
         to: 'files',
         value: total ? String(formatNumber(total)) : '∞',

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -49,6 +49,13 @@ const useStyles = makeStyles(({ spacing, breakpoints, palette }) => ({
   name: {
     marginRight: spacing(4),
   },
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  budgetOverviewCard: {
+    marginRight: spacing(3),
+  },
   infoColor: {
     color: palette.info.main,
   },
@@ -257,25 +264,23 @@ export const ProjectOverview: FC = () => {
               </Grid>
             </Grid>
           )}
-          <Grid container spacing={3}>
-            <Grid item xs={6}>
-              <BudgetOverviewCard budget={data?.project.budget.value} />
-            </Grid>
-            <Grid item xs={6}>
-              {/* TODO When file api is finished need to update query and pass in file information */}
-              <FilesOverviewCard
-                loading={!data}
-                total={undefined}
-                canReadFiles={canReadDirectoryId === true}
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <CardGroup>
-                <ProjectMembersSummary members={data?.project.team} />
-                <PartnershipSummary partnerships={data?.project.partnerships} />
-              </CardGroup>
-            </Grid>
-          </Grid>
+          <div className={classes.container}>
+            <BudgetOverviewCard
+              budget={data?.project.budget.value}
+              className={classes.budgetOverviewCard}
+              loading={!data}
+            />
+            {/* TODO When file api is finished need to update query and pass in file information */}
+            <FilesOverviewCard
+              loading={!data}
+              total={undefined}
+              redacted={canReadDirectoryId === true}
+            />
+          </div>
+          <CardGroup>
+            <ProjectMembersSummary members={data?.project.team} />
+            <PartnershipSummary partnerships={data?.project.partnerships} />
+          </CardGroup>
 
           <Grid container spacing={2} alignItems="center">
             <Grid item>


### PR DESCRIPTION
Closes #466 

We were trying to fix a problem where the Budget card's height did not match the Files card's height during loading. We had originally fixed this by wrapping all the cards in a `material-ui` `<Grid>` component, but that had the
side effect of making the top row of cards the same height as the bottom row, which was undesirable.

The real problem was that the Budget card lacked a `loading` prop. Supplying this fixed the original issue, and removing the `<Grid>` fixed the new issue.

While we were in here messing around, we updated the props for `FilesOverviewCard` and `BudgetOvervieCard` to extend those of `FieldOverviewCard`, which they are wrapping.