### PR TITLE
Use powers to check create

### DIFF
--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -11,8 +11,9 @@ import {
 export const useSession = () => {
   const { data, loading: sessionLoading } = useSessionQuery();
   const session = data?.session.user;
+  const powers = data?.session.powers;
 
-  return { session, sessionLoading };
+  return { session, sessionLoading, powers };
 };
 
 export const updateSessionCache = <T extends LoginMutation | RegisterMutation>(

--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -1,4 +1,5 @@
 import { ApolloCache } from '@apollo/client';
+import { SessionOutput } from '../../api';
 import { LoginMutation } from '../../scenes/Authentication/Login/Login.generated';
 import { RegisterMutation } from '../../scenes/Authentication/Register/register.generated';
 import {
@@ -18,8 +19,9 @@ export const useSession = () => {
 
 export const updateSessionCache = <T extends LoginMutation | RegisterMutation>(
   cache: ApolloCache<T>,
-  user: LoggedInUserFragment
+  sessionData: { user?: LoggedInUserFragment; powers?: SessionOutput['powers'] }
 ) => {
+  const { user, powers } = sessionData;
   const currentSession = cache.readQuery<SessionQuery>({
     query: SessionDocument,
   });
@@ -32,6 +34,7 @@ export const updateSessionCache = <T extends LoginMutation | RegisterMutation>(
           ...currentSession.session.user,
           ...user,
         },
+        powers: [...(powers ? powers : currentSession.session.powers || [])],
       },
     };
     cache.writeQuery({ query: SessionDocument, data: updatedSession });

--- a/src/components/Session/session.graphql
+++ b/src/components/Session/session.graphql
@@ -3,6 +3,7 @@ query Session {
     user {
       ...LoggedInUser
     }
+    powers
   }
 }
 

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -22,9 +22,10 @@ import React, {
   useState,
 } from 'react';
 import { Except, SetOptional } from 'type-fest';
-import { isNetworkRequestInFlight } from '../../../api';
+import { isNetworkRequestInFlight, Power } from '../../../api';
 import { useDialog } from '../../Dialog';
 import { DialogFormProps } from '../../Dialog/DialogForm';
+import { useSession } from '../../Session';
 import { FieldConfig, useField, useFieldName } from '../index';
 import {
   getHelperText,
@@ -66,6 +67,7 @@ export type LookupFieldProps<
     >;
     getInitialValues?: (val: string) => Partial<CreateFormValues>;
     getOptionLabel: (option: T) => string | null | undefined;
+    createPower?: Power;
   } & Except<
     AutocompleteProps<T, Multiple, DisableClearable, false>,
     | 'value'
@@ -105,9 +107,12 @@ export function LookupField<
   getCompareBy,
   getOptionLabel: getOptionLabelProp,
   variant,
+  createPower,
   ...props
 }: LookupFieldProps<T, Multiple, DisableClearable, CreateFormValues>) {
-  const freeSolo = !!CreateDialogForm;
+  const { powers } = useSession();
+  const canCreate = createPower && powers?.includes(createPower);
+  const freeSolo = !!CreateDialogForm && canCreate;
   type Val = Value<T, Multiple, DisableClearable, false>;
   const defaultValue =
     defaultValueProp ?? ((multiple ? emptyArray : null) as Val);
@@ -363,12 +368,14 @@ LookupField.createFor = <T extends { id: string }, CreateFormValues = never>({
       'useLookup' | 'getCompareBy' | 'getOptionLabel'
     >
   ) {
+    const createPower = `Create${resource}` as Power;
     return (
       <LookupField<T, Multiple, DisableClearable, CreateFormValues>
         getCompareBy={compareBy}
         getOptionLabel={(item: StandardNamedObject) => item.name.value}
         {...(config as any)}
         {...props}
+        createPower={createPower}
       />
     );
   };

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -368,14 +368,13 @@ LookupField.createFor = <T extends { id: string }, CreateFormValues = never>({
       'useLookup' | 'getCompareBy' | 'getOptionLabel'
     >
   ) {
-    const createPower = `Create${resource}` as Power;
     return (
       <LookupField<T, Multiple, DisableClearable, CreateFormValues>
         getCompareBy={compareBy}
         getOptionLabel={(item: StandardNamedObject) => item.name.value}
+        createPower={`Create${resource}` as Power}
         {...(config as any)}
         {...props}
-        createPower={createPower}
       />
     );
   };

--- a/src/scenes/Authentication/Login/Login.graphql
+++ b/src/scenes/Authentication/Login/Login.graphql
@@ -3,5 +3,6 @@ mutation Login($input: LoginInput!) {
     user {
       ...LoggedInUser
     }
+    powers
   }
 }

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -26,10 +26,10 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
       await login({
         variables: { input },
         update: (cache, { data }) => {
-          const user = data?.login.user;
-          if (user) {
+          const sessionData = data?.login;
+          if (sessionData) {
             setSuccess(true);
-            updateSessionCache(cache, user);
+            updateSessionCache(cache, sessionData);
           }
         },
       });

--- a/src/scenes/Authentication/Register/Register.tsx
+++ b/src/scenes/Authentication/Register/Register.tsx
@@ -31,10 +31,10 @@ export const Register = (props: Except<Props, 'onSubmit'>) => {
           },
         },
         update: (cache, { data }) => {
-          const user = data?.register.user;
-          if (user) {
+          const sessionData = data?.register;
+          if (sessionData) {
             setSuccess(true);
-            updateSessionCache(cache, user);
+            updateSessionCache(cache, sessionData);
           }
         },
       });

--- a/src/scenes/Authentication/Register/register.graphql
+++ b/src/scenes/Authentication/Register/register.graphql
@@ -3,5 +3,6 @@ mutation Register($input: RegisterInput!) {
     user {
       ...LoggedInUser
     }
+    powers
   }
 }

--- a/src/scenes/Root/Sidebar/Sidebar.tsx
+++ b/src/scenes/Root/Sidebar/Sidebar.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import { CreateButton } from '../../../components/CreateButton';
 import { useDialog } from '../../../components/Dialog';
 import { ListItemLink, ListItemLinkProps } from '../../../components/Routing';
+import { useSession } from '../../../components/Session';
 import { CreateLanguage } from '../../Languages/Create';
 import { CreatePartner } from '../../Partners/Create';
 import { CreateProject } from '../../Projects/Create';
@@ -52,6 +53,14 @@ export const Sidebar: FC = () => {
   const [createLanguageState, createLanguage] = useDialog();
   const [createUserState, createUser] = useDialog();
 
+  const { powers } = useSession();
+
+  const canCreatePartner = powers?.includes('CreatePartner');
+  const canCreateProject = powers?.includes('CreateProject');
+  const canCreateLanguage = powers?.includes('CreateLanguage');
+  const canCreateUser = powers?.includes('CreateUser');
+  const canCreateAny =
+    canCreatePartner || canCreateProject || canCreateLanguage || canCreateUser;
   const createMenu = (
     <Menu
       id="create-menu"
@@ -69,10 +78,18 @@ export const Sidebar: FC = () => {
         horizontal: 'center',
       }}
     >
-      <MenuItem onClick={closeAnd(createPartner)}>Partner</MenuItem>
-      <MenuItem onClick={closeAnd(createProject)}>Project</MenuItem>
-      <MenuItem onClick={closeAnd(createLanguage)}>Language</MenuItem>
-      <MenuItem onClick={closeAnd(createUser)}>Person</MenuItem>
+      {canCreatePartner && (
+        <MenuItem onClick={closeAnd(createPartner)}>Partner</MenuItem>
+      )}
+      {canCreateProject && (
+        <MenuItem onClick={closeAnd(createProject)}>Project</MenuItem>
+      )}
+      {canCreateLanguage && (
+        <MenuItem onClick={closeAnd(createLanguage)}>Language</MenuItem>
+      )}
+      {canCreateUser && (
+        <MenuItem onClick={closeAnd(createUser)}>Person</MenuItem>
+      )}
     </Menu>
   );
 
@@ -94,16 +111,18 @@ export const Sidebar: FC = () => {
       <Paper square className={classes.root}>
         <SidebarHeader />
         <div className={classes.content}>
-          <CreateButton
-            className={classes.createNewItem}
-            fullWidth
-            aria-controls="create-menu"
-            aria-haspopup="true"
-            startIcon={<Add />}
-            onClick={openAddMenu}
-          >
-            Create New Item
-          </CreateButton>
+          {canCreateAny && (
+            <CreateButton
+              className={classes.createNewItem}
+              fullWidth
+              aria-controls="create-menu"
+              aria-haspopup="true"
+              startIcon={<Add />}
+              onClick={openAddMenu}
+            >
+              Create New Item
+            </CreateButton>
+          )}
           {createMenu}
           {navList}
         </div>


### PR DESCRIPTION
Ask for powers in session, login and register, and merge all into session cache with `updateSessionCache`.  have `useSession` hook also return powers to be used at the component level.

Have `LookupField` take in a `canCreate` prop and tie it to `freeSolo`.  Now every time a field is used must pass in `canCreate=true` to enable the create functionality.