### PR TITLE
Partnerships dialog refactor

### DIFF
--- a/src/components/form/Lookup/Partner/PartnerLookup.graphql
+++ b/src/components/form/Lookup/Partner/PartnerLookup.graphql
@@ -19,4 +19,10 @@ fragment PartnerLookupItem on Partner {
       }
     }
   }
+  types {
+    value
+  }
+  financialReportingTypes {
+    value
+  }
 }

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -4,6 +4,7 @@ import React, { FC, useMemo } from 'react';
 import { Except } from 'type-fest';
 import { GQLOperations, UpdatePartnershipInput } from '../../../api';
 import { SubmitAction, SubmitButton } from '../../../components/form';
+import { PartnerLookupItem } from '../../../components/form/Lookup';
 import {
   hasManagingType,
   PartnershipForm,
@@ -16,7 +17,11 @@ import {
 } from './EditPartnership.generated';
 
 export type EditPartnershipFormInput = UpdatePartnershipInput &
-  SubmitAction<'delete'>;
+  SubmitAction<'delete'> & {
+    partnership?: {
+      partnerLookupItem?: PartnerLookupItem;
+    };
+  };
 
 type EditPartnershipProps = Except<
   PartnershipFormProps<EditPartnershipFormInput>,

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
@@ -31,6 +31,12 @@ fragment PartnershipForm on Partnership {
           avatarLetters
         }
       }
+      types {
+        value
+      }
+      financialReportingTypes {
+        value
+      }
     }
   }
   financialReportingType {

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -6,7 +6,6 @@ import {
   PartnershipAgreementStatus,
   PartnershipAgreementStatusList,
   PartnerType,
-  PartnerTypeList,
 } from '../../../api';
 import {
   DialogForm,
@@ -18,14 +17,25 @@ import {
   SecuredField,
   SubmitError,
 } from '../../../components/form';
-import { PartnerField } from '../../../components/form/Lookup';
+import {
+  PartnerField,
+  PartnerLookupItem,
+} from '../../../components/form/Lookup';
 import { Nullable } from '../../../util';
 import { CreatePartnershipFormInput } from '../Create';
 import { EditPartnershipFormInput } from '../Edit';
 import { PartnershipFormFragment } from './PartnershipForm.generated';
 
+type PartnershipformValues = Partial<
+  CreatePartnershipFormInput | EditPartnershipFormInput
+> & {
+  partnership?: {
+    partnerLookupItem?: PartnerLookupItem;
+  };
+};
+
 export type PartnershipFormProps<
-  T extends Partial<CreatePartnershipFormInput | EditPartnershipFormInput>
+  T extends PartnershipformValues
 > = DialogFormProps<T> & {
   partnership?: PartnershipFormFragment;
 };
@@ -33,56 +43,58 @@ export type PartnershipFormProps<
 export const hasManagingType = (types: Nullable<readonly PartnerType[]>) =>
   types?.includes('Managing') ?? false;
 
-export const PartnershipForm = <
-  T extends Partial<CreatePartnershipFormInput | EditPartnershipFormInput>
->({
+export const PartnershipForm = <T extends PartnershipformValues>({
   partnership,
   ...rest
 }: PartnershipFormProps<T>) => (
   <DialogForm<T> {...rest} fieldsPrefix="partnership">
-    {({ values }) => (
-      <>
-        <SubmitError />
-        {!partnership && <PartnerField name="partnerLookupItem" required />}
-        <SecuredField obj={partnership} name="types">
-          {(props) => (
-            <EnumField
-              multiple
-              label="Types"
-              options={PartnerTypeList}
-              layout="two-column"
-              {...props}
-            />
+    {({ values }) => {
+      return (
+        <>
+          <SubmitError />
+          {!partnership && <PartnerField name="partnerLookupItem" required />}
+          {values.partnership?.partnerLookupItem?.types.value.length ? (
+            <SecuredField obj={partnership} name="types">
+              {(props) => (
+                <EnumField
+                  multiple
+                  label="Types"
+                  options={values.partnership!.partnerLookupItem!.types.value}
+                  layout="two-column"
+                  {...props}
+                />
+              )}
+            </SecuredField>
+          ) : null}
+          {hasManagingType(values.partnership?.types) ? (
+            <SecuredField obj={partnership} name="financialReportingType">
+              {(props) => (
+                <EnumField
+                  label="Financial Reporting Type"
+                  options={FinancialReportingTypeList}
+                  getLabel={displayFinancialReportingType}
+                  {...props}
+                />
+              )}
+            </SecuredField>
+          ) : null}
+          {partnership && (
+            <>
+              <SecuredField obj={partnership} name="agreementStatus">
+                {(props) => (
+                  <AgreementStatusField label="Agreement Status" {...props} />
+                )}
+              </SecuredField>
+              <SecuredField obj={partnership} name="mouStatus">
+                {(props) => (
+                  <AgreementStatusField label="Mou Status" {...props} />
+                )}
+              </SecuredField>
+            </>
           )}
-        </SecuredField>
-        {hasManagingType(values.partnership?.types) ? (
-          <SecuredField obj={partnership} name="financialReportingType">
-            {(props) => (
-              <EnumField
-                label="Financial Reporting Type"
-                options={FinancialReportingTypeList}
-                getLabel={displayFinancialReportingType}
-                {...props}
-              />
-            )}
-          </SecuredField>
-        ) : null}
-        {partnership && (
-          <>
-            <SecuredField obj={partnership} name="agreementStatus">
-              {(props) => (
-                <AgreementStatusField label="Agreement Status" {...props} />
-              )}
-            </SecuredField>
-            <SecuredField obj={partnership} name="mouStatus">
-              {(props) => (
-                <AgreementStatusField label="Mou Status" {...props} />
-              )}
-            </SecuredField>
-          </>
-        )}
-      </>
-    )}
+        </>
+      );
+    }}
   </DialogForm>
 );
 

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -1,3 +1,5 @@
+import { Decorator } from 'final-form';
+import onFieldChange from 'final-form-calculate';
 import React from 'react';
 import {
   displayFinancialReportingType,
@@ -25,7 +27,7 @@ import { CreatePartnershipFormInput } from '../Create';
 import { EditPartnershipFormInput } from '../Edit';
 import { PartnershipFormFragment } from './PartnershipForm.generated';
 
-type PartnershipformValues = Partial<
+type PartnershipFormValues = Partial<
   CreatePartnershipFormInput | EditPartnershipFormInput
 > & {
   partnership?: {
@@ -34,7 +36,7 @@ type PartnershipformValues = Partial<
 };
 
 export type PartnershipFormProps<
-  T extends PartnershipformValues
+  T extends PartnershipFormValues
 > = DialogFormProps<T> & {
   partnership?: PartnershipFormFragment;
 };
@@ -42,68 +44,101 @@ export type PartnershipFormProps<
 export const hasManagingType = (types: Nullable<readonly PartnerType[]>) =>
   types?.includes('Managing') ?? false;
 
-export const PartnershipForm = <T extends PartnershipformValues>({
+const decorators: Array<Decorator<PartnershipFormValues>> = [
+  ...DialogForm.defaultDecorators,
+  onFieldChange(
+    // if user selects a different partner (on create partnership), wipe the types and fin type values
+    {
+      field: 'partnership.partnerLookupItem',
+      isEqual: PartnerField.isEqual,
+      updates: {
+        'partnership.types': () => undefined,
+        'partnership.financialReportingType': () => undefined,
+      },
+    },
+    // if user unselects managing type (on create or update), wipe the financial reporting type values
+    {
+      field: 'partnership.types',
+      updates: {
+        'partnership.financialReportingType': (partnerTypes, currentValues) =>
+          partnerTypes?.includes('Managing')
+            ? currentValues.partnership?.financialReportingType
+            : undefined,
+      },
+    }
+  ),
+];
+
+export const PartnershipForm = <T extends PartnershipFormValues>({
   partnership,
   ...rest
-}: PartnershipFormProps<T>) => (
-  <DialogForm<T> {...rest} fieldsPrefix="partnership">
-    {({ values }) => {
-      const lookupPartnerTypes =
-        values.partnership?.partnerLookupItem?.types.value;
-      const lookupPartnerFinType =
-        values.partnership?.partnerLookupItem?.financialReportingTypes.value;
-      const currentPartnerTypes = partnership?.partner.value?.types.value;
-      const currentPartnerFinTypes =
-        partnership?.partner.value?.financialReportingTypes.value;
+}: PartnershipFormProps<T>) => {
+  return (
+    <DialogForm<T>
+      {...rest}
+      fieldsPrefix="partnership"
+      decorators={(decorators as unknown) as Array<Decorator<T>>}
+    >
+      {({ values }) => {
+        const lookupPartnerTypes =
+          values.partnership?.partnerLookupItem?.types.value;
+        const lookupPartnerFinType =
+          values.partnership?.partnerLookupItem?.financialReportingTypes.value;
+        const currentPartnerTypes = partnership?.partner.value?.types.value;
+        const currentPartnerFinTypes =
+          partnership?.partner.value?.financialReportingTypes.value;
 
-      return (
-        <>
-          <SubmitError />
-          {!partnership && <PartnerField name="partnerLookupItem" required />}
-          {lookupPartnerTypes?.length || currentPartnerTypes?.length ? (
-            <SecuredField obj={partnership} name="types">
-              {(props) => (
-                <EnumField
-                  multiple
-                  label="Types"
-                  options={lookupPartnerTypes || currentPartnerTypes || []}
-                  layout="two-column"
-                  {...props}
-                />
-              )}
-            </SecuredField>
-          ) : null}
-          {hasManagingType(values.partnership?.types) ? (
-            <SecuredField obj={partnership} name="financialReportingType">
-              {(props) => (
-                <EnumField
-                  label="Financial Reporting Type"
-                  options={lookupPartnerFinType || currentPartnerFinTypes || []}
-                  getLabel={displayFinancialReportingType}
-                  {...props}
-                />
-              )}
-            </SecuredField>
-          ) : null}
-          {partnership && (
-            <>
-              <SecuredField obj={partnership} name="agreementStatus">
+        return (
+          <>
+            <SubmitError />
+            {!partnership && <PartnerField name="partnerLookupItem" required />}
+            {lookupPartnerTypes?.length || currentPartnerTypes?.length ? (
+              <SecuredField obj={partnership} name="types">
                 {(props) => (
-                  <AgreementStatusField label="Agreement Status" {...props} />
+                  <EnumField
+                    multiple
+                    label="Types"
+                    options={lookupPartnerTypes || currentPartnerTypes || []}
+                    layout="two-column"
+                    {...props}
+                  />
                 )}
               </SecuredField>
-              <SecuredField obj={partnership} name="mouStatus">
+            ) : null}
+            {hasManagingType(values.partnership?.types) ? (
+              <SecuredField obj={partnership} name="financialReportingType">
                 {(props) => (
-                  <AgreementStatusField label="Mou Status" {...props} />
+                  <EnumField
+                    label="Financial Reporting Type"
+                    options={
+                      lookupPartnerFinType || currentPartnerFinTypes || []
+                    }
+                    getLabel={displayFinancialReportingType}
+                    {...props}
+                  />
                 )}
               </SecuredField>
-            </>
-          )}
-        </>
-      );
-    }}
-  </DialogForm>
-);
+            ) : null}
+            {partnership && (
+              <>
+                <SecuredField obj={partnership} name="agreementStatus">
+                  {(props) => (
+                    <AgreementStatusField label="Agreement Status" {...props} />
+                  )}
+                </SecuredField>
+                <SecuredField obj={partnership} name="mouStatus">
+                  {(props) => (
+                    <AgreementStatusField label="Mou Status" {...props} />
+                  )}
+                </SecuredField>
+              </>
+            )}
+          </>
+        );
+      }}
+    </DialogForm>
+  );
+};
 
 const AgreementStatusField = (
   props: Omit<EnumFieldProps<PartnershipAgreementStatus, false>, 'children'>

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   displayFinancialReportingType,
   displayPartnershipStatus,
-  FinancialReportingTypeList,
   PartnershipAgreementStatus,
   PartnershipAgreementStatusList,
   PartnerType,
@@ -49,17 +48,25 @@ export const PartnershipForm = <T extends PartnershipformValues>({
 }: PartnershipFormProps<T>) => (
   <DialogForm<T> {...rest} fieldsPrefix="partnership">
     {({ values }) => {
+      const lookupPartnerTypes =
+        values.partnership?.partnerLookupItem?.types.value;
+      const lookupPartnerFinType =
+        values.partnership?.partnerLookupItem?.financialReportingTypes.value;
+      const currentPartnerTypes = partnership?.partner.value?.types.value;
+      const currentPartnerFinTypes =
+        partnership?.partner.value?.financialReportingTypes.value;
+
       return (
         <>
           <SubmitError />
           {!partnership && <PartnerField name="partnerLookupItem" required />}
-          {values.partnership?.partnerLookupItem?.types.value.length ? (
+          {lookupPartnerTypes?.length || currentPartnerTypes?.length ? (
             <SecuredField obj={partnership} name="types">
               {(props) => (
                 <EnumField
                   multiple
                   label="Types"
-                  options={values.partnership!.partnerLookupItem!.types.value}
+                  options={lookupPartnerTypes || currentPartnerTypes || []}
                   layout="two-column"
                   {...props}
                 />
@@ -71,7 +78,7 @@ export const PartnershipForm = <T extends PartnershipformValues>({
               {(props) => (
                 <EnumField
                   label="Financial Reporting Type"
-                  options={FinancialReportingTypeList}
+                  options={lookupPartnerFinType || currentPartnerFinTypes || []}
                   getLabel={displayFinancialReportingType}
                   {...props}
                 />


### PR DESCRIPTION
On create and update partnership, the type and financialReportingTypes (FRT) fields need to reflect the values on the Partner.  So the enumField has the available types passed in: https://github.com/SeedCompany/cord-field/pull/627/files#diff-04c13b2404d5a2cdbcdf6d57823dc8297575a613af9d032c52beda3a7d73709cR75

Also, if the partner is changed on create, the type and FRT values need to be wiped (or they will be part of the submit input).  Same goes with if the Managing Type is checked or not for FRT. 