### PR TITLE
Fix: Can't Delete a Project File or File Version

### DIFF
--- a/src/components/files/FileActions/DeleteFile.tsx
+++ b/src/components/files/FileActions/DeleteFile.tsx
@@ -31,6 +31,7 @@ export const DeleteFile = (props: Except<DeleteFileProps, 'onSubmit'>) => {
     <DialogForm
       {...props}
       onSubmit={onSubmit}
+      sendIfClean // There's no way to actually make this form dirty
       title={`Delete ${isDirectory ? 'folder' : type}`}
     >
       <Typography variant="body1" color="error">


### PR DESCRIPTION
Closes #498 

Add `sendIfClean` prop to `DialogForm` in `DeleteFile` to allow actually submitting without any 'dirty' data