### PR TITLE
Rename 'Funding Type' to 'Financial Reporting Type' in Partnership Form

### DIFF
--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -116,7 +116,7 @@ const FundingType = <
     partnership ? (
       <SecuredField obj={partnership} name="financialReportingType">
         {(props) => (
-          <RadioField label="Funding Type" fullWidth row {...props}>
+          <RadioField label="Financial Reporting Type" fullWidth row {...props}>
             {radioOptions}
           </RadioField>
         )}
@@ -124,7 +124,7 @@ const FundingType = <
     ) : (
       <RadioField
         name="financialReportingType"
-        label="Funding Type"
+        label="Financial Reporting Type"
         fullWidth
         row
       >

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -39,7 +39,6 @@ export const PartnershipForm = <
   partnership,
   ...rest
 }: PartnershipFormProps<T>) => {
-  console.log('partnership', partnership);
   const radioOptions = PartnershipAgreementStatusList.map((status) => (
     <RadioOption
       key={status}


### PR DESCRIPTION
Closes #477 

The change requested for `PartnershipCard` has already been made