### PR TITLE
Product full testament and full book

### DIFF
--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -120,7 +120,7 @@ export const ProductCard = ({ product }: ProductCardProps) => {
               .join(', ')}
           />
           <DisplaySimpleProperty
-            label="Scripture"
+            label="Scripture Reference"
             align="center"
             value={scriptureRangeToText(
               removeScriptureTypename(product.scriptureReferences.value)

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -22,11 +22,9 @@ import {
   displayProductTypes,
 } from '../../api';
 import { ProductTypes } from '../../scenes/Products/ProductForm/constants';
-import { entries } from '../../util';
 import {
-  getScriptureRangeDisplay,
-  ScriptureRange,
-  scriptureRangeDictionary,
+  removeScriptureTypename,
+  scriptureRangeToText,
 } from '../../util/biblejs';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { ButtonLink, CardActionAreaLink } from '../Routing';
@@ -124,15 +122,9 @@ export const ProductCard = ({ product }: ProductCardProps) => {
           <DisplaySimpleProperty
             label="Scripture"
             align="center"
-            value={entries(
-              scriptureRangeDictionary(
-                product.scriptureReferences.value as ScriptureRange[]
-              )
-            )
-              .map(([book, scriptureRange]) =>
-                getScriptureRangeDisplay(scriptureRange, book)
-              )
-              .join(', ')}
+            value={scriptureRangeToText(
+              removeScriptureTypename(product.scriptureReferences.value)
+            )}
           />
         </CardContent>
       </CardActionAreaLink>

--- a/src/scenes/Products/Create/CreateProduct.tsx
+++ b/src/scenes/Products/Create/CreateProduct.tsx
@@ -7,6 +7,7 @@ import { handleFormError } from '../../../api';
 import { EngagementBreadcrumb } from '../../../components/EngagementBreadcrumb';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { ButtonLink } from '../../../components/Routing';
+import { parsedRangesWithFullTestamentRange } from '../../../util/biblejs';
 import { ProductForm } from '../ProductForm';
 import {
   useCreateProductMutation,
@@ -55,8 +56,20 @@ export const CreateProduct = () => {
       {!loading && (
         <ProductForm
           onSubmit={async ({
-            product: { productType, produces, scriptureReferences, ...inputs },
+            product: {
+              productType,
+              produces,
+              scriptureReferences,
+              fullOldTestament,
+              fullNewTestament,
+              ...inputs
+            },
           }) => {
+            const parsedScriptureReferences = parsedRangesWithFullTestamentRange(
+              scriptureReferences,
+              fullOldTestament,
+              fullNewTestament
+            );
             try {
               const { data } = await createProduct({
                 variables: {
@@ -67,10 +80,10 @@ export const CreateProduct = () => {
                       ...(productType !== 'DirectScriptureProduct' && produces
                         ? {
                             produces: produces.id,
-                            scriptureReferencesOverride: scriptureReferences,
+                            scriptureReferencesOverride: parsedScriptureReferences,
                           }
                         : {
-                            scriptureReferences,
+                            scriptureReferences: parsedScriptureReferences,
                           }),
                     },
                   },

--- a/src/scenes/Products/Create/CreateProduct.tsx
+++ b/src/scenes/Products/Create/CreateProduct.tsx
@@ -13,11 +13,10 @@ import {
   useGetProductBreadcrumbQuery,
 } from './CreateProduct.generated';
 
-const useStyles = makeStyles(({ spacing, breakpoints }) => ({
+const useStyles = makeStyles(({ spacing }) => ({
   root: {
     overflowY: 'auto',
     padding: spacing(4),
-    maxWidth: breakpoints.values.md,
     '& > *': {
       marginBottom: spacing(2),
     },

--- a/src/scenes/Products/Edit/EditProduct.tsx
+++ b/src/scenes/Products/Edit/EditProduct.tsx
@@ -11,23 +11,13 @@ import {
   fullNewTestamentRange,
   fullOldTestamentRange,
   parsedRangesWithFullTestamentRange,
+  removeScriptureTypename,
 } from '../../../util/biblejs';
 import { ProductForm } from '../ProductForm';
-import { ScriptureRangeFragment } from '../ProductForm/ProductForm.generated';
 import {
   useProductQuery,
   useUpdateProductMutation,
 } from './EditProduct.generated';
-
-const removeScriptureTypename = (
-  scriptureReferences: readonly ScriptureRangeFragment[]
-) =>
-  scriptureReferences.map(
-    ({ start: { __typename, ...start }, end: { __typename: _, ...end } }) => ({
-      start,
-      end,
-    })
-  );
 
 const useStyles = makeStyles(({ spacing }) => ({
   root: {

--- a/src/scenes/Products/ProductForm/AccordionSection.tsx
+++ b/src/scenes/Products/ProductForm/AccordionSection.tsx
@@ -245,7 +245,7 @@ export const AccordionSection = ({
       <SecuredAccordion
         {...accordionState}
         name="scriptureReferences"
-        title="Scripture"
+        title="Scripture Reference"
         renderCollapsed={() => {
           const oldTestamentButton = fullOldTestament && (
             <ToggleButton

--- a/src/scenes/Products/ProductForm/AccordionSection.tsx
+++ b/src/scenes/Products/ProductForm/AccordionSection.tsx
@@ -62,7 +62,10 @@ import {
 import { ProductFormFragment } from './ProductForm.generated';
 import { VersesDialog, versesDialogValues } from './VersesDialog';
 
-const useStyles = makeStyles(({ spacing, typography }) => ({
+const useStyles = makeStyles(({ spacing, typography, breakpoints }) => ({
+  accordionContainer: {
+    maxWidth: breakpoints.values.md,
+  },
   accordionSummary: {
     flexDirection: 'column',
   },
@@ -176,7 +179,7 @@ export const AccordionSection = ({
   };
 
   return (
-    <div>
+    <div className={classes.accordionContainer}>
       <SecuredAccordion
         {...accordionState}
         name="produces"

--- a/src/scenes/Products/ProductForm/AccordionSection.tsx
+++ b/src/scenes/Products/ProductForm/AccordionSection.tsx
@@ -171,7 +171,10 @@ export const AccordionSection = ({
 
   const isProducesFieldMissing = !produces && touched?.['product.produces'];
 
-  const onVersesFieldSubmit = ({ updatingScriptures }: versesDialogValues) => {
+  const onVersesFieldSubmit = ({
+    updatingScriptures,
+    fullBook,
+  }: versesDialogValues) => {
     scriptureInitialValues &&
       form.change(
         // @ts-expect-error this is a valid field key
@@ -179,7 +182,8 @@ export const AccordionSection = ({
         mergeScriptureRange(
           updatingScriptures,
           scriptureReferences,
-          scriptureInitialValues.book
+          scriptureInitialValues.book,
+          fullBook
         )
       );
   };

--- a/src/scenes/Products/ProductForm/VersesDialog.tsx
+++ b/src/scenes/Products/ProductForm/VersesDialog.tsx
@@ -5,9 +5,10 @@ import {
   DialogForm,
   DialogFormProps,
 } from '../../../components/Dialog/DialogForm';
+import { SwitchField } from '../../../components/form/SwitchField';
 import { VersesField } from '../../../components/form/VersesField';
 import { Nullable } from '../../../util';
-import { ScriptureRange } from '../../../util/biblejs';
+import { isFullBookRange, ScriptureRange } from '../../../util/biblejs';
 import { ScriptureFormValues } from './AccordionSection';
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -18,6 +19,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 
 export interface versesDialogValues {
   updatingScriptures: ScriptureRange[];
+  fullBook: boolean;
 }
 
 type VersesDialogProps = Except<
@@ -36,9 +38,13 @@ export const VersesDialog = ({
 }: VersesDialogProps) => {
   const classes = useStyles();
 
-  const initialValues = useMemo(() => ({ updatingScriptures }), [
-    updatingScriptures,
-  ]);
+  const initialValues = useMemo(() => {
+    const isFull = isFullBookRange(updatingScriptures[0], book);
+    return {
+      updatingScriptures: isFull ? [] : updatingScriptures,
+      fullBook: isFull,
+    };
+  }, [book, updatingScriptures]);
 
   return (
     <DialogForm<versesDialogValues>
@@ -46,14 +52,24 @@ export const VersesDialog = ({
       title={book}
       initialValues={initialValues}
     >
-      <Typography variant="h4" className={classes.dialogText}>
-        Choose Your Chapters
-      </Typography>
-      <Typography className={classes.dialogText}>
-        When choosing chapters and verses, you can make multiple selections.
-        Input your wanted chapter/s and verses to create multiple selections.
-      </Typography>
-      <VersesField book={book} name="updatingScriptures" />
+      {({ values }: { values: versesDialogValues }) => {
+        return (
+          <>
+            <Typography variant="h4" className={classes.dialogText}>
+              Choose Your Chapters
+            </Typography>
+            <Typography className={classes.dialogText}>
+              When choosing chapters and verses, you can make multiple
+              selections. Input your wanted chapter/s and verses to create
+              multiple selections.
+            </Typography>
+            <SwitchField name="fullBook" label="Full Book" color="primary" />
+            {!values.fullBook && (
+              <VersesField book={book} name="updatingScriptures" />
+            )}
+          </>
+        );
+      }}
     </DialogForm>
   );
 };

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -279,17 +279,19 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(projectOverviewData?.project.step.value)}
               </DataButton>
             </Grid>
-            <Grid item>
-              <DataButton
-                loading={!data}
-                startIcon={<DateRange className={classes.infoColor} />}
-                secured={data?.project.estimatedSubmission}
-                redacted="You do not have permission to view estimated submission date"
-                children={formatDate}
-                empty="Estimated Submission"
-                onClick={() => editField(['estimatedSubmission'])}
-              />
-            </Grid>
+            {data?.project.status === 'InDevelopment' && (
+              <Grid item>
+                <DataButton
+                  loading={!data}
+                  startIcon={<DateRange className={classes.infoColor} />}
+                  secured={data.project.estimatedSubmission}
+                  redacted="You do not have permission to view estimated submission date"
+                  children={formatDate}
+                  empty="Estimated Submission"
+                  onClick={() => editField(['estimatedSubmission'])}
+                />
+              </Grid>
+            )}
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -279,19 +279,6 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(projectOverviewData?.project.step.value)}
               </DataButton>
             </Grid>
-            {data?.project.status === 'InDevelopment' && (
-              <Grid item>
-                <DataButton
-                  loading={!data}
-                  startIcon={<DateRange className={classes.infoColor} />}
-                  secured={data.project.estimatedSubmission}
-                  redacted="You do not have permission to view estimated submission date"
-                  children={formatDate}
-                  empty="Estimated Submission"
-                  onClick={() => editField(['estimatedSubmission'])}
-                />
-              </Grid>
-            )}
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -281,9 +281,9 @@ export const ProjectOverview: FC = () => {
             </Grid>
             <Grid item>
               <DataButton
-                loading={!data}
+                loading={!projectOverviewData}
                 startIcon={<DateRange className={classes.infoColor} />}
-                secured={data?.project.estimatedSubmission}
+                secured={projectOverviewData?.project.estimatedSubmission}
                 redacted="You do not have permission to view estimated submission date"
                 children={formatDate}
                 empty="Estimated Submission"

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -279,6 +279,17 @@ export const ProjectOverview: FC = () => {
                 {displayProjectStep(projectOverviewData?.project.step.value)}
               </DataButton>
             </Grid>
+            <Grid item>
+              <DataButton
+                loading={!data}
+                startIcon={<DateRange className={classes.infoColor} />}
+                secured={data?.project.estimatedSubmission}
+                redacted="You do not have permission to view estimated submission date"
+                children={formatDate}
+                empty="Estimated Submission"
+                onClick={() => editField(['estimatedSubmission'])}
+              />
+            </Grid>
           </Grid>
 
           {directoryIdLoading || !canReadDirectoryId ? null : (

--- a/src/util/biblejs/reference.ts
+++ b/src/util/biblejs/reference.ts
@@ -1,8 +1,9 @@
-import { compact, groupBy, isEqual } from 'lodash';
+import { compact, entries, groupBy, isEqual } from 'lodash';
 import {
   newTestament,
   oldTestament,
 } from '../../scenes/Products/ProductForm/constants';
+import { ScriptureRangeFragment } from '../../scenes/Products/ProductForm/ProductForm.generated';
 import { books } from './bibleBooks';
 import { Nullable } from '..';
 
@@ -347,3 +348,50 @@ export const parsedRangesWithFullTestamentRange = (
     newTestamentRange,
   ]);
 };
+
+/**
+ * Translates scriptureReferences array into readable text, displaying full testaments if found.
+ */
+export const scriptureRangeToText = (scriptureReferences: ScriptureRange[]) => {
+  const isFullOldTestament = scriptureReferences.some((range) =>
+    isEqual(range, fullOldTestamentRange)
+  );
+  const isFullNewTestament = scriptureReferences.some((range) =>
+    isEqual(range, fullNewTestamentRange)
+  );
+
+  const oldTestamentText = isFullOldTestament
+    ? 'Full Old Testament'
+    : undefined;
+
+  const newTestamentText = isFullNewTestament
+    ? 'Full New Testament'
+    : undefined;
+
+  const filteredScriptureRange = filterScriptureRangesByTestament(
+    scriptureReferences,
+    isFullOldTestament,
+    isFullNewTestament
+  );
+
+  const individualRangeText = entries(
+    scriptureRangeDictionary(filteredScriptureRange)
+  ).map(([book, scriptureRange]) =>
+    getScriptureRangeDisplay(scriptureRange, book)
+  );
+  return compact([
+    oldTestamentText,
+    ...individualRangeText,
+    newTestamentText,
+  ]).join(', ');
+};
+
+export const removeScriptureTypename = (
+  scriptureReferences: readonly ScriptureRangeFragment[]
+) =>
+  scriptureReferences.map(
+    ({ start: { __typename, ...start }, end: { __typename: _, ...end } }) => ({
+      start,
+      end,
+    })
+  );

--- a/src/util/biblejs/reference.ts
+++ b/src/util/biblejs/reference.ts
@@ -253,3 +253,29 @@ export const mergeScriptureRange = (
         ...updatingScriptures,
       ]
     : [...updatingScriptures];
+
+export const fullOldTestamentRange: ScriptureRange = {
+  start: {
+    book: 'Genesis',
+    chapter: 1,
+    verse: 1,
+  },
+  end: {
+    book: 'Malachi',
+    chapter: 4,
+    verse: 6,
+  },
+};
+
+export const fullNewTestamentRange: ScriptureRange = {
+  start: {
+    book: 'Matthew',
+    chapter: 1,
+    verse: 1,
+  },
+  end: {
+    book: 'Revelation',
+    chapter: 22,
+    verse: 21,
+  },
+};

--- a/src/util/biblejs/reference.ts
+++ b/src/util/biblejs/reference.ts
@@ -1,4 +1,8 @@
-import { groupBy } from 'lodash';
+import { compact, groupBy } from 'lodash';
+import {
+  newTestament,
+  oldTestament,
+} from '../../scenes/Products/ProductForm/constants';
 import { books } from './bibleBooks';
 import { Nullable } from '..';
 
@@ -278,4 +282,42 @@ export const fullNewTestamentRange: ScriptureRange = {
     chapter: 22,
     verse: 21,
   },
+};
+
+export const filterScriptureRangesByTestament = (
+  scriptureReferences: readonly ScriptureRange[] | undefined,
+  fullOldTestament: boolean | undefined,
+  fullNewTestament: boolean | undefined
+) =>
+  scriptureReferences?.filter(({ start: { book } }) => {
+    const fullTestamentSelectedAndMatch =
+      fullOldTestament && oldTestament.includes(book);
+    const newTestamentSelectedAndMatch =
+      fullNewTestament && newTestament.includes(book);
+    return !fullTestamentSelectedAndMatch && !newTestamentSelectedAndMatch;
+  });
+
+export const parsedRangesWithFullTestamentRange = (
+  scriptureReferences: readonly ScriptureRange[] | undefined,
+  fullOldTestament: boolean | undefined,
+  fullNewTestament: boolean | undefined
+) => {
+  const oldTestamentRange = fullOldTestament
+    ? fullOldTestamentRange
+    : undefined;
+  const newTestamentRange = fullNewTestament
+    ? fullNewTestamentRange
+    : undefined;
+
+  const filteredScriptureRange = filterScriptureRangesByTestament(
+    scriptureReferences,
+    fullOldTestament,
+    fullNewTestament
+  );
+
+  return compact([
+    oldTestamentRange,
+    ...(filteredScriptureRange ? filteredScriptureRange : []),
+    newTestamentRange,
+  ]);
 };


### PR DESCRIPTION
Add ability to set full testament and full book ranges with a toggle field.

Moving alot of the helpers to src/util/biblejs/reference.ts.

The product form is even more algorithmically heavy.  I thought I saw some UI stutters one day but that might be because I had alot running on my machine. Please if you see any lags on your browser.