### PR TITLE
Display Project Sensitivity on all Related Scenes

### DIFF
--- a/src/components/ProjectDetailNavigation/ProjectDetailNavigation.graphql
+++ b/src/components/ProjectDetailNavigation/ProjectDetailNavigation.graphql
@@ -1,0 +1,4 @@
+fragment ProjectDetailNavigation on Project {
+  ...ProjectBreadcrumb
+  sensitivity
+}

--- a/src/components/ProjectDetailNavigation/ProjectDetailNavigation.tsx
+++ b/src/components/ProjectDetailNavigation/ProjectDetailNavigation.tsx
@@ -1,0 +1,45 @@
+import { Breadcrumbs, makeStyles } from '@material-ui/core';
+import React, { FC, ReactNode } from 'react';
+import { Breadcrumb } from '../Breadcrumb';
+import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
+import { ProjectBreadcrumb } from '../ProjectBreadcrumb';
+import { ProjectDetailNavigationFragment } from './ProjectDetailNavigation.generated';
+
+const useStyles = makeStyles(({ spacing }) => ({
+  properties: {
+    marginTop: spacing(1),
+  },
+}));
+
+interface ProjectDetailNavigationProps {
+  project?: ProjectDetailNavigationFragment;
+  title: string | ReactNode;
+}
+
+export const ProjectDetailNavigation: FC<ProjectDetailNavigationProps> = (
+  props
+) => {
+  const { project, title, children } = props;
+  const classes = useStyles();
+  return (
+    <>
+      <Breadcrumbs>
+        <ProjectBreadcrumb data={project} />
+        {typeof title === 'string' ? (
+          <Breadcrumb to=".">{title}</Breadcrumb>
+        ) : (
+          title
+        )}
+        {children}
+      </Breadcrumbs>
+      <div className={classes.properties}>
+        <DisplaySimpleProperty
+          label="Sensitivity"
+          loading={!project}
+          loadingWidth={100}
+          value={project?.sensitivity}
+        />
+      </div>
+    </>
+  );
+};

--- a/src/components/ProjectDetailNavigation/ProjectDetailNavigation.tsx
+++ b/src/components/ProjectDetailNavigation/ProjectDetailNavigation.tsx
@@ -1,7 +1,7 @@
 import { Breadcrumbs, makeStyles } from '@material-ui/core';
 import React, { FC, ReactNode } from 'react';
+import { Sensitivity } from '../../components/Sensitivity';
 import { Breadcrumb } from '../Breadcrumb';
-import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { ProjectBreadcrumb } from '../ProjectBreadcrumb';
 import { ProjectDetailNavigationFragment } from './ProjectDetailNavigation.generated';
 
@@ -33,11 +33,10 @@ export const ProjectDetailNavigation: FC<ProjectDetailNavigationProps> = (
         {children}
       </Breadcrumbs>
       <div className={classes.properties}>
-        <DisplaySimpleProperty
-          label="Sensitivity"
-          loading={!project}
-          loadingWidth={100}
+        <Sensitivity
           value={project?.sensitivity}
+          loading={!project}
+          variant="flex"
         />
       </div>
     </>

--- a/src/components/ProjectDetailNavigation/index.ts
+++ b/src/components/ProjectDetailNavigation/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectDetailNavigation';

--- a/src/components/Sensitivity/Sensitivity.tsx
+++ b/src/components/Sensitivity/Sensitivity.tsx
@@ -11,11 +11,19 @@ const possible: SensitivityType[] = ['Low', 'Medium', 'High'];
 const avgLength = Math.round(meanBy(possible, (s) => s.length));
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
+  flex: {
+    display: 'flex',
+  },
   iconWrapper: {
     display: 'flex',
     alignItems: 'center',
     marginBottom: spacing(),
+    '&$flexed': {
+      marginRight: spacing(0.5),
+      marginBottom: 0,
+    },
   },
+  flexed: {}, // here to pacify TypeScript
   icon: {
     fontSize: 16,
     color: palette.text.secondary,
@@ -56,20 +64,31 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 
 export interface SensitivityProps {
   value?: SensitivityType;
+  variant?: 'stacked' | 'flex';
   loading?: boolean;
   className?: string;
 }
 
 export const Sensitivity: FC<SensitivityProps> = ({
   value,
+  variant = 'stacked',
   loading,
   className,
 }) => {
   const classes = useStyles();
 
+  const containerClassName = clsx(
+    className && className,
+    variant === 'flex' && classes.flex
+  );
+  const iconWrapperClassName = clsx(
+    classes.iconWrapper,
+    variant === 'flex' && classes.flexed
+  );
+
   return (
-    <div className={className}>
-      <div className={classes.iconWrapper}>
+    <div className={containerClassName}>
+      <div className={iconWrapperClassName}>
         <VerifiedUserOutlined className={classes.icon} />
         <Typography variant="body2">Sensitivity</Typography>
       </div>

--- a/src/scenes/Engagement/Engagement.graphql
+++ b/src/scenes/Engagement/Engagement.graphql
@@ -1,6 +1,6 @@
 query Engagement($projectId: ID!, $engagementId: ID!) {
   project(id: $projectId) {
-    ...ProjectBreadcrumb
+    ...ProjectDetailNavigation
   }
   engagement(id: $engagementId) {
     id

--- a/src/scenes/Engagement/EngagementDetailLoading.tsx
+++ b/src/scenes/Engagement/EngagementDetailLoading.tsx
@@ -1,12 +1,11 @@
-import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import React from 'react';
-import { Breadcrumb } from '../../components/Breadcrumb';
 import { DataButton } from '../../components/DataButton';
 import { Fab } from '../../components/Fab';
 import { FieldOverviewCard } from '../../components/FieldOverviewCard';
-import { ProjectBreadcrumb } from '../../components/ProjectBreadcrumb';
+import { ProjectDetailNavigation } from '../../components/ProjectDetailNavigation';
 import { CeremonyCard } from './CeremonyCard';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
@@ -33,12 +32,7 @@ export const EngagementDetailLoading = () => {
         className={classes.main}
       >
         <Grid item>
-          <Breadcrumbs>
-            <ProjectBreadcrumb />
-            <Breadcrumb to=".">
-              <Skeleton width={200} />
-            </Breadcrumb>
-          </Breadcrumbs>
+          <ProjectDetailNavigation title={<Skeleton width={200} />} />
         </Grid>
         <Grid item container spacing={3} alignItems="center">
           <Grid item style={{ width: '50%' }}>

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { ChatOutlined, DateRange } from '@material-ui/icons';
 import React, { FC } from 'react';
 import {
@@ -7,7 +7,6 @@ import {
   securedDateRange,
 } from '../../../api';
 import { AddItemCard } from '../../../components/AddItemCard';
-import { Breadcrumb } from '../../../components/Breadcrumb';
 import { DataButton } from '../../../components/DataButton';
 import { DefinedFileCard } from '../../../components/DefinedFileCard';
 import { useDialog } from '../../../components/Dialog';
@@ -18,8 +17,9 @@ import {
   useDateTimeFormatter,
 } from '../../../components/Formatters';
 import { OptionsIcon, PlantIcon } from '../../../components/Icons';
+import { ContentContainer as Content } from '../../../components/Layout/ContentContainer';
 import { MethodologiesCard } from '../../../components/MethodologiesCard';
-import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
+import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { Redacted } from '../../../components/Redacted';
 import { Link } from '../../../components/Routing';
 import { Many } from '../../../util';
@@ -32,27 +32,20 @@ import { EngagementQuery } from '../Engagement.generated';
 import { useUploadEngagementFile } from '../Files';
 import { MentorCard } from './MentorCard';
 
-const useStyles = makeStyles(
-  ({ spacing, breakpoints, palette, typography }) => ({
-    root: {
-      flex: 1,
-      overflowY: 'auto',
-      padding: spacing(4),
-    },
-    main: {
-      maxWidth: breakpoints.values.md,
-    },
-    nameRedacted: {
-      width: '50%',
-    },
-    infoColor: {
-      color: palette.info.main,
-    },
-    dropzoneText: {
-      fontSize: typography.h2.fontSize,
-    },
-  })
-);
+const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
+  main: {
+    maxWidth: breakpoints.values.md,
+  },
+  nameRedacted: {
+    width: '50%',
+  },
+  infoColor: {
+    color: palette.info.main,
+  },
+  dropzoneText: {
+    fontSize: typography.h2.fontSize,
+  },
+}));
 
 export const InternshipEngagementDetail: FC<EngagementQuery> = ({
   project,
@@ -79,51 +72,62 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
 
   return (
     <>
-      <div className={classes.root}>
-        <Grid
-          component="main"
-          container
-          direction="column"
-          spacing={3}
-          className={classes.main}
-        >
+      <Content>
+        <Grid component="main" container direction="column" spacing={3}>
           <Grid item>
-            <Breadcrumbs>
-              <ProjectBreadcrumb data={project} />
-              {name ? (
-                <Breadcrumb to=".">{name}</Breadcrumb>
-              ) : (
-                <Redacted
-                  info="You do not have permission to view this engagement's name"
-                  width={200}
-                />
-              )}
-            </Breadcrumbs>
+            <ProjectDetailNavigation
+              project={project}
+              title={
+                name ?? (
+                  <Redacted
+                    info="You do not have permission to view this engagement's name"
+                    width={200}
+                  />
+                )
+              }
+            />
           </Grid>
+
           <Grid item container spacing={3} alignItems="center">
-            <Grid item container spacing={3} alignItems="center">
-              <Grid item className={name ? undefined : classes.nameRedacted}>
-                <Typography
-                  variant="h2"
-                  {...(intern
-                    ? { component: Link, to: `/users/${intern.id}` }
-                    : {})}
-                >
-                  {name ?? (
-                    <Redacted
-                      info={`You do not have permission to view this engagement's ${
-                        intern ? 'name' : 'intern'
-                      }`}
-                      width="100%"
-                    />
-                  )}
-                </Typography>
-              </Grid>
+            <Grid item className={name ? undefined : classes.nameRedacted}>
+              <Typography
+                variant="h2"
+                {...(intern
+                  ? { component: Link, to: `/users/${intern.id}` }
+                  : {})}
+              >
+                {name ?? (
+                  <Redacted
+                    info="You do not have permission to view this engagement's name"
+                    width={200}
+                  />
+                )}
+              </Typography>
             </Grid>
             <Grid item container spacing={3} alignItems="center">
-              <Grid item>
-                <Typography variant="h4">Internship Engagement</Typography>
+              <Grid item container spacing={3} alignItems="center">
+                <Grid item className={name ? undefined : classes.nameRedacted}>
+                  <Typography
+                    variant="h2"
+                    {...(intern
+                      ? { component: Link, to: `/users/${intern.id}` }
+                      : {})}
+                  >
+                    {name ?? (
+                      <Redacted
+                        info={`You do not have permission to view this engagement's ${
+                          intern ? 'name' : 'intern'
+                        }`}
+                        width="100%"
+                      />
+                    )}
+                  </Typography>
+                </Grid>
               </Grid>
+              <Grid item container spacing={3} alignItems="center">
+                <Grid item>
+                  <Typography variant="h4">Internship Engagement</Typography>
+                </Grid>
 
               <Grid item>
                 <Typography variant="body2" color="textSecondary">
@@ -191,82 +195,145 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
                   onButtonClick={() => show('disbursementCompleteDate')}
                 />
               </Grid>
-              <Grid item xs={6}>
-                <FieldOverviewCard
-                  title="Communications Complete Date"
-                  data={{
-                    value: formatDate(
-                      engagement.communicationsCompleteDate.value
-                    ),
-                  }}
-                  icon={ChatOutlined}
-                  onClick={() => show('communicationsCompleteDate')}
-                  onButtonClick={() => show('communicationsCompleteDate')}
-                />
-              </Grid>
-              <Grid item container spacing={3} alignItems="center">
-                <Grid item xs={6}>
-                  <Typography variant="h4">Growth Plan</Typography>
+              <Grid item container spacing={1} alignItems="center">
+                <Grid item>
+                  <DataButton
+                    secured={engagement.position}
+                    empty="Enter Intern Position"
+                    redacted="You do not have permission to view intern position"
+                    children={displayInternPosition}
+                    onClick={() => show('position')}
+                  />
+                </Grid>
+                <Grid item>
+                  <DataButton
+                    secured={engagement.countryOfOrigin}
+                    empty="Enter Country of Origin"
+                    redacted="You do not have permission to view country of origin"
+                    children={(location) => location.name.value}
+                    onClick={() => show('countryOfOriginId')}
+                  />
+                </Grid>
+                <Grid item>
+                  <DataButton
+                    startIcon={<DateRange className={classes.infoColor} />}
+                    secured={date}
+                    redacted="You do not have permission to view start/end dates"
+                    children={formatDate.range}
+                    empty="Start - End"
+                    onClick={() =>
+                      show(['startDateOverride', 'endDateOverride'])
+                    }
+                  />
+                </Grid>
+                <Grid item>
+                  <DataButton onClick={() => show('status')}>
+                    {displayEngagementStatus(engagement.status)}
+                  </DataButton>
                 </Grid>
               </Grid>
-              <Grid item container spacing={3} alignItems="center">
-                <FileActionsContextProvider>
+              <Grid item container spacing={3}>
+                <Grid item xs={6}>
+                  <FieldOverviewCard
+                    title="Growth Plan Complete Date"
+                    data={{
+                      value: formatDate(engagement.completeDate.value),
+                    }}
+                    icon={PlantIcon}
+                    onClick={() => show('completeDate')}
+                    onButtonClick={() => show('completeDate')}
+                  />
+                </Grid>
+                <Grid item xs={6}>
+                  <FieldOverviewCard
+                    title="Disbursement Complete Date"
+                    data={{
+                      value: formatDate(
+                        engagement.disbursementCompleteDate.value
+                      ),
+                    }}
+                    icon={OptionsIcon}
+                    onClick={() => show('disbursementCompleteDate')}
+                    onButtonClick={() => show('disbursementCompleteDate')}
+                  />
+                </Grid>
+                <Grid item xs={6}>
+                  <FieldOverviewCard
+                    title="Communications Complete Date"
+                    data={{
+                      value: formatDate(
+                        engagement.communicationsCompleteDate.value
+                      ),
+                    }}
+                    icon={ChatOutlined}
+                    onClick={() => show('communicationsCompleteDate')}
+                    onButtonClick={() => show('communicationsCompleteDate')}
+                  />
+                </Grid>
+                <Grid item container spacing={3} alignItems="center">
                   <Grid item xs={6}>
-                    {growthPlan.canRead && !growthPlan.value ? (
-                      <AddItemCard
-                        actionType="dropzone"
-                        canAdd={growthPlan.canEdit}
-                        DropzoneProps={{
-                          classes: { text: classes.dropzoneText },
-                          options: {
-                            multiple: false,
-                          },
-                        }}
-                        handleFileSelect={(files: File[]) =>
-                          uploadFile({ files, parentId: engagement.id })
-                        }
-                        itemType="Growth Plan"
-                      />
-                    ) : (
-                      <DefinedFileCard
-                        onVersionUpload={(files) =>
-                          uploadFile({
-                            action: 'version',
-                            files,
-                            parentId: engagement.id,
-                          })
-                        }
-                        resourceType="engagement"
-                        securedFile={engagement.growthPlan}
-                      />
-                    )}
+                    <Typography variant="h4">Growth Plan</Typography>
                   </Grid>
-                </FileActionsContextProvider>
+                </Grid>
+                <Grid item container spacing={3} alignItems="center">
+                  <FileActionsContextProvider>
+                    <Grid item xs={6}>
+                      {growthPlan.canRead && !growthPlan.value ? (
+                        <AddItemCard
+                          actionType="dropzone"
+                          canAdd={growthPlan.canEdit}
+                          DropzoneProps={{
+                            classes: { text: classes.dropzoneText },
+                            options: {
+                              multiple: false,
+                            },
+                          }}
+                          handleFileSelect={(files: File[]) =>
+                            uploadFile({ files, parentId: engagement.id })
+                          }
+                          itemType="Growth Plan"
+                        />
+                      ) : (
+                        <DefinedFileCard
+                          onVersionUpload={(files) =>
+                            uploadFile({
+                              action: 'version',
+                              files,
+                              parentId: engagement.id,
+                            })
+                          }
+                          resourceType="engagement"
+                          securedFile={engagement.growthPlan}
+                        />
+                      )}
+                    </Grid>
+                  </FileActionsContextProvider>
+                </Grid>
+                <Grid item xs={6}>
+                  <MethodologiesCard
+                    onClick={() => show('methodologies')}
+                    data={engagement.methodologies}
+                  />
+                </Grid>
               </Grid>
-              <Grid item xs={6}>
-                <MethodologiesCard
-                  onClick={() => show('methodologies')}
-                  data={engagement.methodologies}
+              <Grid item container spacing={3}>
+                <Grid item xs={6}>
+                  <CeremonyCard {...engagement.ceremony} />
+                </Grid>
+                <MentorCard
+                  data={engagement.mentor}
+                  wrap={(node) => (
+                    <Grid item xs={6}>
+                      {node}
+                    </Grid>
+                  )}
+                  onEdit={() => show('mentorId')}
                 />
               </Grid>
-            </Grid>
-            <Grid item container spacing={3}>
-              <Grid item xs={6}>
-                <CeremonyCard {...engagement.ceremony} />
-              </Grid>
-              <MentorCard
-                data={engagement.mentor}
-                wrap={(node) => (
-                  <Grid item xs={6}>
-                    {node}
-                  </Grid>
-                )}
-                onEdit={() => show('mentorId')}
-              />
             </Grid>
           </Grid>
         </Grid>
-      </div>
+      </Content>
       <EditEngagementDialog
         {...editState}
         engagement={engagement}

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -122,71 +122,11 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
                   <Typography variant="h4">Internship Engagement</Typography>
                 </Grid>
 
-              <Grid item>
-                <Typography variant="body2" color="textSecondary">
-                  Updated {formatDateTime(engagement.modifiedAt)}
-                </Typography>
-              </Grid>
-            </Grid>
-            <Grid item container spacing={1} alignItems="center">
-              <Grid item>
-                <DataButton onClick={() => show('status')}>
-                  {displayEngagementStatus(engagement.status)}
-                </DataButton>
-              </Grid>
-              <Grid item>
-                <DataButton
-                  startIcon={<DateRange className={classes.infoColor} />}
-                  secured={date}
-                  redacted="You do not have permission to view start/end dates"
-                  children={formatDate.range}
-                  empty="Start - End"
-                  onClick={() => show(['startDateOverride', 'endDateOverride'])}
-                />
-              </Grid>
-              <Grid item>
-                <DataButton
-                  secured={engagement.position}
-                  empty="Enter Intern Position"
-                  redacted="You do not have permission to view intern position"
-                  children={displayInternPosition}
-                  onClick={() => show('position')}
-                />
-              </Grid>
-              <Grid item>
-                <DataButton
-                  secured={engagement.countryOfOrigin}
-                  empty="Enter Country of Origin"
-                  redacted="You do not have permission to view country of origin"
-                  children={(location) => location.name.value}
-                  onClick={() => show('countryOfOriginId')}
-                />
-              </Grid>
-            </Grid>
-            <Grid item container spacing={3}>
-              <Grid item xs={6}>
-                <FieldOverviewCard
-                  title="Growth Plan Complete Date"
-                  data={{
-                    value: formatDate(engagement.completeDate.value),
-                  }}
-                  icon={PlantIcon}
-                  onClick={() => show('completeDate')}
-                  onButtonClick={() => show('completeDate')}
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <FieldOverviewCard
-                  title="Disbursement Complete Date"
-                  data={{
-                    value: formatDate(
-                      engagement.disbursementCompleteDate.value
-                    ),
-                  }}
-                  icon={OptionsIcon}
-                  onClick={() => show('disbursementCompleteDate')}
-                  onButtonClick={() => show('disbursementCompleteDate')}
-                />
+                <Grid item>
+                  <Typography variant="body2" color="textSecondary">
+                    Updated {formatDateTime(engagement.modifiedAt)}
+                  </Typography>
+                </Grid>
               </Grid>
               <Grid item container spacing={1} alignItems="center">
                 <Grid item>

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -34,7 +34,9 @@ import { MentorCard } from './MentorCard';
 
 const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
   main: {
+    flexWrap: 'nowrap',
     maxWidth: breakpoints.values.md,
+    overflowY: 'scroll',
   },
   nameRedacted: {
     width: '50%',
@@ -73,7 +75,13 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
   return (
     <>
       <Content>
-        <Grid component="main" container direction="column" spacing={3}>
+        <Grid
+          component="main"
+          container
+          direction="column"
+          spacing={3}
+          className={classes.main}
+        >
           <Grid item>
             <ProjectDetailNavigation
               project={project}
@@ -89,21 +97,6 @@ export const InternshipEngagementDetail: FC<EngagementQuery> = ({
           </Grid>
 
           <Grid item container spacing={3} alignItems="center">
-            <Grid item className={name ? undefined : classes.nameRedacted}>
-              <Typography
-                variant="h2"
-                {...(intern
-                  ? { component: Link, to: `/users/${intern.id}` }
-                  : {})}
-              >
-                {name ?? (
-                  <Redacted
-                    info="You do not have permission to view this engagement's name"
-                    width={200}
-                  />
-                )}
-              </Typography>
-            </Grid>
             <Grid item container spacing={3} alignItems="center">
               <Grid item container spacing={3} alignItems="center">
                 <Grid item className={name ? undefined : classes.nameRedacted}>

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -17,7 +17,7 @@ import {
   useDateTimeFormatter,
 } from '../../../components/Formatters';
 import { OptionsIcon, PlantIcon } from '../../../components/Icons';
-import { ContentContainer as Content } from '../../../components/Layout/ContentContainer';
+import { ContentContainer as Content } from '../../../components/Layout';
 import { MethodologiesCard } from '../../../components/MethodologiesCard';
 import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { Redacted } from '../../../components/Redacted';

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -19,7 +19,7 @@ import {
   useDateTimeFormatter,
 } from '../../../components/Formatters';
 import { OptionsIcon, PlantIcon } from '../../../components/Icons';
-import { ContentContainer as Content } from '../../../components/Layout/ContentContainer';
+import { ContentContainer as Content } from '../../../components/Layout';
 import { AddProductCard, ProductCard } from '../../../components/ProductCard';
 import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { Redacted } from '../../../components/Redacted';
@@ -33,14 +33,11 @@ import {
 import { EngagementQuery } from '../Engagement.generated';
 import { useUploadEngagementFile } from '../Files';
 
-const useStyles = makeStyles(({ spacing, breakpoints, palette }) => ({
-  root: {
-    flex: 1,
-    overflowY: 'auto',
-    padding: spacing(4),
-  },
+const useStyles = makeStyles(({ breakpoints, palette }) => ({
   main: {
+    flexWrap: 'nowrap',
     maxWidth: breakpoints.values.md,
+    overflowY: 'scroll',
   },
   nameRedacted: {
     width: '50%',
@@ -80,7 +77,13 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
   return (
     <>
       <Content>
-        <Grid component="main" container direction="column" spacing={3}>
+        <Grid
+          component="main"
+          container
+          direction="column"
+          spacing={3}
+          className={classes.main}
+        >
           <Grid item>
             <ProjectDetailNavigation
               project={project}

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -1,10 +1,4 @@
-import {
-  Breadcrumbs,
-  Grid,
-  makeStyles,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
+import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { ChatOutlined, DateRange, Edit } from '@material-ui/icons';
 import React, { FC } from 'react';
 import {
@@ -14,7 +8,6 @@ import {
 } from '../../../api';
 import { AddItemCard } from '../../../components/AddItemCard';
 import { BooleanProperty } from '../../../components/BooleanProperty';
-import { Breadcrumb } from '../../../components/Breadcrumb';
 import { DataButton } from '../../../components/DataButton';
 import { DefinedFileCard } from '../../../components/DefinedFileCard';
 import { useDialog } from '../../../components/Dialog';
@@ -26,8 +19,9 @@ import {
   useDateTimeFormatter,
 } from '../../../components/Formatters';
 import { OptionsIcon, PlantIcon } from '../../../components/Icons';
+import { ContentContainer as Content } from '../../../components/Layout/ContentContainer';
 import { AddProductCard, ProductCard } from '../../../components/ProductCard';
-import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
+import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { Redacted } from '../../../components/Redacted';
 import { Link } from '../../../components/Routing';
 import { Many } from '../../../util';
@@ -67,6 +61,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
     Many<EditableEngagementField>
   >();
 
+  const date = securedDateRange(engagement.startDate, engagement.endDate);
   const formatDate = useDateFormatter();
   const formatDateTime = useDateTimeFormatter();
 
@@ -84,26 +79,20 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
 
   return (
     <>
-      <div className={classes.root}>
-        <Grid
-          component="main"
-          container
-          direction="column"
-          spacing={3}
-          className={classes.main}
-        >
+      <Content>
+        <Grid component="main" container direction="column" spacing={3}>
           <Grid item>
-            <Breadcrumbs>
-              <ProjectBreadcrumb data={project} />
-              {langName ? (
-                <Breadcrumb to=".">{langName}</Breadcrumb>
-              ) : (
-                <Redacted
-                  info="You do not have permission to view this engagement's name"
-                  width={200}
-                />
-              )}
-            </Breadcrumbs>
+            <ProjectDetailNavigation
+              project={project}
+              title={
+                langName ?? (
+                  <Redacted
+                    info="You do not have permission to view this engagement's name"
+                    width={200}
+                  />
+                )
+              }
+            />
           </Grid>
           <Grid item container spacing={3} alignItems="center">
             <Grid item className={langName ? undefined : classes.nameRedacted}>
@@ -141,7 +130,6 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
             <Grid item>
               <Typography variant="h4">Language Engagement</Typography>
             </Grid>
-
             <Grid item>
               <Typography variant="body2" color="textSecondary">
                 Updated {formatDateTime(engagement.modifiedAt)}
@@ -289,7 +277,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
             )}
           </Grid>
         </Grid>
-      </div>
+      </Content>
       <EditEngagementDialog
         {...editState}
         engagement={engagement}

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -72,8 +72,6 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
   const pnp = engagement.pnp;
   const editable = canEditAny(engagement);
 
-  const date = securedDateRange(engagement.startDate, engagement.endDate);
-
   return (
     <>
       <Content>

--- a/src/scenes/Partnerships/List/PartnershipList.graphql
+++ b/src/scenes/Partnerships/List/PartnershipList.graphql
@@ -1,6 +1,6 @@
 query ProjectPartnerships($input: ID!) {
   project(id: $input) {
-    ...ProjectBreadcrumb
+    ...ProjectDetailNavigation
     partnerships {
       canCreate
       total

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -1,18 +1,12 @@
-import { useQuery } from '@apollo/client';
-import {
-  Breadcrumbs,
-  makeStyles,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
+import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import React, { FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { Breadcrumb } from '../../../components/Breadcrumb';
 import { useDialog } from '../../../components/Dialog';
 import { Fab } from '../../../components/Fab';
+import { ContentContainer as Content } from '../../../components/Layout';
 import { PartnershipCard } from '../../../components/PartnershipCard';
-import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
+import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { listOrPlaceholders } from '../../../util';
 import { CreatePartnership } from '../Create';
 import { EditPartnership } from '../Edit';
@@ -54,13 +48,8 @@ export const PartnershipList: FC = () => {
   >();
 
   return (
-    <div className={classes.root}>
-      <Breadcrumbs>
-        <ProjectBreadcrumb data={project} />
-        <Breadcrumb to={`/projects/${projectId}/partnerships`}>
-          Partnerships
-        </Breadcrumb>
-      </Breadcrumbs>
+    <Content>
+      <ProjectDetailNavigation project={project} title="Partnerships" />
       <div className={classes.headerContainer}>
         <Typography variant="h2" className={classes.title}>
           Partnerships
@@ -89,6 +78,6 @@ export const PartnershipList: FC = () => {
         <EditPartnership {...editDialogState} partnership={partnership} />
       )}
       <CreatePartnership {...createDialogState} projectId={projectId} />
-    </div>
+    </Content>
   );
 };

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@apollo/client';
 import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import React, { FC } from 'react';

--- a/src/scenes/Projects/Budget/ProjectBudget.graphql
+++ b/src/scenes/Projects/Budget/ProjectBudget.graphql
@@ -28,11 +28,7 @@ fragment BudgetRecord on BudgetRecord {
 
 query ProjectBudget($id: ID!) {
   project(id: $id) {
-    id
-    name {
-      canRead
-      value
-    }
+    ...ProjectDetailNavigation
     budget {
       canRead
       canEdit

--- a/src/scenes/Projects/Budget/ProjectBudget.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudget.tsx
@@ -1,16 +1,15 @@
 import { useQuery } from '@apollo/client';
-import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { sumBy } from 'lodash';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { AddItemCard } from '../../../components/AddItemCard';
-import { Breadcrumb } from '../../../components/Breadcrumb';
 import { DefinedFileCard } from '../../../components/DefinedFileCard';
 import { FileActionsContextProvider } from '../../../components/files/FileActions';
 import { useCurrencyFormatter } from '../../../components/Formatters/useCurrencyFormatter';
 import { ContentContainer as Content } from '../../../components/Layout/ContentContainer';
-import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
+import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { useUploadBudgetFile } from '../Files';
 import { ProjectBudgetDocument } from './ProjectBudget.generated';
 import { ProjectBudgetRecords } from './ProjectBudgetRecords';
@@ -61,10 +60,10 @@ export const ProjectBudget = () => {
         </Typography>
       ) : (
         <>
-          <Breadcrumbs>
-            <ProjectBreadcrumb data={data?.project} />
-            <Breadcrumb to=".">Field Budget</Breadcrumb>
-          </Breadcrumbs>
+          <ProjectDetailNavigation
+            project={data?.project}
+            title="Field Budget"
+          />
           <header className={classes.header}>
             <Typography variant="h2">Budget</Typography>
             <Typography

--- a/src/scenes/Projects/Files/ProjectFiles.graphql
+++ b/src/scenes/Projects/Files/ProjectFiles.graphql
@@ -1,6 +1,6 @@
 query ProjectRootDirectory($id: ID!) {
   project(id: $id) {
-    ...ProjectBreadcrumb
+    ...ProjectDetailNavigation
     rootDirectory {
       canEdit
       canRead

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -1,11 +1,5 @@
 import { useQuery } from '@apollo/client';
-import {
-  Box,
-  Breadcrumbs,
-  makeStyles,
-  Typography,
-  useTheme,
-} from '@material-ui/core';
+import { makeStyles, Typography, useTheme } from '@material-ui/core';
 import { CreateNewFolder, Publish } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import React, { FC } from 'react';
@@ -34,7 +28,7 @@ import {
   useDateTimeFormatter,
 } from '../../../components/Formatters';
 import { ContentContainer } from '../../../components/Layout';
-import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
+import { ProjectDetailNavigation } from '../../../components/ProjectDetailNavigation';
 import { Table } from '../../../components/Table';
 import { DropzoneOverlay } from '../../../components/Upload';
 import { CreateProjectDirectory } from './CreateProjectDirectory';
@@ -299,33 +293,23 @@ const ProjectFilesListWrapped: FC = () => {
             {loading ? (
               <Skeleton variant="text" width="20%" />
             ) : (
-              <Box
-                display="flex"
-                justifyContent="space-between"
-                alignItems="center"
-              >
-                <Breadcrumbs>
-                  <ProjectBreadcrumb data={project} />
-                  <Breadcrumb to={`/projects/${projectId}/files`}>
-                    Files
+              <ProjectDetailNavigation project={project} title="Files">
+                {breadcrumbsParents.map((parent) => (
+                  <Breadcrumb
+                    key={parent.id}
+                    to={`/projects/${projectId}/files/${parent.id}`}
+                  >
+                    {parent.name}
                   </Breadcrumb>
-                  {breadcrumbsParents.map((parent) => (
-                    <Breadcrumb
-                      key={parent.id}
-                      to={`/projects/${projectId}/files/${parent.id}`}
-                    >
-                      {parent.name}
-                    </Breadcrumb>
-                  ))}
-                  {isNotRootDirectory && (
-                    <Breadcrumb
-                      to={`/projects/${projectId}/files/${directoryId}`}
-                    >
-                      {data?.directory.name}
-                    </Breadcrumb>
-                  )}
-                </Breadcrumbs>
-              </Box>
+                ))}
+                {isNotRootDirectory && (
+                  <Breadcrumb
+                    to={`/projects/${projectId}/files/${directoryId}`}
+                  >
+                    {data?.directory.name}
+                  </Breadcrumb>
+                )}
+              </ProjectDetailNavigation>
             )}
             <section className={classes.tableWrapper}>
               {loading ? (

--- a/src/scenes/Projects/Members/List/ProjectMembers.graphql
+++ b/src/scenes/Projects/Members/List/ProjectMembers.graphql
@@ -1,6 +1,6 @@
 query ProjectMembers($input: ID!) {
   project(id: $input) {
-    ...ProjectBreadcrumb
+    ...ProjectDetailNavigation
     team {
       items {
         ...ProjectMemberCard

--- a/src/scenes/Projects/Members/List/ProjectMembersList.tsx
+++ b/src/scenes/Projects/Members/List/ProjectMembersList.tsx
@@ -1,18 +1,13 @@
 import { useQuery } from '@apollo/client';
-import {
-  Breadcrumbs,
-  makeStyles,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
+import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import { FC } from 'react';
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { Breadcrumb } from '../../../../components/Breadcrumb';
 import { useDialog } from '../../../../components/Dialog';
 import { Fab } from '../../../../components/Fab';
-import { ProjectBreadcrumb } from '../../../../components/ProjectBreadcrumb';
+import { ContentContainer as Content } from '../../../../components/Layout';
+import { ProjectDetailNavigation } from '../../../../components/ProjectDetailNavigation';
 import { ProjectMemberCard } from '../../../../components/ProjectMemberCard';
 import { listOrPlaceholders } from '../../../../util';
 import { CreateProjectMember } from '../Create/CreateProjectMember';
@@ -20,18 +15,15 @@ import { UpdateProjectMember, UpdateProjectMemberFormParams } from '../Update';
 import { ProjectMembersDocument } from './ProjectMembers.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
-  root: {
-    flex: 1,
-    overflowY: 'auto',
-    padding: spacing(4),
-    maxWidth: breakpoints.values.sm,
-  },
   headerContainer: {
     margin: spacing(3, 0),
     display: 'flex',
   },
   title: {
     marginRight: spacing(3),
+  },
+  list: {
+    maxWidth: breakpoints.values.sm,
   },
   item: {
     marginBottom: spacing(3),
@@ -60,11 +52,8 @@ export const ProjectMembersList: FC = () => {
   ] = useDialog<UpdateProjectMemberFormParams>();
 
   return (
-    <div className={classes.root}>
-      <Breadcrumbs>
-        <ProjectBreadcrumb data={data?.project} />
-        <Breadcrumb to=".">Team Members</Breadcrumb>
-      </Breadcrumbs>
+    <Content>
+      <ProjectDetailNavigation project={data?.project} title="Team Members" />
       <div className={classes.headerContainer}>
         <Typography variant="h2" className={classes.title}>
           Team Members
@@ -91,21 +80,23 @@ export const ProjectMembersList: FC = () => {
           Sorry, you don't have permission to view this project's team members.
         </Typography>
       ) : (
-        listOrPlaceholders(members?.items, 5).map((item, index) => (
-          <ProjectMemberCard
-            key={item?.id ?? index}
-            projectMember={item}
-            className={classes.item}
-            onEdit={() =>
-              item &&
-              openUpdateProjectMemberDialog({
-                projectMemberId: item.id,
-                userId: item.user.value?.id || '',
-                userRoles: item.roles.value,
-              })
-            }
-          />
-        ))
+        <div className={classes.list}>
+          {listOrPlaceholders(members?.items, 5).map((item, index) => (
+            <ProjectMemberCard
+              key={item?.id ?? index}
+              projectMember={item}
+              className={classes.item}
+              onEdit={() =>
+                item &&
+                openUpdateProjectMemberDialog({
+                  projectMemberId: item.id,
+                  userId: item.user.value?.id || '',
+                  userRoles: item.roles.value,
+                })
+              }
+            />
+          ))}
+        </div>
       )}
       {projectMemberProps && (
         <UpdateProjectMember
@@ -113,6 +104,6 @@ export const ProjectMembersList: FC = () => {
           {...projectMemberProps}
         />
       )}
-    </div>
+    </Content>
   );
 };


### PR DESCRIPTION
Closes #471 

- Create `ProjectDetailNavigation` component, wrapping `ProjectBreadcrumb` and   including `project.sensitivity` in a ~~`DisplaySimpleProperty`~~ `Sensitivity` component
- Update `Sensitivity` component with a new optional `variant` property that allows the badge/name and the actual sensitivity to be displayed on the same row
- Replace all existing inline uses of `ProjectBreadcrumb` on Project sub-scenes  (Files, Budget, Members, Partnerships, Engagements) with `ProjectDetailNavigation`
- Add `sensitivity` to a queries feeding the above scenes
- While we were in here messing around, replace several instances of `div` + `makeStyles` with existing `ContentContainer` layout component