### PR TITLE
Refresh Project Files List on new file upload

### DIFF
--- a/src/components/files/FileActions/FileActions.graphql
+++ b/src/components/files/FileActions/FileActions.graphql
@@ -13,6 +13,7 @@ query FileVersions($id: ID!) {
 mutation CreateFileVersion($input: CreateFileVersionInput!) {
   createFileVersion(input: $input) {
     id
+    ...FileNodeInfo
     children {
       items {
         ...FileVersionItem

--- a/src/scenes/Projects/Files/ProjectFiles.graphql
+++ b/src/scenes/Projects/Files/ProjectFiles.graphql
@@ -28,18 +28,22 @@ fragment ProjectDirectoryFileNode on FileNode {
   }
 }
 
+fragment ProjectDirectoryContents on Directory {
+  ...FileNodeInfo
+  children {
+    total
+    items {
+      ...ProjectDirectoryFileNode
+    }
+  }
+  parents {
+    id
+    name
+  }
+}
+
 query ProjectDirectory($id: ID!) {
   directory(id: $id) {
-    ...FileNodeInfo
-    children {
-      total
-      items {
-        ...ProjectDirectoryFileNode
-      }
-    }
-    parents {
-      id
-      name
-    }
+    ...ProjectDirectoryContents
   }
 }

--- a/src/scenes/Projects/Files/useUploadProjectFiles.ts
+++ b/src/scenes/Projects/Files/useUploadProjectFiles.ts
@@ -74,7 +74,7 @@ export const useUploadProjectFiles = (): UploadFilesConsumerFunction => {
             } catch {
               /**
                * We need this try/catch because if this data has never been fetched
-               * before, `cache.readQuery` will throw an error instead of returning
+               * before, `cache.readFragment` will throw an error instead of returning
                * anything, which is apparently a behavior the Apollo team finds
                * acceptable.
                */

--- a/src/scenes/Projects/Files/useUploadProjectFiles.ts
+++ b/src/scenes/Projects/Files/useUploadProjectFiles.ts
@@ -11,6 +11,10 @@ import {
 } from '../../../components/files/hooks';
 import { updateCachedVersions } from '../../../components/files/updateCachedVersions';
 import { useUpdateProjectBudgetUniversalTemplateMutation } from '../Budget/ProjectBudget.generated';
+import {
+  ProjectDirectoryContentsFragment,
+  ProjectDirectoryContentsFragmentDoc,
+} from './ProjectFiles.generated';
 
 export const useUploadProjectFiles = (): UploadFilesConsumerFunction => {
   const uploadFiles = useUploadFiles();
@@ -33,11 +37,50 @@ export const useUploadProjectFiles = (): UploadFilesConsumerFunction => {
         action === 'file' ? [GQLOperations.Query.ProjectDirectory] : undefined,
       update: (cache, { data }) => {
         if (data?.createFileVersion) {
-          updateCachedVersions<CreateFileVersionMutation>(
-            cache,
-            data.createFileVersion.children.items,
-            parentId
-          );
+          if (action === 'version') {
+            updateCachedVersions<CreateFileVersionMutation>(
+              cache,
+              data.createFileVersion.children.items,
+              parentId
+            );
+          } else {
+            try {
+              const id = `Directory:${parentId}`;
+              const response = cache.readFragment<
+                ProjectDirectoryContentsFragment
+              >({
+                id,
+                fragment: ProjectDirectoryContentsFragmentDoc,
+                fragmentName: 'ProjectDirectoryContents',
+              });
+              if (response) {
+                const newFile = data.createFileVersion;
+                const currentItems = response.children.items;
+                const updatedData = {
+                  ...response,
+                  children: {
+                    ...response.children,
+                    items: currentItems.concat(newFile),
+                    total: currentItems.length + 1,
+                  },
+                };
+                cache.writeFragment<ProjectDirectoryContentsFragment>({
+                  id,
+                  fragment: ProjectDirectoryContentsFragmentDoc,
+                  fragmentName: 'ProjectDirectoryContents',
+                  data: updatedData,
+                });
+              }
+            } catch {
+              /**
+               * We need this try/catch because if this data has never been fetched
+               * before, `cache.readQuery` will throw an error instead of returning
+               * anything, which is apparently a behavior the Apollo team finds
+               * acceptable.
+               */
+              return;
+            }
+          }
         }
       },
     });


### PR DESCRIPTION
Closes #612 

- Add new `ProjectDirectoryContents` fragment and use in `ProjectDirectory` query instead of inline fields
- Update `useUploadProjectFiles` hook to write newly uploaded file into cache for immediate UI refresh