### PR TITLE
Add tooltips to fab icons

### DIFF
--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -111,9 +111,11 @@ export const LanguageDetail = () => {
               )}
             </Typography>
             {canEditAnyFields ? (
-              <Fab color="primary" aria-label="edit language" onClick={edit}>
-                <Edit />
-              </Fab>
+              <Tooltip title="Edit Language">
+                <Fab color="primary" aria-label="edit language" onClick={edit}>
+                  <Edit />
+                </Fab>
+              </Tooltip>
             ) : null}
           </div>
           <Grid container spacing={2} alignItems="center">

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -203,14 +203,16 @@ export const ProjectOverview: FC = () => {
             </Typography>
             {(!projectOverviewData ||
               projectOverviewData.project.name.canEdit) && (
-              <Fab
-                color="primary"
-                aria-label="edit project name"
-                onClick={() => editField(['name'])}
-                loading={!projectOverviewData}
-              >
-                <Edit />
-              </Fab>
+              <Tooltip title="Edit Project Name">
+                <Fab
+                  color="primary"
+                  aria-label="edit project name"
+                  onClick={() => editField(['name'])}
+                  loading={!projectOverviewData}
+                >
+                  <Edit />
+                </Fab>
+              </Tooltip>
             )}
           </header>
 
@@ -356,15 +358,17 @@ export const ProjectOverview: FC = () => {
             <Grid item>
               <span {...getRootProps()}>
                 <input {...getInputProps()} />
-                <Fab
-                  loading={!projectOverviewData || directoryIdLoading}
-                  disabled={canReadDirectoryId === false}
-                  onClick={openFileBrowser}
-                  color="primary"
-                  aria-label="Upload Files"
-                >
-                  <Publish />
-                </Fab>
+                <Tooltip title="Upload Files">
+                  <Fab
+                    loading={!projectOverviewData || directoryIdLoading}
+                    disabled={canReadDirectoryId === false}
+                    onClick={openFileBrowser}
+                    color="primary"
+                    aria-label="Upload Files"
+                  >
+                    <Publish />
+                  </Fab>
+                </Tooltip>
               </span>
             </Grid>
             <Grid item>

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Typography } from '@material-ui/core';
+import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
@@ -84,9 +84,15 @@ export const UserDetail = () => {
               )}
             </Typography>
             {canEditAnyFields ? (
-              <Fab color="primary" aria-label="edit person" onClick={editUser}>
-                <Edit />
-              </Fab>
+              <Tooltip title="Edit Person">
+                <Fab
+                  color="primary"
+                  aria-label="edit person"
+                  onClick={editUser}
+                >
+                  <Edit />
+                </Fab>
+              </Tooltip>
             ) : null}
           </div>
           <DisplayProperty


### PR DESCRIPTION
Only one left out is engagement loading scene but I don't think we need a tooltip there.
https://github.com/SeedCompany/cord-field/blob/41b471fba6ec34c367746f56468ccb573e515d95/src/scenes/Engagement/EngagementDetailLoading.tsx#L50

I used the same text as the fab aria labels, but that means some are upper case and some are lower case.  Let me know if that needs to be normalized.