### PR TITLE
On user details show partners cards

### DIFF
--- a/src/api/fragments/user.graphql
+++ b/src/api/fragments/user.graphql
@@ -22,10 +22,10 @@ fragment DisplayUser on User {
   about {
     ...securedString
   }
-  organizations {
+  partners {
     items {
       id
-      ...OrganizationListItem
+      ...PartnerListItem
     }
   }
   roles {

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -14,7 +14,7 @@ import {
   DisplaySimplePropertyProps,
 } from '../../../components/DisplaySimpleProperty';
 import { Fab } from '../../../components/Fab';
-import { OrganizationListItemCard } from '../../../components/OrganizationListItemCard';
+import { PartnerListItemCard } from '../../../components/PartnerListItemCard';
 import { Redacted } from '../../../components/Redacted';
 import { EditUser } from '../Edit';
 import { UserDocument } from './UserDetail.generated';
@@ -38,10 +38,10 @@ const useStyles = makeStyles(({ spacing, breakpoints }) => ({
     flex: 1,
     display: 'flex',
   },
-  organizationsContainer: {
+  partnersContainer: {
     marginTop: spacing(1),
   },
-  organization: {
+  partner: {
     marginBottom: spacing(2),
   },
 }));
@@ -132,15 +132,15 @@ export const UserDetail = () => {
           />
           {user ? <EditUser user={user} {...editUserState} /> : null}
 
-          {!!user?.organizations.items.length && (
+          {!!user?.partners.items.length && (
             <>
               <Typography variant="h3">Partners</Typography>
-              <div className={classes.organizationsContainer}>
-                {user.organizations.items.map((item) => (
-                  <OrganizationListItemCard
+              <div className={classes.partnersContainer}>
+                {user.partners.items.map((item) => (
+                  <PartnerListItemCard
                     key={item.id}
-                    organization={item}
-                    className={classes.organization}
+                    partner={item}
+                    className={classes.partner}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Based off: https://github.com/SeedCompany/cord-api-v3/pull/1466

@CarsonF let me know if you want me to remove `OrganizationListItemCard` from the codebase it's not being used anymore