### PR TITLE
Fix render crash with EnumField

### DIFF
--- a/src/components/form/EnumField.tsx
+++ b/src/components/form/EnumField.tsx
@@ -303,8 +303,6 @@ export const EnumField = <
         }
         onBlur(e);
       }}
-      // If FF says we're focused, show us as focused, regardless of actual focus
-      focused={meta.active}
     >
       {label && (
         <FormLabel component="legend" className={classes.fieldLabel}>


### PR DESCRIPTION
Fixes #488

This removes faking focus on `EnumField`.

This was just thrown in randomly to try to help sync FF focus state with browser state. But it doesn't do that it just shows as focused even when the browser is unaware.

It also caused an infinite render loop with `<FormControl />` which would try (and fail) to set focus to false when disabled while rendering ([source](https://github.com/mui-org/material-ui/blob/c01ce018c9860cad2d2dddcca38ad28495336f15/packages/material-ui/src/FormControl/FormControl.js#L127)). 
While I don't agree that the MUI code is the best, I can agree that we shouldn't show focused while field is disabled.
If we wanted to keep this code, we could change it to `active && !disabled`. I started with this change but then realized the above paragraph.