### PR TITLE
View/Edit ParaText Registry ID for Language Engagements

### DIFF
--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -24,6 +24,7 @@ import {
   RadioField,
   RadioOption,
   SubmitError,
+  TextField,
 } from '../../../components/form';
 import { AutocompleteField } from '../../../components/form/AutocompleteField';
 import { CountryField, UserField } from '../../../components/form/Lookup';
@@ -53,6 +54,7 @@ export type EditableEngagementField = ExtractStrict<
   | 'firstScripture'
   | 'lukePartnership'
   | 'status'
+  | 'paraTextRegistryId'
 >;
 
 interface EngagementFieldProps {
@@ -135,6 +137,9 @@ const fieldMapping: Record<
       autoComplete
     />
   ),
+  paraTextRegistryId: ({ props }) => (
+    <TextField {...props} label="ParaText Registry ID" />
+  ),
 };
 
 interface EngagementFormValues {
@@ -191,6 +196,7 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
         ? {
             lukePartnership: engagement.lukePartnership.value,
             firstScripture: engagement.firstScripture.value,
+            paraTextRegistryId: engagement.paraTextRegistryId.value,
           }
         : engagement.__typename === 'InternshipEngagement'
         ? {

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.graphql
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.graphql
@@ -59,5 +59,10 @@ fragment LanguageEngagementDetail on LanguageEngagement {
       ...ProductCard
     }
   }
+  paraTextRegistryId {
+    canRead
+    canEdit
+    value
+  }
   ...EditEngagement
 }

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -72,6 +72,7 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
 
   const language = engagement.language.value;
   const langName = language?.name.value ?? language?.displayName.value;
+  const ptRegistryId = engagement.paraTextRegistryId;
   const editable = canEditAny(engagement);
 
   return (
@@ -154,6 +155,16 @@ export const LanguageEngagementDetail: FC<EngagementQuery> = ({
             <DataButton onClick={() => show('status')}>
               {displayEngagementStatus(engagement.status)}
             </DataButton>
+          </Grid>
+          <Grid item>
+            <DataButton
+              onClick={() => show(['paraTextRegistryId'])}
+              secured={ptRegistryId}
+              redacted="You do not have permission to view ParaText Registry ID"
+              children={`ParaText Registry ID${
+                ptRegistryId.value ? `: ${ptRegistryId.value}` : ''
+              }`}
+            />
           </Grid>
           <BooleanProperty
             label="First Scripture"


### PR DESCRIPTION
Closes #479 

- Add `paraTextRegistryId` to fields editable for Language Engagement
- Add `paraTextRegistryId` to fields queried in `LanguageEngagementDetail` fragment
- Add `DataButton` for `paraTextRegistryId` to Language Engagement Detail scene