### PR TITLE
Project overview estimated submission field

### DIFF
--- a/src/scenes/Projects/Overview/ProjectOverview.graphql
+++ b/src/scenes/Projects/Overview/ProjectOverview.graphql
@@ -35,6 +35,11 @@ fragment ProjectOverview on Project {
     value
   }
   status
+  estimatedSubmission {
+    canRead
+    canEdit
+    value
+  }
   step {
     canRead
     canEdit

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -233,17 +233,19 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(data?.project.step.value)}
               </DataButton>
             </Grid>
-            <Grid item>
-              <DataButton
-                loading={!data}
-                startIcon={<DateRange className={classes.infoColor} />}
-                secured={data?.project.estimatedSubmission}
-                redacted="You do not have permission to view estimated submission date"
-                children={formatDate}
-                empty="Estimated Submission"
-                onClick={() => editField(['estimatedSubmission'])}
-              />
-            </Grid>
+            {data?.project.status === 'InDevelopment' && (
+              <Grid item>
+                <DataButton
+                  loading={!data}
+                  startIcon={<DateRange className={classes.infoColor} />}
+                  secured={data.project.estimatedSubmission}
+                  redacted="You do not have permission to view estimated submission date"
+                  children={formatDate}
+                  empty="Estimated Submission"
+                  onClick={() => editField(['estimatedSubmission'])}
+                />
+              </Grid>
+            )}
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -223,6 +223,21 @@ export const ProjectOverview: FC = () => {
                 onClick={() => editField(['mouStart', 'mouEnd'])}
               />
             </Grid>
+            {data?.project.status === 'InDevelopment' && (
+              <Grid item>
+                <Tooltip title="Estimated Submission to Regional Director">
+                  <DataButton
+                    loading={!data}
+                    startIcon={<DateRange className={classes.infoColor} />}
+                    secured={data.project.estimatedSubmission}
+                    redacted="You do not have permission to view estimated submission date"
+                    children={formatDate}
+                    empty="Estimated Submission"
+                    onClick={() => editField(['estimatedSubmission'])}
+                  />
+                </Tooltip>
+              </Grid>
+            )}
             <Grid item>
               <DataButton
                 loading={!data}
@@ -233,19 +248,6 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(data?.project.step.value)}
               </DataButton>
             </Grid>
-            {data?.project.status === 'InDevelopment' && (
-              <Grid item>
-                <DataButton
-                  loading={!data}
-                  startIcon={<DateRange className={classes.infoColor} />}
-                  secured={data.project.estimatedSubmission}
-                  redacted="You do not have permission to view estimated submission date"
-                  children={formatDate}
-                  empty="Estimated Submission"
-                  onClick={() => editField(['estimatedSubmission'])}
-                />
-              </Grid>
-            )}
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -233,6 +233,17 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(data?.project.step.value)}
               </DataButton>
             </Grid>
+            <Grid item>
+              <DataButton
+                loading={!data}
+                startIcon={<DateRange className={classes.infoColor} />}
+                secured={data?.project.estimatedSubmission}
+                redacted="You do not have permission to view estimated submission date"
+                children={formatDate}
+                empty="Estimated Submission"
+                onClick={() => editField(['estimatedSubmission'])}
+              />
+            </Grid>
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -26,7 +26,7 @@ import { useUpdateProjectMutation } from './UpdateProject.generated';
 export type EditableProjectField = ExtractStrict<
   keyof UpdateProject,
   // Add more fields here as needed
-  'name' | 'step' | 'mouStart' | 'mouEnd'
+  'name' | 'step' | 'mouStart' | 'mouEnd' | 'estimatedSubmission'
 >;
 
 interface ProjectFieldProps {
@@ -43,6 +43,9 @@ const fieldMapping: Record<
   name: ({ props }) => <TextField {...props} label="Project Name" />,
   mouStart: ({ props }) => <DateField {...props} label="Start Date" />,
   mouEnd: ({ props }) => <DateField {...props} label="End Date" />,
+  estimatedSubmission: ({ props }) => (
+    <DateField {...props} label="Estimated Submission Date" />
+  ),
   step: ({ props }) => (
     <AutocompleteField
       label="Step"

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -88,6 +88,7 @@ export const UpdateProjectDialog = ({
       step: project.step.value,
       mouStart: project.mouStart.value,
       mouEnd: project.mouEnd.value,
+      estimatedSubmission: project.estimatedSubmission.value,
     };
 
     // Filter out irrelevant initial values so they don't get added to the mutation
@@ -109,6 +110,7 @@ export const UpdateProjectDialog = ({
     project.mouEnd.value,
     project.mouStart.value,
     project.step.value,
+    project.estimatedSubmission.value,
   ]);
 
   return (


### PR DESCRIPTION
Closes #467 

- Add `estimatedSubmission` to list of `Project` fields able to be edited in `UpdateProjectDialog`
- Add `DataField` for `estimatedSubmission` to `ProjectOverview`, if `project.status` is 'In Development'
- Add `estimatedSubmission` to Project Overview fragment