### PR TITLE
Project overview height mismatch

### DIFF
--- a/src/components/FieldOverviewCard/FieldOverviewCard.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.tsx
@@ -23,15 +23,18 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
     flex: 1,
     height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
   },
   topArea: {
-    height: '100%',
+    flex: 1,
     display: 'flex',
     justifyContent: 'space-evenly',
     padding: spacing(3, 4),
   },
   rightContent: {
     flex: 1,
+    alignSelf: 'flex-start',
     paddingLeft: spacing(4),
     display: 'flex',
     flexDirection: 'column',

--- a/src/components/FieldOverviewCard/FieldOverviewCard.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.tsx
@@ -125,11 +125,11 @@ export const FieldOverviewCard: FC<FieldOverviewCardProps> = ({
         <CardActions>
           <Grid
             container
-            spacing={!data ? 4 : 2}
+            spacing={loading ? 4 : 2}
             wrap="nowrap"
             className={classes.bottomArea}
           >
-            <Grid item xs={!data}>
+            <Grid item xs={loading}>
               <Btn
                 color="primary"
                 to={data?.to ?? ''}
@@ -146,7 +146,7 @@ export const FieldOverviewCard: FC<FieldOverviewCardProps> = ({
                 )}
               </Btn>
             </Grid>
-            <Grid item xs={!data}>
+            <Grid item xs={loading}>
               {!redacted && (
                 <Typography color="textSecondary" variant="body2">
                   {loading ? (

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -57,13 +57,6 @@ const useStyles = makeStyles(({ spacing, breakpoints, palette }) => ({
   nameLoading: {
     width: '60%',
   },
-  container: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  budgetOverviewCard: {
-    marginRight: spacing(3),
-  },
   infoColor: {
     color: palette.info.main,
   },
@@ -364,19 +357,22 @@ export const ProjectOverview: FC = () => {
               </Grid>
             </Grid>
           )}
-          <div className={classes.container}>
-            <BudgetOverviewCard
-              budget={projectOverviewData?.project.budget.value}
-              className={classes.budgetOverviewCard}
-              loading={!projectOverviewData}
-            />
-            {/* TODO When file api is finished need to update query and pass in file information */}
-            <FilesOverviewCard
-              loading={!projectOverviewData}
-              total={undefined}
-              redacted={canReadDirectoryId === true}
-            />
-          </div>
+          <Grid container spacing={3}>
+            <Grid item xs={6}>
+              <BudgetOverviewCard
+                budget={projectOverviewData?.project.budget.value}
+                loading={!projectOverviewData}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              {/* TODO When file api is finished need to update query and pass in file information */}
+              <FilesOverviewCard
+                loading={!projectOverviewData}
+                total={undefined}
+                redacted={canReadDirectoryId === true}
+              />
+            </Grid>
+          </Grid>
           <CardGroup>
             <ProjectMembersSummary
               members={projectOverviewData?.project.team}


### PR DESCRIPTION
The card height became mismatched after removing the grid: https://github.com/SeedCompany/cord-field/commit/edabe9367a8a1e38b6b4eebcff633e5658c4c1f1.  
That was to make the two rows independent of each other. 

<img width="648" alt="Screen Shot 2020-10-12 at 8 44 52 AM" src="https://user-images.githubusercontent.com/43487134/95765892-514b8280-0c67-11eb-986c-deff8bed4e5e.png">
 I added back the grid container only on the top row to make the card height across the row consistent and also the two rows independent.