### PR TITLE
Only assign field errors if the form has the field registered

### DIFF
--- a/src/api/form-error-handling.test.ts
+++ b/src/api/form-error-handling.test.ts
@@ -7,7 +7,7 @@ describe('handleFormError', () => {
   let error: ApolloError;
   let form: FormApi;
 
-  beforeAll(() => {
+  beforeEach(() => {
     error = createError({
       message: 'Not found',
       codes: ['VerySpecific', 'NotFound', 'SomethingElse', 'Input', 'Client'],
@@ -34,14 +34,25 @@ describe('handleFormError', () => {
     expect(result).toEqual({ [FORM_ERROR]: 'woot' });
   });
 
-  it('input with field uses field error', async () => {
+  it('input with registered field uses field error', async () => {
+    const inputError = createError({
+      message: 'You messed up the foo bar',
+      codes: ['Input'],
+      field: 'foo.bar',
+    });
+    form.registerField('foo.bar', noop, {});
+    const result = await handleFormError(inputError, form);
+    expect(result).toEqual({ foo: { bar: 'You messed up the foo bar' } });
+  });
+
+  it('input with unknown field uses next', async () => {
     const inputError = createError({
       message: 'You messed up the foo bar',
       codes: ['Input'],
       field: 'foo.bar',
     });
     const result = await handleFormError(inputError, form);
-    expect(result).toEqual({ foo: { bar: 'You messed up the foo bar' } });
+    expect(result).toEqual({ [FORM_ERROR]: 'You messed up the foo bar' });
   });
 
   it('input without field uses next', async () => {

--- a/src/api/form-error-handling.ts
+++ b/src/api/form-error-handling.ts
@@ -122,7 +122,10 @@ export type ErrorHandler<E> =
 type NextHandler<E> = (e: E) => Promisable<ErrorHandlerResult>;
 export type ErrorHandlerResult = string | SubmissionErrors | undefined;
 
-interface HandlerUtils {}
+interface HandlerUtils {
+  /** Does the form have this field registered? */
+  hasField: (field: string) => boolean;
+}
 
 const expandDotNotation = (input: Record<string, any>) =>
   Object.entries(input).reduce(
@@ -159,7 +162,9 @@ export const handleFormError = async <T, P>(
 ) => {
   const error = getErrorInfo(e);
 
-  const utils: HandlerUtils = {};
+  const utils: HandlerUtils = {
+    hasField: (field) => form.getRegisteredFields().includes(field),
+  };
 
   const mergedHandlers = { ...defaultHandlers, ...handlers };
   const handler = error.codes

--- a/src/api/form-error-handling.ts
+++ b/src/api/form-error-handling.ts
@@ -143,8 +143,8 @@ export const renderValidationErrors = (e: ValidationError) =>
  */
 const defaultHandlers: ErrorHandlers = {
   Validation: renderValidationErrors,
-  Input: (e, next) => (e.field ? setIn({}, e.field, e.message) : next(e)),
-  Duplicate: (e) => setIn({}, e.field, e.message),
+  Input: (e, next, { hasField }) =>
+    e.field && hasField(e.field) ? setIn({}, e.field, e.message) : next(e),
 
   // Assume server errors are handled separately
   // Return failure but no error message

--- a/src/api/form-error-handling.ts
+++ b/src/api/form-error-handling.ts
@@ -1,5 +1,5 @@
 import { ApolloError } from '@apollo/client';
-import { FORM_ERROR, setIn, SubmissionErrors } from 'final-form';
+import { FORM_ERROR, FormApi, setIn, SubmissionErrors } from 'final-form';
 import { identity, mapValues } from 'lodash';
 import { assert } from 'ts-essentials';
 import { Promisable } from 'type-fest';
@@ -146,7 +146,11 @@ const defaultHandlers: ErrorHandlers = {
 /**
  * Handles the error according to the form error handlers passed in.
  */
-export const handleFormError = async (e: unknown, handlers?: ErrorHandlers) => {
+export const handleFormError = async <T, P>(
+  e: unknown,
+  form: FormApi<T, P>,
+  handlers?: ErrorHandlers
+) => {
   const error = getErrorInfo(e);
 
   const mergedHandlers = { ...defaultHandlers, ...handlers };

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -140,7 +140,7 @@ export function DialogForm<T, R = void>({
           onClose?.('success', form);
           return null;
         } catch (e) {
-          return await handleFormError(e, errorHandlers);
+          return await handleFormError(e, form, errorHandlers);
         }
       }}
     >

--- a/src/scenes/Authentication/ForgotPassword/ForgotPassword.tsx
+++ b/src/scenes/Authentication/ForgotPassword/ForgotPassword.tsx
@@ -13,14 +13,14 @@ export const ForgotPassword = (props: Except<Props, 'onSubmit'>) => {
   const [forgotPassword] = useMutation(ForgotPasswordDocument);
   const [email, setEmail] = useState<string | null>(null);
 
-  const submit: Props['onSubmit'] = async (input) => {
+  const submit: Props['onSubmit'] = async (input, form) => {
     try {
       await forgotPassword({
         variables: input,
       });
       setEmail(input.email);
     } catch (e) {
-      return await handleFormError(e, {
+      return await handleFormError(e, form, {
         // Shouldn't ever be hit
         Default: `Something wasn't right. Try again or contact Support.`,
       });

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -22,7 +22,7 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
     }
   }, [navigate, session, sessionLoading, success]);
 
-  const submit: Props['onSubmit'] = async (input) => {
+  const submit: Props['onSubmit'] = async (input, form) => {
     try {
       await login({
         variables: { input },
@@ -37,7 +37,7 @@ export const Login = (props: Except<Props, 'onSubmit'>) => {
       const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
       navigate(returnTo, { replace: true });
     } catch (e) {
-      return await handleFormError(e, {
+      return await handleFormError(e, form, {
         Default: {
           [FORM_ERROR]: `Something wasn't right. Try again, or reset password.`,
           // Add errors to fields so they show invalid

--- a/src/scenes/Authentication/Register/Register.tsx
+++ b/src/scenes/Authentication/Register/Register.tsx
@@ -22,7 +22,10 @@ export const Register = (props: Except<Props, 'onSubmit'>) => {
     }
   }, [navigate, session, sessionLoading, success]);
 
-  const submit: Props['onSubmit'] = async ({ confirmPassword, ...input }) => {
+  const submit: Props['onSubmit'] = async (
+    { confirmPassword, ...input },
+    form
+  ) => {
     try {
       await register({
         variables: {
@@ -42,7 +45,7 @@ export const Register = (props: Except<Props, 'onSubmit'>) => {
       const returnTo = decodeURIComponent(query.get('returnTo') ?? '/');
       navigate(returnTo, { replace: true });
     } catch (e) {
-      return await handleFormError(e);
+      return await handleFormError(e, form);
     }
   };
 

--- a/src/scenes/Authentication/ResetPassword/ResetPassword.tsx
+++ b/src/scenes/Authentication/ResetPassword/ResetPassword.tsx
@@ -15,7 +15,7 @@ export const ResetPassword = (props: Except<Props, 'onSubmit'>) => {
   const { token } = useParams() as { token: string };
   const [success, setSuccess] = useState(false);
 
-  const submit: Props['onSubmit'] = async ({ password }) => {
+  const submit: Props['onSubmit'] = async ({ password }, form) => {
     try {
       await resetPassword({
         variables: {
@@ -27,7 +27,7 @@ export const ResetPassword = (props: Except<Props, 'onSubmit'>) => {
       });
       setSuccess(true);
     } catch (e) {
-      return await handleFormError(e, {
+      return await handleFormError(e, form, {
         TokenExpired: `Password reset request has expired. Try forgot password again.`,
         Default: `Something went wrong. Try forgot password again.`,
       });

--- a/src/scenes/Products/Create/CreateProduct.tsx
+++ b/src/scenes/Products/Create/CreateProduct.tsx
@@ -56,16 +56,19 @@ export const CreateProduct = () => {
       </Typography>
       {!loading && (
         <ProductForm
-          onSubmit={async ({
-            product: {
-              productType,
-              produces,
-              scriptureReferences,
-              fullOldTestament,
-              fullNewTestament,
-              ...inputs
+          onSubmit={async (
+            {
+              product: {
+                productType,
+                produces,
+                scriptureReferences,
+                fullOldTestament,
+                fullNewTestament,
+                ...inputs
+              },
             },
-          }) => {
+            form
+          ) => {
             const parsedScriptureReferences = parsedRangesWithFullTestamentRange(
               scriptureReferences,
               fullOldTestament,
@@ -107,7 +110,7 @@ export const CreateProduct = () => {
 
               navigate('../../');
             } catch (e) {
-              await handleFormError(e);
+              await handleFormError(e, form);
             }
           }}
         />

--- a/src/scenes/Products/Edit/EditProduct.tsx
+++ b/src/scenes/Products/Edit/EditProduct.tsx
@@ -112,16 +112,19 @@ export const EditProduct = () => {
       {product && (
         <ProductForm
           product={product}
-          onSubmit={async ({
-            product: {
-              productType,
-              produces,
-              scriptureReferences,
-              fullOldTestament,
-              fullNewTestament,
-              ...input
+          onSubmit={async (
+            {
+              product: {
+                productType,
+                produces,
+                scriptureReferences,
+                fullOldTestament,
+                fullNewTestament,
+                ...input
+              },
             },
-          }) => {
+            form
+          ) => {
             try {
               const parsedScriptureReferences = parsedRangesWithFullTestamentRange(
                 scriptureReferences,
@@ -154,7 +157,7 @@ export const EditProduct = () => {
 
               navigate('../../');
             } catch (e) {
-              await handleFormError(e);
+              await handleFormError(e, form);
             }
           }}
           initialValues={initialValues}


### PR DESCRIPTION
This prevents the form from showing "nothing" because the API error had a field that didn't match a form field that we've defined.