### PR TITLE
Default budget records sorting

### DIFF
--- a/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
@@ -59,6 +59,7 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
       {
         field: 'fiscalYear',
         editable: 'never',
+        defaultSort: 'asc',
       },
       {
         field: 'amount',

--- a/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
@@ -33,13 +33,16 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
 
   const records: readonly BudgetRecord[] = budget?.value?.records ?? [];
 
-  const rowData = records.map<BudgetRowData>((record) => ({
-    id: record.id,
-    fundingPartner: record.organization.value?.name.value ?? '',
-    fiscalYear: String(record.fiscalYear.value),
-    amount: String(record.amount.value ?? ''),
-    canEdit: record.amount.canEdit,
-  }));
+  const rowData = records
+    .map<BudgetRowData>((record) => ({
+      id: record.id,
+      fundingPartner: record.organization.value?.name.value ?? '',
+      fiscalYear: String(record.fiscalYear.value),
+      amount: String(record.amount.value ?? ''),
+      canEdit: record.amount.canEdit,
+    }))
+    .sort((a, b) => (a.fundingPartner > b.fundingPartner ? 1 : -1))
+    .sort((a, b) => Number(a.fiscalYear) - Number(b.fiscalYear));
 
   const blankAmount = 'click to edit';
   const columns: Array<Column<BudgetRowData>> = useMemo(
@@ -93,6 +96,9 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
             }
           : undefined
       }
+      options={{
+        thirdSortClick: false,
+      }}
     />
   );
 };

--- a/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
@@ -1,3 +1,4 @@
+import { sortBy } from 'lodash';
 import { Column, Components } from 'material-table';
 import React, { FC, useMemo } from 'react';
 import { useCurrencyFormatter } from '../../../components/Formatters/useCurrencyFormatter';
@@ -33,16 +34,16 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
 
   const records: readonly BudgetRecord[] = budget?.value?.records ?? [];
 
-  const rowData = records
-    .map<BudgetRowData>((record) => ({
+  const rowData = sortBy(
+    records.map<BudgetRowData>((record) => ({
       id: record.id,
       fundingPartner: record.organization.value?.name.value ?? '',
       fiscalYear: String(record.fiscalYear.value),
       amount: String(record.amount.value ?? ''),
       canEdit: record.amount.canEdit,
-    }))
-    .sort((a, b) => (a.fundingPartner > b.fundingPartner ? 1 : -1))
-    .sort((a, b) => Number(a.fiscalYear) - Number(b.fiscalYear));
+    })),
+    [(record) => record.fiscalYear, (record) => record.fundingPartner]
+  );
 
   const blankAmount = 'click to edit';
   const columns: Array<Column<BudgetRowData>> = useMemo(

--- a/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
@@ -15,7 +15,7 @@ const tableComponents: Components = {
 
 interface BudgetRowData {
   id: string;
-  organization: string;
+  fundingPartner: string;
   fiscalYear: string;
   amount: string | null;
   canEdit: boolean;
@@ -35,7 +35,7 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
 
   const rowData = records.map<BudgetRowData>((record) => ({
     id: record.id,
-    organization: record.organization.value?.name.value ?? '',
+    fundingPartner: record.organization.value?.name.value ?? '',
     fiscalYear: String(record.fiscalYear.value),
     amount: String(record.amount.value ?? ''),
     canEdit: record.amount.canEdit,
@@ -49,7 +49,7 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
         hidden: true,
       },
       {
-        field: 'organization',
+        field: 'fundingPartner',
         editable: 'never',
       },
       {


### PR DESCRIPTION
Closes #472 

`material-table` doesn't offer much in terms of default sorting of data; it expects the consumer to pass in the data pre-sorted into the desired default. So we do that here, and also add `options.thirdSortClick: false` to the props we pass to our `Table` component. This is because the normal `material-table` sort button click is as follows:

First click: Sort column ascending
Second click: Sort column descending
Third click: Return column to original unsorted state

We're disabling that third click because the original "unsorted" state for two of our three columns will actually be sorted, so leaving the third click enabled would make it appear to the user as if the behavior were:

First click: Sort column ascending
Second click: Sort column descending
Third click: Do nothing