### PR TITLE
Budget Card loading state with Icon

### DIFF
--- a/src/components/BudgetOverviewCard/BudgetOverviewCard.tsx
+++ b/src/components/BudgetOverviewCard/BudgetOverviewCard.tsx
@@ -25,15 +25,11 @@ export const BudgetOverviewCard: FC<BudgetOverviewCardProps> = ({
       title="Field Budget"
       viewLabel="Budget Details"
       loading={loading}
-      data={
-        budget
-          ? {
-              updatedAt: budget.createdAt,
-              value: formatCurrency(budget.total),
-              to: `budget`,
-            }
-          : undefined
-      }
+      data={{
+        updatedAt: budget?.createdAt,
+        value: budget ? formatCurrency(budget.total) : 'Not Available',
+        to: `budget`,
+      }}
       icon={AccountBalance}
     />
   );


### PR DESCRIPTION
Data prop with a truthy value will render the icon.

Right now inside `FieldOverviewCard` the HugeIcon rendering is decoupled with the loading prop: https://github.com/SeedCompany/cord-field/blob/e42b6ed0a999290970091e4f63d4a0c8752ab04c/src/components/FieldOverviewCard/FieldOverviewCard.tsx#L99

But it seems like Seth wants the icon to render when the card is loading...