### PR TITLE
Fix non-boolean `checked` value passed to Edit Engagement checkbox fields

### DIFF
--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -62,7 +62,7 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
           <Checkbox
             {...rest}
             inputRef={ref}
-            checked={input.value}
+            checked={input.value || defaultValue}
             value={name}
             onChange={(e) => input.onChange(e.target.checked)}
             required={props.required}

--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -45,6 +45,9 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
   const disabled = disabledProp ?? meta.submitting;
   const ref = useFocusOnEnabled<HTMLInputElement>(meta, disabled);
 
+  const inputValueIsValid =
+    (input.value as unknown) === false || (input.value as unknown) === true;
+
   return (
     <FormControl
       required={props.required}
@@ -62,7 +65,7 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
           <Checkbox
             {...rest}
             inputRef={ref}
-            checked={input.value || defaultValue}
+            checked={inputValueIsValid ? input.value : defaultValue}
             value={name}
             onChange={(e) => input.onChange(e.target.checked)}
             required={props.required}


### PR DESCRIPTION
When creating the initial values for this form, we add `engagement.lukePartnership.value` `engagement.firstScripture.value`, even though those values might be `null`, and the checkbox field is expecting a boolean.

- Add double-! to value in `initialValues` object for `lukePartnership` and `firstScripture` fields to ensure that `null` values get passed to the form field as booleans