### PR TITLE
Strict Apollo Cache type policies

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -35,6 +35,11 @@ generates:
     plugins:
       - ./src/api/enumLists/enumLists.codegen
 
+  # Generate a type map for all of our GQL object types
+  ./src/api/typeMap.generated.ts:
+    plugins:
+      - ./src/api/typeMap.codegen
+
   # Generate TypeScript version of graphql schema
   ./src/api/schema.generated.ts:
     plugins:

--- a/src/api/ApolloProvider.tsx
+++ b/src/api/ApolloProvider.tsx
@@ -7,6 +7,7 @@ import {
   NormalizedCacheObject,
   Observable,
   RequestHandler,
+  TypePolicies,
 } from '@apollo/client';
 import {
   onError as createErrorLink,
@@ -79,7 +80,13 @@ export const ApolloProvider: FC = ({ children }) => {
     return new ApolloClient({
       cache: new InMemoryCache({
         possibleTypes,
-        typePolicies,
+        // Yes the assertion is necessary. It's because, as of TS 4.0, index
+        // signatures still incorrectly convey that values for missing keys
+        // would still give the expected value instead of undefined, which is
+        // absolutely how JS works. I believe this is getting fixed finally in 4.1.
+        // See: https://github.com/microsoft/TypeScript/pull/39560
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        typePolicies: typePolicies as TypePolicies,
       }),
       link: ApolloLink.from(compact([errorLink, delayLink, httpLink])),
     });

--- a/src/api/typeMap.codegen.ts
+++ b/src/api/typeMap.codegen.ts
@@ -1,0 +1,33 @@
+import { isObjectType } from 'graphql';
+import { sortBy } from 'lodash';
+import { OptionalKind, PropertySignatureStructure } from 'ts-morph';
+import { getSchemaTypes } from './codeGenUtil/gql.util';
+import { tsMorphPlugin } from './codeGenUtil/ts.util';
+
+export const plugin = tsMorphPlugin(({ schema, file }) => {
+  file.addImportDeclaration({
+    namespaceImport: 'Types',
+    moduleSpecifier: './schema.generated',
+    isTypeOnly: true,
+  });
+
+  const userDefinedTypes = getSchemaTypes(schema).filter(
+    (type) =>
+      isObjectType(type) &&
+      !type.name.startsWith('__') &&
+      type !== schema.getQueryType() &&
+      type !== schema.getMutationType() &&
+      type !== schema.getSubscriptionType()
+  );
+
+  file.addInterface({
+    name: 'GqlTypeMap',
+    isExported: true,
+    properties: sortBy(userDefinedTypes, (type) => type.name).map(
+      (type): OptionalKind<PropertySignatureStructure> => ({
+        name: type.name,
+        type: `Types.${type.name}`,
+      })
+    ),
+  });
+});

--- a/src/api/typeMap.codegen.ts
+++ b/src/api/typeMap.codegen.ts
@@ -1,5 +1,5 @@
-import { isObjectType } from 'graphql';
-import { sortBy } from 'lodash';
+import { GraphQLNamedType, isObjectType } from 'graphql';
+import { difference, sortBy } from 'lodash';
 import { OptionalKind, PropertySignatureStructure } from 'ts-morph';
 import { getSchemaTypes } from './codeGenUtil/gql.util';
 import { tsMorphPlugin } from './codeGenUtil/ts.util';
@@ -20,14 +20,32 @@ export const plugin = tsMorphPlugin(({ schema, file }) => {
       type !== schema.getSubscriptionType()
   );
 
+  const mainTypes = userDefinedTypes.filter(
+    (t) =>
+      !t.name.startsWith('Secured') &&
+      !t.name.startsWith('Create') &&
+      !t.name.startsWith('Update') &&
+      !t.name.endsWith('Output')
+  );
+  const mainTsType = file.addInterface({
+    name: 'GqlTypeMapMain',
+    isExported: true,
+    properties: getProperties(mainTypes),
+  });
+
+  const auxTypes = difference(userDefinedTypes, mainTypes);
   file.addInterface({
     name: 'GqlTypeMap',
     isExported: true,
-    properties: sortBy(userDefinedTypes, (type) => type.name).map(
-      (type): OptionalKind<PropertySignatureStructure> => ({
-        name: type.name,
-        type: `Types.${type.name}`,
-      })
-    ),
+    extends: [mainTsType.getName()],
+    properties: getProperties(auxTypes),
   });
 });
+
+const getProperties = (types: readonly GraphQLNamedType[]) =>
+  sortBy(types, (type) => type.name).map(
+    (type): OptionalKind<PropertySignatureStructure> => ({
+      name: type.name,
+      type: `Types.${type.name}`,
+    })
+  );

--- a/src/api/typePolicies/scalars/scalars.parser.ts
+++ b/src/api/typePolicies/scalars/scalars.parser.ts
@@ -1,7 +1,10 @@
 import { DateTime } from 'luxon';
 import { CalendarDate } from '../../../util';
 
-export const Parsers = {
+// Our new strict types for type policies doesn't account for custom scalars
+// which are actually stored in cache differently than TS declares.
+// Ignoring this for now. We can circle back when it becomes more of a problem.
+export const Parsers: any = {
   Date: (val: string) => CalendarDate.fromISO(val),
   DateTime: (val: string) => DateTime.fromISO(val),
 };

--- a/src/api/typePolicies/typePolicies.base.ts
+++ b/src/api/typePolicies/typePolicies.base.ts
@@ -1,3 +1,26 @@
-import { TypePolicies } from '@apollo/client';
+import type {
+  FieldPolicy,
+  FieldReadFunction,
+  KeyFieldsFunction,
+} from '@apollo/client/cache/inmemory/policies';
+import type { GqlTypeMap } from '../typeMap.generated';
+
+type FieldPolicies<T> = {
+  [K in keyof T]?: FieldPolicy<T[K]> | FieldReadFunction<T[K]>;
+};
+
+type KeySpecifier<K = string> = ReadonlyArray<K | readonly any[]>;
+
+export interface TypePolicy<T> {
+  keyFields?: KeySpecifier<keyof T> | KeyFieldsFunction | false;
+  queryType?: true;
+  mutationType?: true;
+  subscriptionType?: true;
+  fields?: FieldPolicies<T>;
+}
+
+type TypePolicies = {
+  [K in keyof GqlTypeMap]?: TypePolicy<GqlTypeMap[K]>;
+};
 
 export const typePolicies: TypePolicies = {};

--- a/src/api/typePolicies/typePolicies.base.ts
+++ b/src/api/typePolicies/typePolicies.base.ts
@@ -23,4 +23,11 @@ type TypePolicies = {
   [K in keyof GqlTypeMap]?: TypePolicy<GqlTypeMap[K]>;
 };
 
-export const typePolicies: TypePolicies = {};
+export const typePolicies: TypePolicies = {
+  Language: {
+    fields: {
+      ethnologue: { merge: true },
+    },
+  },
+  EthnologueLanguage: { keyFields: false },
+};

--- a/src/api/typePolicies/typePolicies.base.ts
+++ b/src/api/typePolicies/typePolicies.base.ts
@@ -23,6 +23,8 @@ type TypePolicies = {
   [K in keyof GqlTypeMap]?: TypePolicy<GqlTypeMap[K]>;
 };
 
+const scriptureKeyFields = ['book', 'chapter', 'verse'] as const;
+
 export const typePolicies: TypePolicies = {
   Language: {
     fields: {
@@ -30,4 +32,13 @@ export const typePolicies: TypePolicies = {
     },
   },
   EthnologueLanguage: { keyFields: false },
+  IanaCountry: { keyFields: ['code'] },
+  TimeZone: { keyFields: ['name'] },
+  IsoCountry: { keyFields: ['alpha3'] },
+  ScriptureReference: {
+    keyFields: scriptureKeyFields,
+  },
+  ScriptureRange: {
+    keyFields: ['start', scriptureKeyFields, 'end', scriptureKeyFields],
+  },
 };


### PR DESCRIPTION
- Use codegen to create a mapping of our GQL types in TS
- Use this mapping to power a strict version of `TypePolices`.
  Main goal was for DX while tweaking these policies.
- Adjust type policies for our types that are non-standard and not the auto-configured "secure" or custom-scalars configs