### PR TITLE
Display user roles on detail page

### DIFF
--- a/src/scenes/Users/Detail/UserDetail.graphql
+++ b/src/scenes/Users/Detail/UserDetail.graphql
@@ -37,5 +37,10 @@ fragment userDetails on User {
       ...OrganizationListItem
     }
   }
+  roles {
+    canEdit
+    canRead
+    value
+  }
   createdAt
 }

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -6,7 +6,7 @@ import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 import { useParams } from 'react-router';
 import { useInterval } from 'react-use';
-import { canEditAny } from '../../../api';
+import { canEditAny, displayRoles } from '../../../api';
 import { useDialog } from '../../../components/Dialog';
 import {
   DisplaySimpleProperty,
@@ -97,6 +97,11 @@ export const UserDetail = () => {
           <DisplayProperty
             label="Title"
             value={user?.title.value}
+            loading={!user}
+          />
+          <DisplayProperty
+            label="Roles"
+            value={user?.roles.value && displayRoles(user.roles.value)}
             loading={!user}
           />
           <DisplayProperty


### PR DESCRIPTION
Doesn't look great for users with alot of roles, like root, but I this page needs a re-design anyways.
<img width="1576" alt="Screen Shot 2020-10-01 at 12 54 28 PM" src="https://user-images.githubusercontent.com/43487134/94857049-bee4ec80-03e5-11eb-9687-ca8dcbf74b85.png">
 