### PR TITLE
Expose mou start and end overrides on partnership Edit

### DIFF
--- a/src/components/PartnershipCard/PartnershipCard.graphql
+++ b/src/components/PartnershipCard/PartnershipCard.graphql
@@ -10,6 +10,16 @@ fragment PartnershipCard on Partnership {
   mouStatus {
     value
   }
+  mouStart {
+    canRead
+    canEdit
+    value
+  }
+  mouEnd {
+    canRead
+    canEdit
+    value
+  }
   partner {
     canRead
     canEdit

--- a/src/components/PartnershipCard/PartnershipCard.stories.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.stories.tsx
@@ -31,6 +31,16 @@ export const WithData = () => {
         },
       },
     },
+    mouStart: {
+      canRead: true,
+      canEdit: true,
+      value: dateTime('updatedAt'),
+    },
+    mouEnd: {
+      canRead: true,
+      canEdit: true,
+      value: dateTime('updatedAt'),
+    },
     createdAt: dateTime('createdAt'),
     types: {
       value: csv(text('Types', 'Managing, Funding')),

--- a/src/components/PartnershipCard/PartnershipCard.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.tsx
@@ -91,7 +91,7 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
           </Grid>
           <Grid item>
             <DisplaySimpleProperty
-              label="Mou Status"
+              label="MOU Status"
               value={displayPartnershipStatus(partnership?.mouStatus.value)}
               loading={!partnership}
               loadingWidth="40%"
@@ -99,7 +99,7 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
           </Grid>
           <Grid item>
             <DisplaySimpleProperty
-              label="Mou Start - End"
+              label="MOU Date Range"
               value={dateRangeString}
               loading={!partnership}
               loadingWidth="40%"

--- a/src/components/PartnershipCard/PartnershipCard.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.tsx
@@ -12,9 +12,10 @@ import React, { FC } from 'react';
 import {
   displayFinancialReportingType,
   displayPartnershipStatus,
+  securedDateRange,
 } from '../../api';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
-import { useDateTimeFormatter } from '../Formatters';
+import { useDateFormatter, useDateTimeFormatter } from '../Formatters';
 import { PartnershipCardFragment } from './PartnershipCard.generated';
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -38,6 +39,12 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
 }) => {
   const classes = useStyles();
   const formatDateTime = useDateTimeFormatter();
+  const formatDate = useDateFormatter();
+  const dateRangeString =
+    partnership &&
+    formatDate.range(
+      securedDateRange(partnership.mouStart, partnership.mouEnd).value
+    );
 
   return (
     <Card className={className}>
@@ -86,6 +93,14 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
             <DisplaySimpleProperty
               label="Mou Status"
               value={displayPartnershipStatus(partnership?.mouStatus.value)}
+              loading={!partnership}
+              loadingWidth="40%"
+            />
+          </Grid>
+          <Grid item>
+            <DisplaySimpleProperty
+              label="Mou Start - End"
+              value={dateRangeString}
               loading={!partnership}
               loadingWidth="40%"
             />

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -70,12 +70,16 @@ export const EditPartnership: FC<EditPartnershipProps> = (props) => {
         mouStatus: partnership.mouStatus.value ?? 'NotAttached',
         types: partnership.types.value,
         financialReportingType: partnership.financialReportingType.value,
+        mouStartOverride: partnership.mouStartOverride.value,
+        mouEndOverride: partnership.mouEndOverride.value,
       },
     }),
     [
       partnership.agreementStatus.value,
       partnership.financialReportingType.value,
       partnership.id,
+      partnership.mouEndOverride.value,
+      partnership.mouStartOverride.value,
       partnership.mouStatus.value,
       partnership.types.value,
     ]

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
@@ -15,6 +15,16 @@ fragment PartnershipForm on Partnership {
     canEdit
     canRead
   }
+  mouEndOverride {
+    canRead
+    canEdit
+    value
+  }
+  mouStartOverride {
+    canRead
+    canEdit
+    value
+  }
   partner {
     canRead
     canEdit

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -13,6 +13,7 @@ import {
   DialogFormProps,
 } from '../../../components/Dialog/DialogForm';
 import {
+  DateField,
   EnumField,
   EnumFieldProps,
   SecuredField,
@@ -129,6 +130,25 @@ export const PartnershipForm = <T extends PartnershipFormValues>({
                 <SecuredField obj={partnership} name="mouStatus">
                   {(props) => (
                     <AgreementStatusField label="Mou Status" {...props} />
+                  )}
+                </SecuredField>
+
+                <SecuredField obj={partnership} name="mouStartOverride">
+                  {(props) => (
+                    <DateField
+                      {...props}
+                      label="Start Date"
+                      helperText="Leave blank to use the project's mou start date"
+                    />
+                  )}
+                </SecuredField>
+                <SecuredField obj={partnership} name="mouEndOverride">
+                  {(props) => (
+                    <DateField
+                      {...props}
+                      label="End Date"
+                      helperText="Leave blank to use the project's mou end date"
+                    />
                   )}
                 </SecuredField>
               </>


### PR DESCRIPTION
@CarsonF should I also show the dates on the partnership cards?

Also this seem different than the other override values?  There's no direct `mouDate` field on the Partnership object