### PR TITLE
Display and Edit Project Sensitivity on Project Overview

### DIFF
--- a/src/components/Sensitivity/SensitivityIcon.tsx
+++ b/src/components/Sensitivity/SensitivityIcon.tsx
@@ -1,5 +1,5 @@
 import { colors, makeStyles, SvgIconProps } from '@material-ui/core';
-import { VerifiedUserOutlined } from '@material-ui/icons';
+import { VerifiedUser } from '@material-ui/icons';
 import clsx from 'clsx';
 import { FC } from 'react';
 import * as React from 'react';
@@ -31,7 +31,7 @@ export const SensitivityIcon: FC<SensitivityIconProps> = ({
   const classes = useStyles();
 
   return (
-    <VerifiedUserOutlined
+    <VerifiedUser
       className={clsx(!loading && value ? classes[value] : null, className)}
       {...rest}
     />

--- a/src/components/Sensitivity/SensitivityIcon.tsx
+++ b/src/components/Sensitivity/SensitivityIcon.tsx
@@ -1,0 +1,39 @@
+import { colors, makeStyles, SvgIconProps } from '@material-ui/core';
+import { VerifiedUserOutlined } from '@material-ui/icons';
+import clsx from 'clsx';
+import { FC } from 'react';
+import * as React from 'react';
+import { Sensitivity as SensitivityType } from '../../api';
+
+const useStyles = makeStyles(({ palette }) => ({
+  Low: {
+    color: colors.grey[400],
+  },
+  Medium: {
+    color: palette.warning.main,
+  },
+  High: {
+    color: palette.error.main,
+  },
+}));
+
+export interface SensitivityIconProps extends SvgIconProps {
+  value?: SensitivityType;
+  loading?: boolean;
+}
+
+export const SensitivityIcon: FC<SensitivityIconProps> = ({
+  value,
+  loading,
+  className,
+  ...rest
+}) => {
+  const classes = useStyles();
+
+  return (
+    <VerifiedUserOutlined
+      className={clsx(!loading && value ? classes[value] : null, className)}
+      {...rest}
+    />
+  );
+};

--- a/src/components/Sensitivity/index.ts
+++ b/src/components/Sensitivity/index.ts
@@ -1,1 +1,2 @@
 export * from './Sensitivity';
+export * from './SensitivityIcon';

--- a/src/scenes/Projects/Overview/ProjectOverview.graphql
+++ b/src/scenes/Projects/Overview/ProjectOverview.graphql
@@ -57,6 +57,7 @@ fragment ProjectOverview on Project {
       type
     }
   }
+  sensitivity
   modifiedAt
   budget {
     canRead
@@ -67,6 +68,7 @@ fragment ProjectOverview on Project {
   team {
     ...ProjectMemberList
   }
+  type
   partnerships {
     ...PartnershipSummary
   }

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -281,6 +281,15 @@ export const ProjectOverview: FC = () => {
             <Grid item>
               <DataButton
                 loading={!projectOverviewData}
+                onClick={() => editField('sensitivity')}
+                disabled={projectOverviewData?.project.type === 'Translation'}
+              >
+                {projectOverviewData?.project.sensitivity}
+              </DataButton>
+            </Grid>
+            <Grid item>
+              <DataButton
+                loading={!projectOverviewData}
                 secured={locations}
                 empty="Enter Location | Field Region"
                 redacted="You do not have permission to view location"
@@ -327,15 +336,6 @@ export const ProjectOverview: FC = () => {
                 }
               >
                 {displayProjectStep(projectOverviewData?.project.step.value)}
-              </DataButton>
-            </Grid>
-            <Grid item>
-              <DataButton
-                loading={!projectOverviewData}
-                onClick={() => editField('sensitivity')}
-                disabled={projectOverviewData?.project.type === 'Translation'}
-              >
-                {projectOverviewData?.project.sensitivity}
               </DataButton>
             </Grid>
           </Grid>

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -273,23 +273,32 @@ export const ProjectOverview: FC = () => {
             />
           </Grid>
           <Grid container spacing={1} alignItems="center">
-            <Grid item>
-              <DataButton
-                loading={!projectOverviewData}
-                onClick={() => editField('sensitivity')}
-                disabled={projectOverviewData?.project.type === 'Translation'}
-                startIcon={
-                  <SensitivityIcon
-                    value={projectOverviewData?.project.sensitivity}
-                    loading={!projectOverviewData}
-                  />
-                }
-              >
-                {projectOverviewData
-                  ? `${projectOverviewData.project.sensitivity} Sensitivity`
-                  : null}
-              </DataButton>
-            </Grid>
+            <Tooltip
+              title={
+                isTranslation
+                  ? 'Sensitivity is automatically determined by the most sensitive language engaged'
+                  : ''
+              }
+            >
+              <Grid item>
+                <DataButton
+                  loading={!projectOverviewData}
+                  onClick={() =>
+                    isTranslation === false && editField('sensitivity')
+                  }
+                  startIcon={
+                    <SensitivityIcon
+                      value={projectOverviewData?.project.sensitivity}
+                      loading={!projectOverviewData}
+                    />
+                  }
+                >
+                  {projectOverviewData
+                    ? `${projectOverviewData.project.sensitivity} Sensitivity`
+                    : null}
+                </DataButton>
+              </Grid>
+            </Tooltip>
             <Grid item>
               <DataButton
                 loading={!projectOverviewData}

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -116,12 +116,12 @@ export const ProjectOverview: FC = () => {
   });
 
   const projectName = projectOverviewData?.project.name;
-
-  const engagementTypeLabel = projectOverviewData?.project.__typename
+  const isTranslation = projectOverviewData
     ? projectOverviewData.project.__typename === 'TranslationProject'
-      ? 'Language'
-      : 'Intern'
-    : null;
+    : undefined;
+
+  const engagementTypeLabel =
+    isTranslation != null ? (isTranslation ? 'Language' : 'Intern') : null;
 
   const populationTotal = engagementListData?.project.engagements.items.reduce(
     (total, item) =>
@@ -172,10 +172,9 @@ export const ProjectOverview: FC = () => {
       )
     : undefined;
 
-  const CreateEngagement =
-    projectOverviewData?.project.__typename === 'TranslationProject'
-      ? CreateLanguageEngagement
-      : CreateInternshipEngagement;
+  const CreateEngagement = isTranslation
+    ? CreateLanguageEngagement
+    : CreateInternshipEngagement;
 
   return (
     <main className={classes.root}>
@@ -202,11 +201,13 @@ export const ProjectOverview: FC = () => {
                 />
               )}
             </Typography>
-            {projectOverviewData?.project.name.canEdit && (
+            {(!projectOverviewData ||
+              projectOverviewData.project.name.canEdit) && (
               <Fab
                 color="primary"
                 aria-label="edit project name"
                 onClick={() => editField(['name'])}
+                loading={!projectOverviewData}
               >
                 <Edit />
               </Fab>
@@ -228,56 +229,49 @@ export const ProjectOverview: FC = () => {
             )}
           </div>
 
-          <Grid container spacing={1}>
-            <Grid item>
-              <DisplaySimpleProperty
-                loading={!projectOverviewData}
-                label="Project ID"
-                value={projectOverviewData?.project.id}
-                loadingWidth={100}
-                LabelProps={{ color: 'textSecondary' }}
-                ValueProps={{ color: 'textPrimary' }}
-              />
-            </Grid>
-            <Grid item>
-              <DisplaySimpleProperty
-                loading={!projectOverviewData}
-                label="Department ID"
-                value={projectOverviewData?.project.departmentId.value}
-                loadingWidth={100}
-                LabelProps={{ color: 'textSecondary' }}
-                ValueProps={{ color: 'textPrimary' }}
-              />
-            </Grid>
+          <Grid container spacing={2}>
+            <DisplaySimpleProperty
+              loading={!projectOverviewData}
+              label="Project ID"
+              value={projectOverviewData?.project.id}
+              loadingWidth={100}
+              LabelProps={{ color: 'textSecondary' }}
+              ValueProps={{ color: 'textPrimary' }}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+            <DisplaySimpleProperty
+              loading={!projectOverviewData}
+              label="Department ID"
+              value={projectOverviewData?.project.departmentId.value}
+              loadingWidth={100}
+              LabelProps={{ color: 'textSecondary' }}
+              ValueProps={{ color: 'textPrimary' }}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+            <DisplaySimpleProperty
+              loading={!engagementListData || !projectOverviewData}
+              label={isTranslation ? 'Population Total' : 'Total Interns'}
+              value={formatNumber(
+                isTranslation
+                  ? populationTotal
+                  : engagementListData?.project.engagements.total
+              )}
+              loadingWidth={100}
+              LabelProps={{ color: 'textSecondary' }}
+              ValueProps={{ color: 'textPrimary' }}
+              wrap={(node) => (
+                <Tooltip
+                  title={
+                    isTranslation
+                      ? 'Total population of all languages engaged'
+                      : ''
+                  }
+                >
+                  <Grid item>{node}</Grid>
+                </Tooltip>
+              )}
+            />
           </Grid>
-          {projectOverviewData?.project.__typename === 'TranslationProject' && (
-            <Tooltip title={'Total population of all languages engaged'}>
-              <Grid item xs={3}>
-                <DisplaySimpleProperty
-                  loading={!engagementListData}
-                  label="Population Total"
-                  value={formatNumber(populationTotal)} // formats to string
-                  loadingWidth={100}
-                  LabelProps={{ color: 'textSecondary' }}
-                  ValueProps={{ color: 'textPrimary' }}
-                />
-              </Grid>
-            </Tooltip>
-          )}
-          {projectOverviewData?.project.__typename === 'InternshipProject' && (
-            <Grid item>
-              <DisplaySimpleProperty
-                loading={!engagementListData}
-                label="Total Interns"
-                value={formatNumber(
-                  engagementListData?.project.engagements.total
-                )} // formats to string
-                loadingWidth={100}
-                LabelProps={{ color: 'textSecondary' }}
-                ValueProps={{ color: 'textPrimary' }}
-              />
-            </Grid>
-          )}
           <Grid container spacing={1} alignItems="center">
             <Grid item>
               <DataButton
@@ -349,32 +343,32 @@ export const ProjectOverview: FC = () => {
             </Grid>
           </Grid>
 
-          {directoryIdLoading || !canReadDirectoryId ? null : (
-            <Grid container spacing={1} alignItems="center">
-              <Grid item>
-                <span {...getRootProps()}>
-                  <input {...getInputProps()} />
-                  <Fab
-                    loading={!projectOverviewData}
-                    onClick={openFileBrowser}
-                    color="primary"
-                    aria-label="Upload Files"
-                  >
-                    <Publish />
-                  </Fab>
-                </span>
-              </Grid>
-              <Grid item>
-                <Typography variant="h4">
-                  {projectOverviewData ? (
-                    'Upload Files'
-                  ) : (
-                    <Skeleton width="12ch" />
-                  )}
-                </Typography>
-              </Grid>
+          <Grid container spacing={1} alignItems="center">
+            <Grid item>
+              <span {...getRootProps()}>
+                <input {...getInputProps()} />
+                <Fab
+                  loading={!projectOverviewData || directoryIdLoading}
+                  disabled={canReadDirectoryId === false}
+                  onClick={openFileBrowser}
+                  color="primary"
+                  aria-label="Upload Files"
+                >
+                  <Publish />
+                </Fab>
+              </span>
             </Grid>
-          )}
+            <Grid item>
+              <Typography variant="h4">
+                {projectOverviewData ? (
+                  'Upload Files'
+                ) : (
+                  <Skeleton width="12ch" />
+                )}
+              </Typography>
+            </Grid>
+          </Grid>
+
           <Grid container spacing={3}>
             <Grid item xs={6}>
               <BudgetOverviewCard

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -23,6 +23,7 @@ import { LanguageEngagementListItemCard } from '../../../components/LanguageEnga
 import { PartnershipSummary } from '../../../components/PartnershipSummary';
 import { ProjectMembersSummary } from '../../../components/ProjectMembersSummary';
 import { Redacted } from '../../../components/Redacted';
+import { SensitivityIcon } from '../../../components/Sensitivity';
 import { Many } from '../../../util';
 import { CreateInternshipEngagement } from '../../Engagement/InternshipEngagement/Create/CreateInternshipEngagement';
 import { CreateLanguageEngagement } from '../../Engagement/LanguageEngagement/Create/CreateLanguageEngagement';
@@ -283,8 +284,16 @@ export const ProjectOverview: FC = () => {
                 loading={!projectOverviewData}
                 onClick={() => editField('sensitivity')}
                 disabled={projectOverviewData?.project.type === 'Translation'}
+                startIcon={
+                  <SensitivityIcon
+                    value={projectOverviewData?.project.sensitivity}
+                    loading={!projectOverviewData}
+                  />
+                }
               >
-                {projectOverviewData?.project.sensitivity}
+                {projectOverviewData
+                  ? `${projectOverviewData.project.sensitivity} Sensitivity`
+                  : null}
               </DataButton>
             </Grid>
             <Grid item>

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -329,6 +329,15 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(projectOverviewData?.project.step.value)}
               </DataButton>
             </Grid>
+            <Grid item>
+              <DataButton
+                loading={!projectOverviewData}
+                onClick={() => editField('sensitivity')}
+                disabled={projectOverviewData?.project.type === 'Translation'}
+              >
+                {projectOverviewData?.project.sensitivity}
+              </DataButton>
+            </Grid>
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -1,7 +1,7 @@
 import { pick } from 'lodash';
 import React, { ComponentType, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
-import { UpdateProject } from '../../../api';
+import { SensitivityList, UpdateProject } from '../../../api';
 import {
   DisplayFieldRegionFragment,
   DisplayLocationFragment,
@@ -13,6 +13,8 @@ import {
 import {
   DateField,
   FieldGroup,
+  RadioField,
+  RadioOption,
   SubmitError,
   TextField,
 } from '../../../components/form';
@@ -33,6 +35,7 @@ export type EditableProjectField = ExtractStrict<
   | 'estimatedSubmission'
   | 'fieldRegionId'
   | 'primaryLocationId'
+  | 'sensitivity'
 >;
 
 interface ProjectFieldProps {
@@ -57,6 +60,17 @@ const fieldMapping: Record<
   mouEnd: ({ props }) => <DateField {...props} label="End Date" />,
   estimatedSubmission: ({ props }) => (
     <DateField {...props} label="Estimated Submission Date" />
+  ),
+  sensitivity: ({ props }) => (
+    <RadioField {...props} label="Sensitivity">
+      {SensitivityList.map((sensitivity) => (
+        <RadioOption
+          key={sensitivity}
+          label={sensitivity}
+          value={sensitivity}
+        />
+      ))}
+    </RadioField>
   ),
 };
 
@@ -100,6 +114,7 @@ export const UpdateProjectDialog = ({
       mouStart: project.mouStart.value,
       mouEnd: project.mouEnd.value,
       estimatedSubmission: project.estimatedSubmission.value,
+      sensitivity: project.sensitivity,
     };
 
     // Filter out irrelevant initial values so they don't get added to the mutation
@@ -123,6 +138,7 @@ export const UpdateProjectDialog = ({
     project.mouEnd.value,
     project.mouStart.value,
     project.estimatedSubmission.value,
+    project.sensitivity,
   ]);
 
   return (

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -12,9 +12,8 @@ import {
 } from '../../../components/Dialog/DialogForm';
 import {
   DateField,
+  EnumField,
   FieldGroup,
-  RadioField,
-  RadioOption,
   SubmitError,
   TextField,
 } from '../../../components/form';
@@ -62,15 +61,7 @@ const fieldMapping: Record<
     <DateField {...props} label="Estimated Submission Date" />
   ),
   sensitivity: ({ props }) => (
-    <RadioField {...props} label="Sensitivity">
-      {SensitivityList.map((sensitivity) => (
-        <RadioOption
-          key={sensitivity}
-          label={sensitivity}
-          value={sensitivity}
-        />
-      ))}
-    </RadioField>
+    <EnumField {...props} label="Sensitivity" options={SensitivityList} />
   ),
 };
 


### PR DESCRIPTION
Closes #470 

- Add `sensitivity` and `type` to fields returned by `ProjectOverview`
  fragment
- Add `sensitivity` to editable fields in `UpdateProjectDialog`
- ~~Add `DataButton` for `sensitivity` to `ProjectOverview` and set as `disabled`~~
- Update `Sensitivity` component to be optionally clickable and disable-able
- Add `Sensitivity` component for `sensitivity` to `ProjectOverview` and set as `disabled`
  when `project.type === 'Translation'