### PR TITLE
Update full testament and full book displays

### DIFF
--- a/src/scenes/Products/ProductForm/AccordionSection.tsx
+++ b/src/scenes/Products/ProductForm/AccordionSection.tsx
@@ -307,11 +307,13 @@ export const AccordionSection = ({
                     <ToggleButton
                       key={book}
                       value={book}
-                      selected={Boolean(matchingArr.length)}
+                      selected={Boolean(matchingArr.length) || fullOldTestament}
                       disabled={disabled || fullOldTestament}
                       onClick={openBook}
                     >
-                      {getScriptureRangeDisplay(matchingArr, book)}
+                      {fullOldTestament
+                        ? book
+                        : getScriptureRangeDisplay(matchingArr, book)}
                     </ToggleButton>
                   );
                 })}
@@ -334,11 +336,13 @@ export const AccordionSection = ({
                   <ToggleButton
                     key={book}
                     value={book}
-                    selected={Boolean(matchingArr.length)}
+                    selected={Boolean(matchingArr.length) || fullNewTestament}
                     disabled={disabled || fullNewTestament}
                     onClick={openBook}
                   >
-                    {getScriptureRangeDisplay(matchingArr, book)}
+                    {fullNewTestament
+                      ? book
+                      : getScriptureRangeDisplay(matchingArr, book)}
                   </ToggleButton>
                 );
               })}

--- a/src/util/biblejs/reference.ts
+++ b/src/util/biblejs/reference.ts
@@ -220,16 +220,25 @@ export const matchingScriptureRanges = (
     ({ start: { book } }: ScriptureRange) => book === bookToMatch
   );
 
+/**
+ * Takes in a scripture range arr and a book, outputs the shortened display string of this range.
+ * Assumes all ranges in array are of the same book
+ * e.g. "Luke 1:2-4 + 1 more" or "Job (Full Book)".
+ * @param scriptureReferenceArr
+ * @param book
+ */
 export const getScriptureRangeDisplay = (
   scriptureReferenceArr: readonly ScriptureRange[],
   book: string
 ) => {
   const count = scriptureReferenceArr.length;
-  return count
-    ? `${book} ${formatScriptureRange(scriptureReferenceArr[0])} ${
+  if (!count) return book;
+  const isFullBook = isEqual(scriptureReferenceArr[0], getFullBookRange(book));
+  return isFullBook
+    ? `${book} (Full Book)`
+    : `${book} ${formatScriptureRange(scriptureReferenceArr[0])} ${
         count > 1 ? `+ ${count - 1} more` : ''
-      }`
-    : book;
+      }`;
 };
 
 /**


### PR DESCRIPTION
Full Testament:
I selected all buttons but did have to disable them to remove the click and hover.  
<img width="932" alt="Screen Shot 2020-10-14 at 11 37 27 AM" src="https://user-images.githubusercontent.com/43487134/96031232-f013e280-0e11-11eb-8cec-df749b104cc8.png">


Full Book:

<img width="302" alt="Screen Shot 2020-10-14 at 11 37 16 AM" src="https://user-images.githubusercontent.com/43487134/96031224-ee4a1f00-0e11-11eb-96e7-473e54081e57.png">
<img width="938" alt="Screen Shot 2020-10-14 at 11 37 22 AM" src="https://user-images.githubusercontent.com/43487134/96031229-ef7b4c00-0e11-11eb-91d0-9ba86f31d892.png">

