### PR TITLE
More query param handling

### DIFF
--- a/src/components/Sort/useSort.ts
+++ b/src/components/Sort/useSort.ts
@@ -1,5 +1,4 @@
-import { decodeString, encodeString } from 'serialize-query-params';
-import { makeQueryHandler, StringParam } from '../../hooks';
+import { makeQueryHandler, StringParam, withTransform } from '../../hooks';
 import { SortValue } from './SortControl';
 
 export const useSort = <T>() => {
@@ -13,8 +12,8 @@ export const useSort = <T>() => {
 
 const useSortHandler = makeQueryHandler({
   sort: StringParam,
-  order: {
-    decode: (val) => decodeString(val)?.toUpperCase(),
-    encode: (val) => encodeString(val)?.toLowerCase(),
-  },
+  order: withTransform(StringParam, {
+    encode: (val, encoder) => encoder(val?.toLowerCase()),
+    decode: (val, decoder) => decoder(val)?.toUpperCase(),
+  }),
 });

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,4 +1,4 @@
-import { compact, omit, pick, pickBy } from 'lodash';
+import { compact, mapValues, omit, pick, pickBy } from 'lodash';
 import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -7,35 +7,62 @@ import {
   decodeQueryParams,
   encodeDelimitedArray,
   encodeQueryParams,
-  QueryParamConfig,
-  QueryParamConfigMap,
   StringParam,
+  QueryParamConfig as UpstreamQueryParamConfig,
 } from 'serialize-query-params';
+import { areListsEqual, compareNullable } from '../components/form/util';
 
-export { withDefault, NumberParam, StringParam } from 'serialize-query-params';
+export { NumberParam, StringParam } from 'serialize-query-params';
 
-// This is a list param that encodes with commas.
-// It also doesn't empty list in the url.
+export interface QueryParamConfig<Val, Encoded = Val>
+  extends UpstreamQueryParamConfig<Val, Encoded> {
+  defaultValue?: Val;
+}
+
 export const ListParam: QueryParamConfig<string[] | undefined> = {
   encode: (val) => encodeDelimitedArray(val, ',') || undefined,
   decode: (val) => compact(decodeDelimitedArray(val, ',')),
+  equals: compareNullable(areListsEqual),
 };
 
-// This is a boolean param, but it doesn't put the default value in the url.
-export const BooleanParam = (
-  defaultVal = false
-): QueryParamConfig<boolean | undefined> => ({
-  encode: (val) => (val == null || val === defaultVal ? '' : val ? '1' : '0'),
-  decode: (val) => (val === '1' ? true : val === '0' ? false : undefined),
+export const BooleanParam = (): QueryParamConfig<boolean | undefined> => ({
+  encode: (val) => (val == null ? undefined : val ? '1' : '0'),
+  decode: (val) =>
+    val === '1' || val === 'true'
+      ? true
+      : val === '0' || val === 'false'
+      ? false
+      : undefined,
 });
 
 // This is just a list param, but is typed as T[]. Useful for string literals.
 export const EnumListParam = <T extends string>() =>
-  (ListParam as unknown) as QueryParamConfig<T[]>;
+  (ListParam as unknown) as QueryParamConfig<T[] | undefined>;
 
 // This is just a string param, but is typed as T. Useful for string literals.
 export const EnumParam = <T extends string>() =>
-  (StringParam as unknown) as QueryParamConfig<T>;
+  (StringParam as unknown) as QueryParamConfig<T | undefined>;
+
+/**
+ * This applies a default value to the param config.
+ * The default value is used when the value is omitted from the url.
+ * The default value is omitted from the url on change.
+ */
+export const withDefault = <Val, Default extends Val>(
+  param: QueryParamConfig<Val | undefined>,
+  defaultValue: Default
+): QueryParamConfig<NonNullable<Val> | Default> => ({
+  ...param,
+  encode: (val) =>
+    (param.equals ?? tripleEquals)(val, defaultValue)
+      ? undefined
+      : param.encode(val),
+  decode: (val) =>
+    val == null ? defaultValue : param.decode(val) ?? defaultValue,
+  defaultValue,
+});
+
+const tripleEquals = (a: unknown, b: unknown) => a === b;
 
 interface QueryChangeOptions {
   // Whether to push a new history state or replace the existing one.
@@ -43,6 +70,8 @@ interface QueryChangeOptions {
   push?: boolean | undefined;
   state?: Record<string, any> | null | undefined;
 }
+
+type QueryParamConfigMapShape = Record<string, QueryParamConfig<any>>;
 
 /**
  * Creates a query/search param hook with a defined schema.
@@ -80,7 +109,7 @@ interface QueryChangeOptions {
  * This is essentially what `use-query-params` library does, but it isn't updated
  * for RR v6. RR v6 includes more OOTB in this area so only thin wrapper is needed.
  */
-export const makeQueryHandler = <QPCMap extends QueryParamConfigMap>(
+export const makeQueryHandler = <QPCMap extends QueryParamConfigMapShape>(
   paramConfigMap: QPCMap
 ) => () => {
   const [search] = useSearchParams();
@@ -91,7 +120,10 @@ export const makeQueryHandler = <QPCMap extends QueryParamConfigMap>(
     const toObj = Object.fromEntries(search);
     const filtered = pick(toObj, Object.keys(paramConfigMap));
     const decoded = decodeQueryParams(paramConfigMap, filtered as any);
-    return decoded;
+    return {
+      ...mapValues(paramConfigMap, (c) => c.defaultValue),
+      ...decoded,
+    };
   }, [search]);
 
   const setQuery = useCallback(

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -62,6 +62,31 @@ export const withDefault = <Val, Default extends Val>(
   defaultValue,
 });
 
+export interface Transforms<OuterD, InnerD = OuterD> {
+  encode: (
+    value: OuterD,
+    encoder: QueryParamConfig<InnerD>['encode']
+  ) => RawParamValue;
+  decode: (
+    value: RawParamValue,
+    decoder: QueryParamConfig<InnerD>['decode']
+  ) => OuterD;
+}
+export const withTransform = <OuterD, InnerD = OuterD>(
+  param: QueryParamConfig<InnerD>,
+  transforms: Transforms<OuterD, InnerD>
+): QueryParamConfig<OuterD> => ({
+  ...param,
+  encode: (val) => transforms.encode(val, param.encode),
+  decode: (val) => transforms.decode(val, param.decode),
+  // @ts-expect-error assume default value, if given, is still compatible.
+  // withDefault can be applied on top of this function to fix if its not.
+  defaultValue: param.defaultValue,
+});
+
+/** The value a url parameter can be */
+type RawParamValue = string | Array<string | null> | null | undefined;
+
 const tripleEquals = (a: unknown, b: unknown) => a === b;
 
 interface QueryChangeOptions {

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -9,12 +9,17 @@ import {
 } from '../../../api';
 import { CheckboxesField, CheckboxOption } from '../../../components/form';
 import { SwitchField } from '../../../components/form/SwitchField';
-import { BooleanParam, EnumListParam, makeQueryHandler } from '../../../hooks';
+import {
+  BooleanParam,
+  EnumListParam,
+  makeQueryHandler,
+  withDefault,
+} from '../../../hooks';
 
 export const useProjectFilters = makeQueryHandler({
   status: EnumListParam<ProjectStatus>(),
   sensitivity: EnumListParam<Sensitivity>(),
-  onlyMultipleEngagements: BooleanParam(),
+  onlyMultipleEngagements: withDefault(BooleanParam(), false),
 });
 
 export const ProjectFilterOptions = () => {

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -54,12 +54,14 @@ export const ProjectFilterOptions = () => {
           ))}
         </Grid>
       </CheckboxesField>
-      <Tooltip title="Clusters/Cohorts are projects with multiple engagements">
-        <SwitchField
-          name="onlyMultipleEngagements"
-          label="Only Show Cluster/Cohort Projects"
-        />
-      </Tooltip>
+      <SwitchField
+        name="onlyMultipleEngagements"
+        label={
+          <Tooltip title="Clusters/Cohorts are projects with multiple engagements">
+            <span>Only Show Cluster/Cohort Projects</span>
+          </Tooltip>
+        }
+      />
     </>
   );
 };

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -14,12 +14,13 @@ import {
   EnumListParam,
   makeQueryHandler,
   withDefault,
+  withKey,
 } from '../../../hooks';
 
 export const useProjectFilters = makeQueryHandler({
   status: EnumListParam<ProjectStatus>(),
   sensitivity: EnumListParam<Sensitivity>(),
-  onlyMultipleEngagements: withDefault(BooleanParam(), false),
+  onlyMultipleEngagements: withKey(withDefault(BooleanParam(), false), 'multi'),
 });
 
 export const ProjectFilterOptions = () => {

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -1,4 +1,5 @@
 import { Grid, Tooltip } from '@material-ui/core';
+import { upperFirst } from 'lodash';
 import * as React from 'react';
 import {
   displayStatus,
@@ -15,11 +16,17 @@ import {
   makeQueryHandler,
   withDefault,
   withKey,
+  withTransform,
 } from '../../../hooks';
 
 export const useProjectFilters = makeQueryHandler({
   status: EnumListParam<ProjectStatus>(),
-  sensitivity: EnumListParam<Sensitivity>(),
+  sensitivity: withTransform(EnumListParam<Sensitivity>(), {
+    encode: (value, encoder) =>
+      encoder(value?.map((v: Sensitivity) => v.toLowerCase())),
+    decode: (value, decoder) =>
+      decoder(value)?.map((v) => upperFirst(v) as Sensitivity),
+  }),
   onlyMultipleEngagements: withKey(withDefault(BooleanParam(), false), 'multi'),
 });
 

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -20,7 +20,21 @@ import {
 } from '../../../hooks';
 
 export const useProjectFilters = makeQueryHandler({
-  status: EnumListParam<ProjectStatus>(),
+  status: withTransform(EnumListParam<ProjectStatus>(), {
+    encode: (value, encoder) =>
+      encoder(
+        value?.map((s: ProjectStatus) =>
+          s === 'InDevelopment' ? 'dev' : s.toLowerCase()
+        )
+      ),
+    decode: (value, decoder) =>
+      decoder(value)?.map(
+        (s): ProjectStatus =>
+          s.toLowerCase() === 'dev'
+            ? 'InDevelopment'
+            : (upperFirst(s) as ProjectStatus)
+      ),
+  }),
   sensitivity: withTransform(EnumListParam<Sensitivity>(), {
     encode: (value, encoder) =>
       encoder(value?.map((v: Sensitivity) => v.toLowerCase())),


### PR DESCRIPTION
This adds better handling of query parameters, including default values & mapping key/values to different strings for url.

## Default Values

Default values can now be specified with the `withDefault` wrapper function
```tsx
export const useProjectFilters = makeQueryHandler({
  onlyMultipleEngagements: withDefault(BooleanParam(), false),
});
```
The underlying library has this function as well but we are using a custom one now to:
- Remove default values from the url when using setter
- Supplies default values to the hooks current value even when omitted from the url

The types also now correctly account for the value being `undefined` when `withDefault` is not used.

## Different keys for url

Our query param keys are usually pretty specific due to whatever is best for code, and for syncing with API keys.
However, these are not always the best keys to use in urls.

The best example is `onlyMultipleEngagements` flag which just got renamed (formally "cluster").
This is really long for urls, so now we can map that to something shorter like `multi`.
https://github.com/SeedCompany/cord-field/blob/92dcead3797b4201a05d8163595c7338291ba85f/src/scenes/Projects/List/ProjectFilterOptions.tsx#L44

## Transforms

Along the same lines as keys, it would also be nice to be able to map values in the url.
I've added a `withTransform` wrapper function.

Previously `useSort` transformed values by referencing the underlying functions directly:
https://github.com/SeedCompany/cord-field/blob/a57b6e10ea80b54ea0ee9da90ef8de85b249c041/src/components/Sort/useSort.ts#L16-L19

Now with the decorator we have those functions given to us:
https://github.com/SeedCompany/cord-field/blob/3c2d8f4548c39c97ed9f3940b91840eac7619e40/src/components/Sort/useSort.ts#L15-L18

I'm not exactly thrilled with the API - I would've liked to make it simpler. However, we don't know if we should be calling the inner decoder/encoder before or after the transform function, so I just opted to give it to the transform function. This way it can decided whether to call it before or after the transformation. 

I also updated project filter [`status`](https://github.com/SeedCompany/cord-field/blob/92dcead3797b4201a05d8163595c7338291ba85f/src/scenes/Projects/List/ProjectFilterOptions.tsx#L23-L37) & [`sensitivity`](https://github.com/SeedCompany/cord-field/blob/92dcead3797b4201a05d8163595c7338291ba85f/src/scenes/Projects/List/ProjectFilterOptions.tsx#L38-L43) definitions to lowercase their values.

---

I also know there's that render error on status change due to an infinite loop. I opted to not solve that here. 