### PR TITLE
People Details | Rename 'Biography' to 'About'

### DIFF
--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -11,7 +11,7 @@ fragment userDetails on User {
     ...ss
   }
   fullName
-  bio {
+  about {
     ...ss
   }
   phone {

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -115,8 +115,8 @@ export const UserDetail = () => {
             loading={!user}
           />
           <DisplayProperty
-            label="Biography"
-            value={user?.bio.value}
+            label="About"
+            value={user?.about.value}
             loading={!user}
           />
           {user ? <EditUser user={user} {...editUserState} /> : null}

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -12,6 +12,7 @@ export type EditUserProps = Except<
 export const EditUser = (props: EditUserProps) => {
   const [updateUser] = useUpdateUserMutation();
   const user = props.user;
+  console.log('user', user);
 
   const initialValues = useMemo(
     () =>
@@ -25,7 +26,7 @@ export const EditUser = (props: EditUserProps) => {
               displayLastName: user.displayLastName.value,
               phone: user.phone.value,
               timezone: user.timezone.value?.name,
-              bio: user.bio.value,
+              about: user.about.value,
               email: user.email.value,
               title: user.title.value,
             },

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -12,7 +12,6 @@ export type EditUserProps = Except<
 export const EditUser = (props: EditUserProps) => {
   const [updateUser] = useUpdateUserMutation();
   const user = props.user;
-  console.log('user', user);
 
   const initialValues = useMemo(
     () =>

--- a/src/scenes/Users/UserForm/UserForm.graphql
+++ b/src/scenes/Users/UserForm/UserForm.graphql
@@ -29,7 +29,7 @@ fragment UserForm on User {
   phone {
     ...ss
   }
-  bio {
+  about {
     ...ss
   }
   title {

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -123,12 +123,12 @@ export const UserForm = <T, R = void>({
           <TextField label="Timezone" placeholder="Enter Timezone" {...props} />
         )}
       </SecuredField>
-      <SecuredField obj={user} name="bio">
+      <SecuredField obj={user} name="about">
         {(props) => (
           <TextField
-            label="Biography"
+            label="About"
             multiline
-            placeholder="Enter Biography"
+            placeholder="Enter About"
             inputProps={{ rowsMin: 2 }}
             {...props}
           />


### PR DESCRIPTION
Closes #482 — **Requires API PR #1264**

- Change all instances of `bio` to `about`