### PR TITLE
First Scripture Property

### DIFF
--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@apollo/client';
+import { setIn } from 'final-form';
 import { compact, keyBy, pick, startCase } from 'lodash';
 import React, { ComponentType, FC, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
@@ -130,7 +131,7 @@ const fieldMapping: Record<
   ),
   mentorId: ({ props }) => <UserField {...props} label="Mentor" />,
   firstScripture: ({ props }) => (
-    <CheckboxField {...props} label="First Scripture" />
+    <CheckboxField {...props} label="First Scripture" keepHelperTextSpacing />
   ),
   lukePartnership: ({ props }) => (
     <CheckboxField {...props} label="Luke Partnership" />
@@ -248,6 +249,16 @@ export const EditEngagementDialog: FC<EditEngagementDialogProps> = ({
         };
 
         await updateEngagement({ variables: { input } });
+      }}
+      errorHandlers={{
+        Input: (e, next) =>
+          e.field === 'languageEngagement.firstScripture'
+            ? setIn(
+                {},
+                'engagement.firstScripture',
+                'Language has already has first Scripture'
+              )
+            : next(e),
       }}
     >
       <SubmitError />

--- a/src/scenes/Languages/Detail/FirstScripture/FirstScripture.graphql
+++ b/src/scenes/Languages/Detail/FirstScripture/FirstScripture.graphql
@@ -1,0 +1,41 @@
+fragment FirstScripture on Language {
+  id
+  hasExternalFirstScripture {
+    canRead
+    canEdit
+    value
+  }
+  projects {
+    canRead
+    canCreate
+    items {
+      id
+      name {
+        value
+        canRead
+      }
+      engagements {
+        items {
+          ...LanguageProjectEngagement
+        }
+      }
+    }
+  }
+}
+
+fragment LanguageProjectEngagement on Engagement {
+  id
+  ... on LanguageEngagement {
+    language {
+      value {
+        id
+      }
+      canRead
+    }
+    firstScripture {
+      value
+      canRead
+      canEdit
+    }
+  }
+}

--- a/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
+++ b/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
@@ -1,0 +1,115 @@
+import { makeStyles, Typography } from '@material-ui/core';
+import {
+  Check,
+  IndeterminateCheckBox,
+  NotInterested,
+} from '@material-ui/icons';
+import { Skeleton } from '@material-ui/lab';
+import * as React from 'react';
+import { assert } from 'ts-essentials';
+import { Redacted } from '../../../../components/Redacted';
+import { Link } from '../../../../components/Routing';
+import { isTypename } from '../../../../util';
+import {
+  LanguageProjectEngagement_LanguageEngagement_Fragment as Engagement,
+  FirstScriptureFragment,
+} from './FirstScripture.generated';
+
+const useStyles = makeStyles(({ spacing }) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  icon: {
+    marginRight: spacing(1),
+  },
+  text: {
+    display: 'flex',
+  },
+}));
+
+export const FirstScripture = ({ data }: { data?: FirstScriptureFragment }) => {
+  const classes = useStyles();
+
+  const engagements = data?.projects.items
+    .flatMap((project) => project.engagements.items)
+    .filter(isTypename<Engagement>('LanguageEngagement'));
+
+  if (!data) {
+    return (
+      <div className={classes.root}>
+        <Skeleton
+          variant="circle"
+          width={24}
+          height={24}
+          className={classes.icon}
+        />
+        <Skeleton width={300} />
+      </div>
+    );
+  }
+  assert(engagements);
+
+  if (
+    !data.projects.canRead ||
+    !data.hasExternalFirstScripture.canRead ||
+    engagements.some((e) => !e.firstScripture.canRead || !e.language.canRead)
+  ) {
+    return (
+      <div className={classes.root}>
+        <IndeterminateCheckBox className={classes.icon} />
+        <Redacted
+          info="You cannot view whether this language has first Scripture"
+          width={300}
+        />
+      </div>
+    );
+  }
+
+  if (data.hasExternalFirstScripture.value) {
+    return (
+      <div className={classes.root}>
+        <Check color="primary" className={classes.icon} />
+        <Typography>First Scripture was completed outside of CORD</Typography>
+      </div>
+    );
+  }
+
+  // If the API is working properly, there should be a maximum of 1
+  const engagement = engagements.find(
+    (engagement) =>
+      engagement.firstScripture.value &&
+      engagement.language.value!.id === data.id
+  );
+  if (engagement) {
+    const project = data.projects.items.find((p) =>
+      p.engagements.items.some((e) => e.id === engagement.id)
+    )!;
+
+    return (
+      <div className={classes.root}>
+        <Check color="primary" className={classes.icon} />
+        <Typography className={classes.text}>
+          First Scripture:&nbsp;&nbsp;
+          <Link
+            to={`/projects/${project.id}/engagements/${engagement.id}`}
+            underline={project.name.canRead ? undefined : 'none'}
+          >
+            {project.name.canRead ? (
+              project.name.value
+            ) : (
+              <Redacted info="You cannot view the project's name" width={200} />
+            )}
+          </Link>
+        </Typography>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.root}>
+      <NotInterested className={classes.icon} />
+      <Typography>No Scripture yet</Typography>
+    </div>
+  );
+};

--- a/src/scenes/Languages/Detail/FirstScripture/index.ts
+++ b/src/scenes/Languages/Detail/FirstScripture/index.ts
@@ -1,0 +1,1 @@
+export * from './FirstScripture';

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -61,34 +61,9 @@ fragment LanguageDetail on Language {
     canCreate
     items {
       ...ProjectListItem
-      engagements {
-        items {
-          ...languageProjectEngagement
-        }
-      }
     }
   }
-  hasExternalFirstScripture {
-    canRead
-    canEdit
-    value
-  }
-}
-
-fragment languageProjectEngagement on Engagement {
-  id
-  ... on LanguageEngagement {
-    language {
-      value {
-        id
-      }
-    }
-    firstScripture {
-      value
-      canRead
-      canEdit
-    }
-  }
+  ...FirstScripture
 }
 
 mutation RemoveLocationFromLanguage($languageId: ID!, $locationId: ID!) {

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -63,6 +63,11 @@ fragment LanguageDetail on Language {
       ...ProjectListItem
     }
   }
+  hasExternalFirstScripture {
+    canRead
+    canEdit
+    value
+  }
 }
 
 mutation RemoveLocationFromLanguage($languageId: ID!, $locationId: ID!) {

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -85,6 +85,8 @@ fragment languageProjectEngagement on Engagement {
     }
     firstScripture {
       value
+      canRead
+      canEdit
     }
   }
 }

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -61,12 +61,31 @@ fragment LanguageDetail on Language {
     canCreate
     items {
       ...ProjectListItem
+      engagements {
+        items {
+          ...languageProjectEngagement
+        }
+      }
     }
   }
   hasExternalFirstScripture {
     canRead
     canEdit
     value
+  }
+}
+
+fragment languageProjectEngagement on Engagement {
+  id
+  ... on LanguageEngagement {
+    language {
+      value {
+        id
+      }
+    }
+    firstScripture {
+      value
+    }
   }
 }
 

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -110,11 +110,19 @@ export const LanguageDetail = () => {
     []
   );
 
+  // If the API is working properly, there should be a maximum of 1
+  const firstScriptureEngagement = engagements?.find(
+    (engagement) => engagement.firstScripture.value
+  );
+
+  const firstScripture = {
+    value: firstScriptureEngagement?.firstScripture.value,
+    canRead: firstScriptureEngagement?.firstScripture.canRead,
+  };
+
   const hasFirstScripture = {
-    value:
-      engagements?.some((engagement) => engagement.firstScripture.value) ||
-      hasExternalFirstScripture?.value,
-    canRead: hasExternalFirstScripture?.canRead ?? true,
+    value: firstScripture.value ?? hasExternalFirstScripture?.value,
+    canRead: !!firstScripture.canRead || !!hasExternalFirstScripture?.canRead,
   };
 
   const canEditAnyFields = canEditAny(language) || canEditAny(ethnologue);

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -21,14 +21,15 @@ import {
 } from '../../../components/Formatters';
 import { LocationCard } from '../../../components/LocationCard';
 import { ProjectListItemCard } from '../../../components/ProjectListItemCard';
+import { ProjectListItemFragment } from '../../../components/ProjectListItemCard/ProjectListItem.generated';
 import { Redacted } from '../../../components/Redacted';
 import { Sensitivity } from '../../../components/Sensitivity';
 import { CalendarDate, listOrPlaceholders } from '../../../util';
 import { EditLanguage } from '../Edit';
 import { AddLocationToLanguageForm } from '../Edit/AddLocationToLanguageForm';
+import { FirstScripture } from './FirstScripture';
 import {
   LanguageDocument,
-  LanguageProjectEngagement_LanguageEngagement_Fragment as LanguageFragment,
   RemoveLocationFromLanguageDocument,
 } from './LanguageDetail.generated';
 import { LeastOfThese } from './LeastOfThese';
@@ -88,31 +89,7 @@ export const LanguageDetail = () => {
     sponsorEstimatedEndDate,
     displayName,
     name,
-    hasExternalFirstScripture,
   } = language ?? {};
-
-  // If the API is working properly, there should be a maximum of 1
-  const firstScriptureEngagement = projects?.items
-    .flatMap((project) => project.engagements.items)
-    .filter(
-      (engagement): engagement is LanguageFragment =>
-        engagement.__typename === 'LanguageEngagement'
-    )
-    .find(
-      (engagement) =>
-        engagement.firstScripture.value &&
-        engagement.language.value?.id === languageId
-    );
-
-  const firstScripture = {
-    value: firstScriptureEngagement?.firstScripture.value,
-    canRead: firstScriptureEngagement?.firstScripture.canRead,
-  };
-
-  const hasFirstScripture = {
-    value: firstScripture.value ?? hasExternalFirstScripture?.value,
-    canRead: !!firstScripture.canRead || !!hasExternalFirstScripture?.canRead,
-  };
 
   const canEditAnyFields = canEditAny(language) || canEditAny(ethnologue);
 
@@ -231,12 +208,10 @@ export const LanguageDetail = () => {
             loading={!language}
           />
 
-          <BooleanProperty
-            label="First Scripture"
-            redacted="You do not have permission to view whether the language has a first Scripture"
-            data={hasFirstScripture}
-            wrap={(node) => <Grid item>{node}</Grid>}
-          />
+          <Grid item>
+            <FirstScripture data={data?.language} />
+          </Grid>
+
           <Grid container spacing={3}>
             <Grid item xs={12}>
               <Grid
@@ -300,7 +275,10 @@ export const LanguageDetail = () => {
               <Typography variant="h3" paragraph>
                 Projects
               </Typography>
-              {listOrPlaceholders(projects?.items, 3).map((project, index) => (
+              {listOrPlaceholders(
+                projects?.items as ProjectListItemFragment[] | undefined,
+                3
+              ).map((project, index) => (
                 <ProjectListItemCard
                   key={project?.id ?? index}
                   project={project}

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -91,29 +91,18 @@ export const LanguageDetail = () => {
     hasExternalFirstScripture,
   } = language ?? {};
 
-  const engagements = projects?.items.reduce(
-    (e: LanguageFragment[], project) => {
-      const projectEngagements = project.engagements.items.reduce(
-        (pe: LanguageFragment[], engagement) => {
-          if (engagement.__typename === 'LanguageEngagement') {
-            return engagement.language.value?.id === languageId
-              ? pe.concat(engagement)
-              : pe;
-          } else {
-            return pe;
-          }
-        },
-        []
-      );
-      return e.concat(projectEngagements);
-    },
-    []
-  );
-
   // If the API is working properly, there should be a maximum of 1
-  const firstScriptureEngagement = engagements?.find(
-    (engagement) => engagement.firstScripture.value
-  );
+  const firstScriptureEngagement = projects?.items
+    .flatMap((project) => project.engagements.items)
+    .filter(
+      (engagement): engagement is LanguageFragment =>
+        engagement.__typename === 'LanguageEngagement'
+    )
+    .find(
+      (engagement) =>
+        engagement.firstScripture.value &&
+        engagement.language.value?.id === languageId
+    );
 
   const firstScripture = {
     value: firstScriptureEngagement?.firstScripture.value,

--- a/src/scenes/Languages/Edit/EditLanguage.tsx
+++ b/src/scenes/Languages/Edit/EditLanguage.tsx
@@ -47,6 +47,8 @@ export const EditLanguage = (props: EditLanguageProps) => {
                 CalendarDate.toFiscalYear(
                   language.sponsorEstimatedEndDate.value
                 ),
+              hasExternalFirstScripture:
+                language.hasExternalFirstScripture.value,
             },
           }
         : undefined,

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -1,4 +1,5 @@
 import { Grid, makeStyles, Typography } from '@material-ui/core';
+import { setIn } from 'final-form';
 import React from 'react';
 import { Except } from 'type-fest';
 import {
@@ -65,6 +66,16 @@ export const LanguageForm = <T extends any>({
       {...rest}
       decorators={decorators}
       fieldsPrefix="language"
+      errorHandlers={{
+        Input: (e, next) =>
+          e.field === 'language.hasExternalFirstScripture'
+            ? setIn(
+                {},
+                e.field,
+                'Language already engaged with first Scripture'
+              )
+            : next(e),
+      }}
     >
       {({
         values,
@@ -193,6 +204,7 @@ export const LanguageForm = <T extends any>({
                         <CheckboxField
                           label="Was this language's first scripture produced outside of CORD?"
                           margin="none"
+                          keepHelperTextSpacing
                           {...props}
                         />
                       </Grid>

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -187,6 +187,17 @@ export const LanguageForm = <T extends any>({
                       </Grid>
                     )}
                   </SecuredField>
+                  <SecuredField obj={language} name="hasExternalFirstScripture">
+                    {(props) => (
+                      <Grid item xs={12} sm={6}>
+                        <CheckboxField
+                          label="Was this language's first scripture produced outside of CORD?"
+                          margin="none"
+                          {...props}
+                        />
+                      </Grid>
+                    )}
+                  </SecuredField>
                   <Grid item xs={12} sm={6}>
                     <SelectField
                       label="Sensitivity"

--- a/src/scenes/Languages/LanguageForm/LangugeForm.graphql
+++ b/src/scenes/Languages/LanguageForm/LangugeForm.graphql
@@ -59,4 +59,9 @@ fragment LanguageForm on Language {
     canEdit
     value
   }
+  hasExternalFirstScripture {
+    canRead
+    canEdit
+    value
+  }
 }


### PR DESCRIPTION
Closes #39 

- Update Language Detail to display whether the language is marked as having an external First Scripture OR has an engagement that is marked as `firstScripture`
- Update Language Form to include a `hasExternalFirstScripture` checkbox (validation will be performed by the API)