### PR TITLE
Separate project engagements query and loading

### DIFF
--- a/src/scenes/Projects/Overview/ProjectOverview.graphql
+++ b/src/scenes/Projects/Overview/ProjectOverview.graphql
@@ -53,18 +53,24 @@ fragment ProjectOverview on Project {
   partnerships {
     ...PartnershipSummary
   }
-  engagements {
-    canRead
-    canCreate
-    total
-    items {
-      ... on LanguageEngagement {
-        __typename
-        ...LanguageEngagementListItem
-      }
-      ... on InternshipEngagement {
-        __typename
-        ...InternshipEngagementListItem
+}
+
+query ProjectEngagementListOverview($input: ID!) {
+  project(id: $input) {
+    id
+    engagements {
+      canRead
+      canCreate
+      total
+      items {
+        ... on LanguageEngagement {
+          __typename
+          ...LanguageEngagementListItem
+        }
+        ... on InternshipEngagement {
+          __typename
+          ...InternshipEngagementListItem
+        }
       }
     }
   }

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -115,14 +115,13 @@ export const ProjectOverview: FC = () => {
       : 'Intern'
     : null;
 
-  const populationTotal =
-    engagementListData?.project.engagements.items.reduce(
-      (total, item) =>
-        item.__typename === 'LanguageEngagement'
-          ? total + (item.language.value?.population.value ?? 0)
-          : total,
-      0
-    ) || undefined;
+  const populationTotal = engagementListData?.project.engagements.items.reduce(
+    (total, item) =>
+      item.__typename === 'LanguageEngagement'
+        ? total + (item.language.value?.population.value ?? 0)
+        : total,
+    0
+  );
 
   const date = projectOverviewData
     ? securedDateRange(
@@ -205,27 +204,20 @@ export const ProjectOverview: FC = () => {
               />
             </Grid>
           </Grid>
-          <DisplaySimpleProperty
-            label="Population Total"
-            value={formatNumber(populationTotal)}
-            loadingWidth={100}
-            LabelProps={{ color: 'textSecondary' }}
-            ValueProps={{ color: 'textPrimary' }}
-            wrap={(node) => (
-              <Grid item>
-                <Tooltip
-                  title={
-                    projectOverviewData
-                      ? 'Total population of all languages engaged'
-                      : ''
-                  }
-                >
-                  {node}
-                </Tooltip>
+          {projectOverviewData?.project.__typename === 'TranslationProject' && (
+            <Tooltip title={'Total population of all languages engaged'}>
+              <Grid item xs={3}>
+                <DisplaySimpleProperty
+                  loading={!engagementListData}
+                  label="Population Total"
+                  value={formatNumber(populationTotal)} // formats to string
+                  loadingWidth={100}
+                  LabelProps={{ color: 'textSecondary' }}
+                  ValueProps={{ color: 'textPrimary' }}
+                />
               </Grid>
-            )}
-          />
-
+            </Tooltip>
+          )}
           <Grid container spacing={1} alignItems="center">
             <Grid item>
               <DataButton

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -28,7 +28,10 @@ import { CreateInternshipEngagement } from '../../Engagement/InternshipEngagemen
 import { CreateLanguageEngagement } from '../../Engagement/LanguageEngagement/Create/CreateLanguageEngagement';
 import { useProjectCurrentDirectory, useUploadProjectFiles } from '../Files';
 import { EditableProjectField, UpdateProjectDialog } from '../Update';
-import { useProjectOverviewQuery } from './ProjectOverview.generated';
+import {
+  useProjectEngagementListOverviewQuery,
+  useProjectOverviewQuery,
+} from './ProjectOverview.generated';
 
 const useStyles = makeStyles(({ spacing, breakpoints, palette }) => ({
   root: {
@@ -100,6 +103,12 @@ export const ProjectOverview: FC = () => {
     },
   });
 
+  const { data: engagementListData } = useProjectEngagementListOverviewQuery({
+    variables: {
+      input: projectId,
+    },
+  });
+
   const engagementTypeLabel = data?.project.__typename
     ? data.project.__typename === 'TranslationProject'
       ? 'Language'
@@ -107,7 +116,7 @@ export const ProjectOverview: FC = () => {
     : null;
 
   const populationTotal =
-    data?.project.engagements.items.reduce(
+    engagementListData?.project.engagements.items.reduce(
       (total, item) =>
         item.__typename === 'LanguageEngagement'
           ? total + (item.language.value?.population.value ?? 0)
@@ -190,7 +199,6 @@ export const ProjectOverview: FC = () => {
             </Grid>
           </Grid>
           <DisplaySimpleProperty
-            loading={!data}
             label="Population Total"
             value={formatNumber(populationTotal)}
             loadingWidth={100}
@@ -285,14 +293,14 @@ export const ProjectOverview: FC = () => {
           <Grid container spacing={2} alignItems="center">
             <Grid item>
               <Typography variant="h3">
-                {data ? (
-                  !data.project.engagements.canRead ? (
+                {engagementListData ? (
+                  !engagementListData.project.engagements.canRead ? (
                     <Redacted
                       info="You do not have permission to view engagements"
                       width="50%"
                     />
                   ) : (
-                    `${data.project.engagements.total} ${engagementTypeLabel} Engagements`
+                    `${engagementListData.project.engagements.total} ${engagementTypeLabel} Engagements`
                   )
                 ) : (
                   <Skeleton width="40%" />
@@ -300,7 +308,7 @@ export const ProjectOverview: FC = () => {
               </Typography>
             </Grid>
             <Grid item>
-              {data?.project.engagements.canCreate && (
+              {engagementListData?.project.engagements.canCreate && (
                 <Tooltip title={`Add ${engagementTypeLabel} Engagement`}>
                   <Fab
                     color="error"
@@ -313,7 +321,7 @@ export const ProjectOverview: FC = () => {
               )}
             </Grid>
           </Grid>
-          {data?.project.engagements.items.map((engagement) =>
+          {engagementListData?.project.engagements.items.map((engagement) =>
             engagement.__typename === 'LanguageEngagement' ? (
               <LanguageEngagementListItemCard
                 key={engagement.id}

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -218,6 +218,20 @@ export const ProjectOverview: FC = () => {
               </Grid>
             </Tooltip>
           )}
+          {projectOverviewData?.project.__typename === 'InternshipProject' && (
+            <Grid item>
+              <DisplaySimpleProperty
+                loading={!engagementListData}
+                label="Total Interns"
+                value={formatNumber(
+                  engagementListData?.project.engagements.total
+                )} // formats to string
+                loadingWidth={100}
+                LabelProps={{ color: 'textSecondary' }}
+                ValueProps={{ color: 'textPrimary' }}
+              />
+            </Grid>
+          )}
           <Grid container spacing={1} alignItems="center">
             <Grid item>
               <DataButton

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -97,7 +97,7 @@ export const ProjectOverview: FC = () => {
 
   const [createEngagementState, createEngagement] = useDialog();
 
-  const { data, error } = useProjectOverviewQuery({
+  const { data: projectOverviewData, error } = useProjectOverviewQuery({
     variables: {
       input: projectId,
     },
@@ -109,8 +109,8 @@ export const ProjectOverview: FC = () => {
     },
   });
 
-  const engagementTypeLabel = data?.project.__typename
-    ? data.project.__typename === 'TranslationProject'
+  const engagementTypeLabel = projectOverviewData?.project.__typename
+    ? projectOverviewData.project.__typename === 'TranslationProject'
       ? 'Language'
       : 'Intern'
     : null;
@@ -124,12 +124,15 @@ export const ProjectOverview: FC = () => {
       0
     ) || undefined;
 
-  const date = data
-    ? securedDateRange(data.project.mouStart, data.project.mouEnd)
+  const date = projectOverviewData
+    ? securedDateRange(
+        projectOverviewData.project.mouStart,
+        projectOverviewData.project.mouEnd
+      )
     : undefined;
 
   const CreateEngagement =
-    data?.project.__typename === 'TranslationProject'
+    projectOverviewData?.project.__typename === 'TranslationProject'
       ? CreateLanguageEngagement
       : CreateInternshipEngagement;
 
@@ -141,9 +144,9 @@ export const ProjectOverview: FC = () => {
         <div className={classes.main}>
           <header className={classes.header}>
             <Typography variant="h2" className={classes.name}>
-              {data ? (
-                data.project.name.canRead ? (
-                  data.project.name.value
+              {projectOverviewData ? (
+                projectOverviewData.project.name.canRead ? (
+                  projectOverviewData.project.name.value
                 ) : (
                   <Redacted
                     info="You do not have permission to view project's name"
@@ -154,7 +157,7 @@ export const ProjectOverview: FC = () => {
                 <Skeleton width="50%" />
               )}
             </Typography>
-            {data?.project.name.canEdit && (
+            {projectOverviewData?.project.name.canEdit && (
               <Fab
                 color="primary"
                 aria-label="edit project name"
@@ -167,11 +170,15 @@ export const ProjectOverview: FC = () => {
 
           <div className={classes.subheader}>
             <Typography variant="h4">
-              {data ? 'Project Overview' : <Skeleton width={200} />}
+              {projectOverviewData ? (
+                'Project Overview'
+              ) : (
+                <Skeleton width={200} />
+              )}
             </Typography>
-            {data && (
+            {projectOverviewData && (
               <Typography variant="body2" color="textSecondary">
-                Updated {formatDateTime(data.project.modifiedAt)}
+                Updated {formatDateTime(projectOverviewData.project.modifiedAt)}
               </Typography>
             )}
           </div>
@@ -179,9 +186,9 @@ export const ProjectOverview: FC = () => {
           <Grid container spacing={1}>
             <Grid item>
               <DisplaySimpleProperty
-                loading={!data}
+                loading={!projectOverviewData}
                 label="Project ID"
-                value={data?.project.id}
+                value={projectOverviewData?.project.id}
                 loadingWidth={100}
                 LabelProps={{ color: 'textSecondary' }}
                 ValueProps={{ color: 'textPrimary' }}
@@ -189,9 +196,9 @@ export const ProjectOverview: FC = () => {
             </Grid>
             <Grid item>
               <DisplaySimpleProperty
-                loading={!data}
+                loading={!projectOverviewData}
                 label="Department ID"
-                value={data?.project.departmentId.value}
+                value={projectOverviewData?.project.departmentId.value}
                 loadingWidth={100}
                 LabelProps={{ color: 'textSecondary' }}
                 ValueProps={{ color: 'textPrimary' }}
@@ -208,7 +215,9 @@ export const ProjectOverview: FC = () => {
               <Grid item>
                 <Tooltip
                   title={
-                    data ? 'Total population of all languages engaged' : ''
+                    projectOverviewData
+                      ? 'Total population of all languages engaged'
+                      : ''
                   }
                 >
                   {node}
@@ -220,8 +229,8 @@ export const ProjectOverview: FC = () => {
           <Grid container spacing={1} alignItems="center">
             <Grid item>
               <DataButton
-                loading={!data}
-                secured={data?.project.location}
+                loading={!projectOverviewData}
+                secured={projectOverviewData?.project.location}
                 empty="Enter Location"
                 redacted="You do not have permission to view location"
                 children={displayLocation}
@@ -229,7 +238,7 @@ export const ProjectOverview: FC = () => {
             </Grid>
             <Grid item>
               <DataButton
-                loading={!data}
+                loading={!projectOverviewData}
                 startIcon={<DateRange className={classes.infoColor} />}
                 secured={date}
                 redacted="You do not have permission to view start/end dates"
@@ -240,12 +249,12 @@ export const ProjectOverview: FC = () => {
             </Grid>
             <Grid item>
               <DataButton
-                loading={!data}
-                secured={data?.project.step}
+                loading={!projectOverviewData}
+                secured={projectOverviewData?.project.step}
                 redacted="You do not have permission to view project step"
                 onClick={() => editField('step')}
               >
-                {displayProjectStep(data?.project.step.value)}
+                {displayProjectStep(projectOverviewData?.project.step.value)}
               </DataButton>
             </Grid>
           </Grid>
@@ -256,7 +265,7 @@ export const ProjectOverview: FC = () => {
                 <span {...getRootProps()}>
                   <input {...getInputProps()} />
                   <Fab
-                    loading={!data}
+                    loading={!projectOverviewData}
                     onClick={openFileBrowser}
                     color="primary"
                     aria-label="Upload Files"
@@ -267,33 +276,41 @@ export const ProjectOverview: FC = () => {
               </Grid>
               <Grid item>
                 <Typography variant="h4">
-                  {data ? 'Upload Files' : <Skeleton width="12ch" />}
+                  {projectOverviewData ? (
+                    'Upload Files'
+                  ) : (
+                    <Skeleton width="12ch" />
+                  )}
                 </Typography>
               </Grid>
             </Grid>
           )}
           <div className={classes.container}>
             <BudgetOverviewCard
-              budget={data?.project.budget.value}
+              budget={projectOverviewData?.project.budget.value}
               className={classes.budgetOverviewCard}
-              loading={!data}
+              loading={!projectOverviewData}
             />
             {/* TODO When file api is finished need to update query and pass in file information */}
             <FilesOverviewCard
-              loading={!data}
+              loading={!projectOverviewData}
               total={undefined}
               redacted={canReadDirectoryId === true}
             />
           </div>
           <CardGroup>
-            <ProjectMembersSummary members={data?.project.team} />
-            <PartnershipSummary partnerships={data?.project.partnerships} />
+            <ProjectMembersSummary
+              members={projectOverviewData?.project.team}
+            />
+            <PartnershipSummary
+              partnerships={projectOverviewData?.project.partnerships}
+            />
           </CardGroup>
 
           <Grid container spacing={2} alignItems="center">
             <Grid item>
               <Typography variant="h3">
-                {engagementListData ? (
+                {projectOverviewData && engagementListData ? (
                   !engagementListData.project.engagements.canRead ? (
                     <Redacted
                       info="You do not have permission to view engagements"
@@ -303,7 +320,7 @@ export const ProjectOverview: FC = () => {
                     `${engagementListData.project.engagements.total} ${engagementTypeLabel} Engagements`
                   )
                 ) : (
-                  <Skeleton width="40%" />
+                  <Skeleton width={400} />
                 )}
               </Typography>
             </Grid>
@@ -338,10 +355,10 @@ export const ProjectOverview: FC = () => {
           )}
         </div>
       )}
-      {data ? (
+      {projectOverviewData ? (
         <UpdateProjectDialog
           {...editState}
-          project={data.project}
+          project={projectOverviewData.project}
           editFields={fieldsBeingEdited}
         />
       ) : null}


### PR DESCRIPTION
Separate the loading states for project detail and engagement list with the same query fragment as before.  

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/43487134/94756930-c2c53000-034d-11eb-94ba-2caab30fc54f.gif)

There's an imperfect behavior with the population line.  Just to confirm this is supposed to evaluate to undefined when the populations add up to 0? https://github.com/SeedCompany/cord-field/pull/534/files#diff-b6f8a4fabe48e786a616409ff388e241L116

If so then then on non zero population the page below will shift down when this number gets loaded.  We can put a loading skeleton there, but that means on 0 population (on all internship projects) the page will shift up.

What we can do is if it's an internship project never show this line.  If Translation project then always show a loader or the population total, even if it adds to 0.