### PR TITLE
Debug API delays

### DIFF
--- a/src/api/ApolloProvider.tsx
+++ b/src/api/ApolloProvider.tsx
@@ -25,11 +25,27 @@ import { typePolicies } from './typePolicies';
 
 const serverHost = process.env.REACT_APP_API_BASE_URL || '';
 
-const API_DEBUG = {
+let API_DEBUG = {
   delay: 0,
 };
 if (process.env.NODE_ENV !== 'production') {
+  let privateDelay = 0;
+  API_DEBUG = {
+    get delay() {
+      return privateDelay;
+    },
+    set delay(newDelay) {
+      privateDelay = newDelay;
+      saveState();
+    },
+  };
   (globalThis as any).API_DEBUG = API_DEBUG;
+  const saveState = () =>
+    window.history.replaceState({ API_DEBUG }, window.document.title);
+  const prev = window.history.state?.API_DEBUG;
+  if (prev) {
+    API_DEBUG.delay = prev.delay;
+  }
 }
 
 export const ApolloProvider: FC = ({ children }) => {

--- a/src/api/ApolloProvider.tsx
+++ b/src/api/ApolloProvider.tsx
@@ -65,7 +65,10 @@ export const ApolloProvider: FC = ({ children }) => {
         ? null
         : (operation, forward) => {
             const currentDelay = API_DEBUG.delay;
-            if (!currentDelay) {
+            if (
+              !currentDelay ||
+              operation.operationName === GQLOperations.Query.Session
+            ) {
               return forward(operation);
             }
             return promiseToObservable(sleep(currentDelay)).flatMap(() =>


### PR DESCRIPTION
A lot of times are trying to dev loading states and we want to simulate more delay from the API. This is usually done with the browser's network throttling. However, this is frustrating because it also slows down retrieving our UI code with every change. Which is typically very large for non-production - a few MBs at least.

So this change allows you to only "slow down" (delay) requests to the API. This increases efficiency while deving because it shortens the cycle between making code change, seeing loading state in UI, seeing UI transition to real data, repeat.

The delay can be set in dev console
```
API_DEBUG.delay = 5000; // milliseconds
```
It's persisted in history so it doesn't reset on page refreshes (either from your CMD+R or code changes).