### PR TITLE
547 update cache after user actions

### DIFF
--- a/src/scenes/Languages/Create/CreateLanguage.graphql
+++ b/src/scenes/Languages/Create/CreateLanguage.graphql
@@ -1,17 +1,9 @@
 mutation createLanguage($input: CreateLanguageInput!) {
   createLanguage(input: $input) {
     language {
-      ...NewLanguage
+      id
+      name { value }
+      ...LanguageListItem
     }
   }
-}
-
-fragment NewLanguage on Language {
-  id
-  name {
-    value
-    canRead
-    canEdit
-  }
-  createdAt
 }

--- a/src/scenes/Languages/Create/CreateLanguage.graphql
+++ b/src/scenes/Languages/Create/CreateLanguage.graphql
@@ -1,13 +1,17 @@
 mutation createLanguage($input: CreateLanguageInput!) {
   createLanguage(input: $input) {
     language {
-      id
-      name {
-        value
-        canRead
-        canEdit
-      }
-      createdAt
+      ...NewLanguage
     }
   }
+}
+
+fragment NewLanguage on Language {
+  id
+  name {
+    value
+    canRead
+    canEdit
+  }
+  createdAt
 }

--- a/src/scenes/Languages/Create/CreateLanguage.tsx
+++ b/src/scenes/Languages/Create/CreateLanguage.tsx
@@ -2,12 +2,9 @@ import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
-import {
-  CreateLanguage as CreateLanguageType,
-  GQLOperations,
-} from '../../../api';
+import { CreateLanguage as CreateLanguageType } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';
-import { CalendarDate, updateListQueryItems } from '../../../util';
+import { addItemToList, CalendarDate } from '../../../util';
 import {
   LanguageForm,
   LanguageFormProps,
@@ -23,7 +20,13 @@ export type CreateLanguageProps = Except<
   'onSubmit'
 >;
 export const CreateLanguage = (props: CreateLanguageProps) => {
-  const [createLang] = useMutation(CreateLanguageDocument);
+  const [createLang] = useMutation(CreateLanguageDocument, {
+    update: addItemToList(
+      'languages',
+      NewLanguageFragmentDoc,
+      (data) => data.createLanguage.language
+    ),
+  });
   const { enqueueSnackbar } = useSnackbar();
 
   return (
@@ -41,22 +44,6 @@ export const CreateLanguage = (props: CreateLanguageProps) => {
                 ...rest,
               },
             },
-          },
-          update(cache, { data }) {
-            cache.modify({
-              fields: {
-                languages(existingItemRefs, { readField }) {
-                  updateListQueryItems({
-                    cache,
-                    existingItemRefs,
-                    fragment: NewLanguageFragmentDoc,
-                    fragmentName: GQLOperations.Fragment.NewLanguage,
-                    newItem: data?.createLanguage.language,
-                    readField,
-                  });
-                },
-              },
-            });
           },
         });
 

--- a/src/scenes/Languages/Create/CreateLanguage.tsx
+++ b/src/scenes/Languages/Create/CreateLanguage.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
@@ -50,7 +49,7 @@ export const CreateLanguage = (props: CreateLanguageProps) => {
                   updateListQueryItems({
                     cache,
                     existingItemRefs,
-                    fragment: NewLanguageFragmentDoc as DocumentNode,
+                    fragment: NewLanguageFragmentDoc,
                     fragmentName: GQLOperations.Fragment.NewLanguage,
                     newItem: data?.createLanguage.language,
                     readField,

--- a/src/scenes/Languages/Create/CreateLanguage.tsx
+++ b/src/scenes/Languages/Create/CreateLanguage.tsx
@@ -3,6 +3,7 @@ import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
 import { CreateLanguage as CreateLanguageType } from '../../../api';
+import { LanguageListItemFragmentDoc } from '../../../components/LanguageListItemCard/LanguageListItem.generated';
 import { ButtonLink } from '../../../components/Routing';
 import { addItemToList, CalendarDate } from '../../../util';
 import {
@@ -10,10 +11,7 @@ import {
   LanguageFormProps,
   LanguageFormValues,
 } from '../LanguageForm';
-import {
-  CreateLanguageDocument,
-  NewLanguageFragmentDoc,
-} from './CreateLanguage.generated';
+import { CreateLanguageDocument } from './CreateLanguage.generated';
 
 export type CreateLanguageProps = Except<
   LanguageFormProps<LanguageFormValues<CreateLanguageType>>,
@@ -23,7 +21,7 @@ export const CreateLanguage = (props: CreateLanguageProps) => {
   const [createLang] = useMutation(CreateLanguageDocument, {
     update: addItemToList(
       'languages',
-      NewLanguageFragmentDoc,
+      LanguageListItemFragmentDoc,
       (data) => data.createLanguage.language
     ),
   });

--- a/src/scenes/Partners/Create/CreatePartner.graphql
+++ b/src/scenes/Partners/Create/CreatePartner.graphql
@@ -1,12 +1,12 @@
 mutation CreatePartner($input: CreatePartnerInput!) {
   createPartner(input: $input) {
     partner {
-      ...NewPartner
+      id
+      organization { value {
+        name { value }
+      }}
+      ...PartnerListItem
+      ...PartnerLookupItem
     }
   }
-}
-
-fragment NewPartner on Partner {
-  id
-  ...PartnerLookupItem
 }

--- a/src/scenes/Partners/Create/CreatePartner.graphql
+++ b/src/scenes/Partners/Create/CreatePartner.graphql
@@ -1,8 +1,12 @@
 mutation CreatePartner($input: CreatePartnerInput!) {
   createPartner(input: $input) {
     partner {
-      id
-      ...PartnerLookupItem
+      ...NewPartner
     }
   }
+}
+
+fragment NewPartner on Partner {
+  id
+  ...PartnerLookupItem
 }

--- a/src/scenes/Partners/Create/CreatePartner.tsx
+++ b/src/scenes/Partners/Create/CreatePartner.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
@@ -54,7 +53,7 @@ export const CreatePartner = (props: CreatePartnerProps) => {
                   updateListQueryItems({
                     cache,
                     existingItemRefs,
-                    fragment: NewPartnerFragmentDoc as DocumentNode,
+                    fragment: NewPartnerFragmentDoc,
                     fragmentName: GQLOperations.Fragment.NewPartner,
                     newItem: data?.createPartner.partner,
                     readField,

--- a/src/scenes/Partners/Create/CreatePartner.tsx
+++ b/src/scenes/Partners/Create/CreatePartner.tsx
@@ -2,9 +2,8 @@ import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
-import { GQLOperations } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';
-import { updateListQueryItems } from '../../../util';
+import { addItemToList } from '../../../util';
 import {
   CreatePartnerDocument,
   CreatePartnerMutation,
@@ -18,7 +17,13 @@ type CreatePartnerProps = Except<
 >;
 
 export const CreatePartner = (props: CreatePartnerProps) => {
-  const [createPartner] = useMutation(CreatePartnerDocument);
+  const [createPartner] = useMutation(CreatePartnerDocument, {
+    update: addItemToList(
+      'partners',
+      NewPartnerFragmentDoc,
+      (data) => data.createPartner.partner
+    ),
+  });
   const { enqueueSnackbar } = useSnackbar();
 
   return (
@@ -45,22 +50,6 @@ export const CreatePartner = (props: CreatePartnerProps) => {
                 organizationId,
               },
             },
-          },
-          update(cache, { data }) {
-            cache.modify({
-              fields: {
-                partners(existingItemRefs, { readField }) {
-                  updateListQueryItems({
-                    cache,
-                    existingItemRefs,
-                    fragment: NewPartnerFragmentDoc,
-                    fragmentName: GQLOperations.Fragment.NewPartner,
-                    newItem: data?.createPartner.partner,
-                    readField,
-                  });
-                },
-              },
-            });
           },
         });
         return data!.createPartner.partner;

--- a/src/scenes/Partners/Create/CreatePartner.tsx
+++ b/src/scenes/Partners/Create/CreatePartner.tsx
@@ -1,12 +1,15 @@
 import { useMutation } from '@apollo/client';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
 import { GQLOperations } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';
+import { updateListQueryItems } from '../../../util';
 import {
   CreatePartnerDocument,
   CreatePartnerMutation,
+  NewPartnerFragmentDoc,
 } from './CreatePartner.generated';
 import { CreatePartnerForm, CreatePartnerFormProps } from './CreatePartnerForm';
 
@@ -44,7 +47,22 @@ export const CreatePartner = (props: CreatePartnerProps) => {
               },
             },
           },
-          refetchQueries: [GQLOperations.Query.Partners],
+          update(cache, { data }) {
+            cache.modify({
+              fields: {
+                partners(existingItemRefs, { readField }) {
+                  updateListQueryItems({
+                    cache,
+                    existingItemRefs,
+                    fragment: NewPartnerFragmentDoc as DocumentNode,
+                    fragmentName: GQLOperations.Fragment.NewPartner,
+                    newItem: data?.createPartner.partner,
+                    readField,
+                  });
+                },
+              },
+            });
+          },
         });
         return data!.createPartner.partner;
       }}

--- a/src/scenes/Partners/Create/CreatePartner.tsx
+++ b/src/scenes/Partners/Create/CreatePartner.tsx
@@ -2,12 +2,12 @@ import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
+import { PartnerListItemFragmentDoc } from '../../../components/PartnerListItemCard/PartnerListItemCard.generated';
 import { ButtonLink } from '../../../components/Routing';
 import { addItemToList } from '../../../util';
 import {
   CreatePartnerDocument,
   CreatePartnerMutation,
-  NewPartnerFragmentDoc,
 } from './CreatePartner.generated';
 import { CreatePartnerForm, CreatePartnerFormProps } from './CreatePartnerForm';
 
@@ -20,7 +20,7 @@ export const CreatePartner = (props: CreatePartnerProps) => {
   const [createPartner] = useMutation(CreatePartnerDocument, {
     update: addItemToList(
       'partners',
-      NewPartnerFragmentDoc,
+      PartnerListItemFragmentDoc,
       (data) => data.createPartner.partner
     ),
   });

--- a/src/scenes/Projects/Create/CreateProject.graphql
+++ b/src/scenes/Projects/Create/CreateProject.graphql
@@ -1,18 +1,9 @@
 mutation CreateProject($input: CreateProjectInput!) {
   createProject(input: $input) {
     project {
-      ...NewProject
+      id
+      name { value }
+      ...ProjectListItem
     }
   }
-}
-
-fragment NewProject on Project {
-  id
-  name {
-    value
-    canRead
-    canEdit
-  }
-  type
-  createdAt
 }

--- a/src/scenes/Projects/Create/CreateProject.graphql
+++ b/src/scenes/Projects/Create/CreateProject.graphql
@@ -1,14 +1,18 @@
 mutation CreateProject($input: CreateProjectInput!) {
   createProject(input: $input) {
     project {
-      id
-      name {
-        value
-        canRead
-        canEdit
-      }
-      type
-      createdAt
+      ...NewProject
     }
   }
+}
+
+fragment NewProject on Project {
+  id
+  name {
+    value
+    canRead
+    canEdit
+  }
+  type
+  createdAt
 }

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -2,9 +2,8 @@ import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
-import { GQLOperations } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';
-import { updateListQueryItems } from '../../../util';
+import { addItemToList } from '../../../util';
 import {
   CreateProjectDocument,
   NewProjectFragmentDoc,
@@ -15,27 +14,17 @@ import {
 } from './CreateProjectForm';
 
 export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
-  const [createProject] = useMutation(CreateProjectDocument);
+  const [createProject] = useMutation(CreateProjectDocument, {
+    update: addItemToList(
+      'projects',
+      NewProjectFragmentDoc,
+      (data) => data.createProject.project
+    ),
+  });
   const { enqueueSnackbar } = useSnackbar();
   const submit: Props['onSubmit'] = async (input) => {
     const res = await createProject({
       variables: { input },
-      update(cache, { data }) {
-        cache.modify({
-          fields: {
-            projects(existingItemRefs, { readField }) {
-              updateListQueryItems({
-                cache,
-                existingItemRefs,
-                fragment: NewProjectFragmentDoc,
-                fragmentName: GQLOperations.Fragment.NewProject,
-                newItem: data?.createProject.project,
-                readField,
-              });
-            },
-          },
-        });
-      },
     });
     const project = res.data!.createProject.project;
 

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -2,12 +2,10 @@ import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
+import { ProjectListItemFragmentDoc } from '../../../components/ProjectListItemCard/ProjectListItem.generated';
 import { ButtonLink } from '../../../components/Routing';
 import { addItemToList } from '../../../util';
-import {
-  CreateProjectDocument,
-  NewProjectFragmentDoc,
-} from './CreateProject.generated';
+import { CreateProjectDocument } from './CreateProject.generated';
 import {
   CreateProjectForm,
   CreateProjectFormProps as Props,
@@ -17,7 +15,7 @@ export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
   const [createProject] = useMutation(CreateProjectDocument, {
     update: addItemToList(
       'projects',
-      NewProjectFragmentDoc,
+      ProjectListItemFragmentDoc,
       (data) => data.createProject.project
     ),
   });

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
@@ -28,7 +27,7 @@ export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
               updateListQueryItems({
                 cache,
                 existingItemRefs,
-                fragment: NewProjectFragmentDoc as DocumentNode,
+                fragment: NewProjectFragmentDoc,
                 fragmentName: GQLOperations.Fragment.NewProject,
                 newItem: data?.createProject.project,
                 readField,

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -3,8 +3,9 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
+import { GQLOperations } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';
-import { updateListQueryItems } from '../../../util/updateListQueryItems';
+import { updateListQueryItems } from '../../../util';
 import {
   CreateProjectDocument,
   NewProjectFragmentDoc,
@@ -23,14 +24,13 @@ export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
       update(cache, { data }) {
         cache.modify({
           fields: {
-            projects(existingProjectRefs, { readField }) {
-              const newProject = data?.createProject.project;
-              if (!newProject) return existingProjectRefs;
+            projects(existingItemRefs, { readField }) {
               updateListQueryItems({
                 cache,
-                existingItemRefs: existingProjectRefs,
+                existingItemRefs,
                 fragment: NewProjectFragmentDoc as DocumentNode,
-                newItem: newProject,
+                fragmentName: GQLOperations.Fragment.NewProject,
+                newItem: data?.createProject.project,
                 readField,
               });
             },

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -1,8 +1,10 @@
 import { useMutation } from '@apollo/client';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
 import { ButtonLink } from '../../../components/Routing';
+import { updateListQueryItems } from '../../../util/updateListQueryItems';
 import {
   CreateProjectDocument,
   NewProjectFragmentDoc,
@@ -24,21 +26,13 @@ export const CreateProject = (props: Except<Props, 'onSubmit'>) => {
             projects(existingProjectRefs, { readField }) {
               const newProject = data?.createProject.project;
               if (!newProject) return existingProjectRefs;
-              const newProjectRef = cache.writeFragment({
-                data: newProject,
-                fragment: NewProjectFragmentDoc,
+              updateListQueryItems({
+                cache,
+                existingItemRefs: existingProjectRefs,
+                fragment: NewProjectFragmentDoc as DocumentNode,
+                newItem: newProject,
+                readField,
               });
-              if (
-                existingProjectRefs?.items.some(
-                  (ref: any) => readField('id', ref) === newProject.id
-                )
-              ) {
-                return existingProjectRefs;
-              }
-              return {
-                ...existingProjectRefs,
-                items: [...existingProjectRefs.items, newProjectRef],
-              };
             },
           },
         });

--- a/src/scenes/Users/Create/CreateUser.graphql
+++ b/src/scenes/Users/Create/CreateUser.graphql
@@ -1,12 +1,11 @@
 mutation CreatePerson($input: CreatePersonInput!) {
   createPerson(input: $input) {
     user {
-      ...NewUser
+      id
+      fullName
+      ...DisplayUser
+      ...UserLookupItem
+      ...UserListItem
     }
   }
-}
-
-fragment NewUser on User {
-  ...DisplayUser
-  ...UserLookupItem
 }

--- a/src/scenes/Users/Create/CreateUser.graphql
+++ b/src/scenes/Users/Create/CreateUser.graphql
@@ -1,8 +1,12 @@
 mutation CreatePerson($input: CreatePersonInput!) {
   createPerson(input: $input) {
     user {
-      ...DisplayUser
-      ...UserLookupItem
+      ...NewUser
     }
   }
+}
+
+fragment NewUser on User {
+  ...DisplayUser
+  ...UserLookupItem
 }

--- a/src/scenes/Users/Create/CreateUser.tsx
+++ b/src/scenes/Users/Create/CreateUser.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 import { useSnackbar } from 'notistack';
 import React from 'react';
 import { Except } from 'type-fest';
@@ -50,7 +49,7 @@ export const CreateUser = (props: CreateUserProps) => {
                   updateListQueryItems({
                     cache,
                     existingItemRefs,
-                    fragment: NewUserFragmentDoc as DocumentNode,
+                    fragment: NewUserFragmentDoc,
                     fragmentName: GQLOperations.Fragment.NewUser,
                     newItem: data?.createPerson.user,
                     readField,

--- a/src/scenes/Users/Create/CreateUser.tsx
+++ b/src/scenes/Users/Create/CreateUser.tsx
@@ -4,12 +4,12 @@ import React from 'react';
 import { Except } from 'type-fest';
 import { CreatePersonInput } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';
+import { UserListItemFragmentDoc } from '../../../components/UserListItemCard/UserListItem.generated';
 import { addItemToList } from '../../../util';
 import { UserForm, UserFormProps } from '../UserForm';
 import {
   CreatePersonDocument,
   CreatePersonMutation,
-  NewUserFragmentDoc,
 } from './CreateUser.generated';
 
 export type CreateUserProps = Except<
@@ -24,7 +24,7 @@ export const CreateUser = (props: CreateUserProps) => {
   const [createPerson] = useMutation(CreatePersonDocument, {
     update: addItemToList(
       'users',
-      NewUserFragmentDoc,
+      UserListItemFragmentDoc,
       (data) => data.createPerson.user
     ),
   });

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,3 +4,4 @@ export * from './log';
 export * from './sleep';
 export * from './styles';
 export * from './types';
+export * from './updateListQueryItems';

--- a/src/util/updateListQueryItems.ts
+++ b/src/util/updateListQueryItems.ts
@@ -2,27 +2,17 @@ import { ApolloCache } from '@apollo/client';
 import { ReadFieldFunction } from '@apollo/client/cache/core/types/common';
 import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 
-type ExtractFragmentReturn<Type> = Type extends DocumentNode<infer X>
-  ? X
-  : never;
-
-interface UpdateListQueryItemsInput<
-  FragmentDoc extends DocumentNode,
-  Item extends ExtractFragmentReturn<FragmentDoc> | undefined
-> {
+interface UpdateListQueryItemsInput<Type extends { id: string }> {
   cache: ApolloCache<unknown>;
   existingItemRefs: any;
-  fragment: FragmentDoc;
+  fragment: DocumentNode<Type, unknown>;
   fragmentName: string;
-  newItem: Item;
+  newItem: Type | undefined;
   readField: ReadFieldFunction;
 }
 
-export const updateListQueryItems = <
-  FragmentDoc extends DocumentNode,
-  Item extends ExtractFragmentReturn<FragmentDoc> | undefined
->(
-  input: UpdateListQueryItemsInput<FragmentDoc, Item>
+export const updateListQueryItems = <Type extends { id: string }>(
+  input: UpdateListQueryItemsInput<Type>
 ) => {
   const {
     cache,

--- a/src/util/updateListQueryItems.ts
+++ b/src/util/updateListQueryItems.ts
@@ -8,25 +8,35 @@ type ExtractFragmentReturn<Type> = Type extends DocumentNode<infer X>
 
 interface UpdateListQueryItemsInput<
   FragmentDoc extends DocumentNode,
-  Item extends ExtractFragmentReturn<FragmentDoc>
+  Item extends ExtractFragmentReturn<FragmentDoc> | undefined
 > {
   cache: ApolloCache<unknown>;
   existingItemRefs: any;
   fragment: FragmentDoc;
+  fragmentName: string;
   newItem: Item;
   readField: ReadFieldFunction;
 }
 
 export const updateListQueryItems = <
   FragmentDoc extends DocumentNode,
-  Item extends ExtractFragmentReturn<FragmentDoc>
+  Item extends ExtractFragmentReturn<FragmentDoc> | undefined
 >(
   input: UpdateListQueryItemsInput<FragmentDoc, Item>
 ) => {
-  const { fragment, newItem, existingItemRefs, readField, cache } = input;
+  const {
+    cache,
+    existingItemRefs,
+    fragment,
+    fragmentName,
+    newItem,
+    readField,
+  } = input;
+  if (!newItem) return existingItemRefs;
   const newItemRef = cache.writeFragment({
     data: newItem,
     fragment,
+    fragmentName,
   });
   if (
     existingItemRefs?.items.some(
@@ -37,6 +47,7 @@ export const updateListQueryItems = <
   }
   return {
     ...existingItemRefs,
-    items: [...existingItemRefs.items, newItemRef],
+    total: Number(existingItemRefs.total) + 1,
+    items: [newItemRef, ...existingItemRefs.items],
   };
 };

--- a/src/util/updateListQueryItems.ts
+++ b/src/util/updateListQueryItems.ts
@@ -1,0 +1,42 @@
+import { ApolloCache } from '@apollo/client';
+import { ReadFieldFunction } from '@apollo/client/cache/core/types/common';
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+
+type ExtractFragmentReturn<Type> = Type extends DocumentNode<infer X>
+  ? X
+  : never;
+
+interface UpdateListQueryItemsInput<
+  FragmentDoc extends DocumentNode,
+  Item extends ExtractFragmentReturn<FragmentDoc>
+> {
+  cache: ApolloCache<unknown>;
+  existingItemRefs: any;
+  fragment: FragmentDoc;
+  newItem: Item;
+  readField: ReadFieldFunction;
+}
+
+export const updateListQueryItems = <
+  FragmentDoc extends DocumentNode,
+  Item extends ExtractFragmentReturn<FragmentDoc>
+>(
+  input: UpdateListQueryItemsInput<FragmentDoc, Item>
+) => {
+  const { fragment, newItem, existingItemRefs, readField, cache } = input;
+  const newItemRef = cache.writeFragment({
+    data: newItem,
+    fragment,
+  });
+  if (
+    existingItemRefs?.items.some(
+      (ref: any) => readField('id', ref) === newItem.id
+    )
+  ) {
+    return existingItemRefs;
+  }
+  return {
+    ...existingItemRefs,
+    items: [...existingItemRefs.items, newItemRef],
+  };
+};

--- a/src/util/updateListQueryItems.ts
+++ b/src/util/updateListQueryItems.ts
@@ -1,43 +1,67 @@
-import { ApolloCache } from '@apollo/client';
-import { ReadFieldFunction } from '@apollo/client/cache/core/types/common';
+import type { Reference } from '@apollo/client';
+import type { MutationUpdaterFn } from '@apollo/client/core';
 import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+import type { DefinitionNode, ExecutableDefinitionNode } from 'graphql';
+import type { ConditionalKeys } from 'type-fest';
+import type { Query } from '../api';
+import type { Nullable } from './types';
 
-interface UpdateListQueryItemsInput<Type extends { id: string }> {
-  cache: ApolloCache<unknown>;
-  existingItemRefs: any;
-  fragment: DocumentNode<Type, unknown>;
-  fragmentName: string;
-  newItem: Type | undefined;
-  readField: ReadFieldFunction;
+interface PaginatedList<T> {
+  readonly items: readonly T[];
+  readonly total: number;
+  readonly hasMore: boolean;
 }
 
-export const updateListQueryItems = <Type extends { id: string }>(
-  input: UpdateListQueryItemsInput<Type>
-) => {
-  const {
-    cache,
-    existingItemRefs,
-    fragment,
-    fragmentName,
-    newItem,
-    readField,
-  } = input;
-  if (!newItem) return existingItemRefs;
-  const newItemRef = cache.writeFragment({
-    data: newItem,
-    fragment,
-    fragmentName,
+export const addItemToList = <Type extends { id: string }, MutationOutput>(
+  listQueryName: ConditionalKeys<Query, PaginatedList<any>>,
+  fragment: DocumentNode<Type, unknown>,
+  outputToItem: (out: MutationOutput) => Type
+): MutationUpdaterFn<MutationOutput> => (cache, { data }) => {
+  cache.modify({
+    fields: {
+      [listQueryName](
+        existingItemRefs: Nullable<PaginatedList<Reference>>,
+        { readField }
+      ): Nullable<PaginatedList<Reference>> {
+        if (!data) return existingItemRefs;
+
+        const newItem = outputToItem(data);
+
+        const newItemRef = cache.writeFragment({
+          data: newItem,
+          fragment,
+          // writeFragment wants the fragment name to use when the doc has
+          // multiple. We can safely assume these are all sub-fragments being
+          // referenced, and the first one is the one we want.
+          fragmentName: getFirstExecutableName(fragment),
+        });
+
+        if (
+          !newItemRef ||
+          !existingItemRefs ||
+          existingItemRefs.items.some(
+            (ref) => readField('id', ref) === newItem.id
+          )
+        ) {
+          return existingItemRefs;
+        }
+
+        return {
+          ...existingItemRefs,
+          total: Number(existingItemRefs.total) + 1,
+          items: [newItemRef, ...existingItemRefs.items],
+        };
+      },
+    },
   });
-  if (
-    existingItemRefs?.items.some(
-      (ref: any) => readField('id', ref) === newItem.id
-    )
-  ) {
-    return existingItemRefs;
-  }
-  return {
-    ...existingItemRefs,
-    total: Number(existingItemRefs.total) + 1,
-    items: [newItemRef, ...existingItemRefs.items],
-  };
 };
+
+const getFirstExecutableName = (document: DocumentNode<unknown, unknown>) => {
+  const firstDef = document.definitions.find(isExecutableDef);
+  return firstDef?.name?.value;
+};
+
+const isExecutableDef = (
+  def: DefinitionNode
+): def is ExecutableDefinitionNode =>
+  def.kind === 'OperationDefinition' || def.kind === 'FragmentDefinition';


### PR DESCRIPTION
Closes #547 

For all top-level "create" mutations—Project, Language, User, Partner—we call the `update` method and use `cache.modify` to write the new item to the `items` field of the relevant List query. This required refactoring all relevant mutations to use a fragment so that fragment can be used in the write operation.