### PR TITLE
Prevent stale search results

### DIFF
--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
@@ -3,7 +3,7 @@ import { Search } from '@material-ui/icons';
 import { FC } from 'react';
 import * as React from 'react';
 import { Form } from 'react-final-form';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { TextField } from '../../../../components/form';
 import { makeQueryHandler, StringParam } from '../../../../hooks';
 
@@ -25,6 +25,8 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 export const HeaderSearch: FC = () => {
   const classes = useStyles();
   const [{ q: search = '' }] = useSearch();
+  const { pathname, search: routeSearch } = useLocation();
+  const currentSearch = routeSearch.split('?q=')[1];
   const navigate = useNavigate();
 
   return (
@@ -32,7 +34,12 @@ export const HeaderSearch: FC = () => {
       initialValues={{ search }}
       onSubmit={({ search }) => {
         if (search) {
-          navigate(`/search?q=${search}`);
+          // cover cases where the user searches for the exact same thing again
+          if (pathname === '/search' && search === currentSearch) {
+            navigate(0);
+          } else {
+            navigate(`/search?q=${search}`);
+          }
         }
       }}
     >

--- a/src/scenes/SearchResults/SearchResults.tsx
+++ b/src/scenes/SearchResults/SearchResults.tsx
@@ -34,6 +34,7 @@ export const SearchResults: FC = () => {
     variables: {
       input: { query: query ?? '' },
     },
+    fetchPolicy: 'cache-and-network',
   });
 
   const displayItem = (item: SearchResult) => {


### PR DESCRIPTION
Closes #546 

- Add `fetchPolicy: 'cache-and-network'` to search query to make sure that results added since last fetch are pulled in
- Add logic to reload the search page if the user searches for the exact same thing again

I don't love this page reload, but `makeQueryParams` is memoized so as not to re-render unless the query changes. It seems like performing a search, then performing the exact same search again without navigating away from the search page, will probably be kind of an edge case, so it's probably okay.