### PR TITLE
Form field improvements

### DIFF
--- a/src/components/form/AlphaLowercaseField.tsx
+++ b/src/components/form/AlphaLowercaseField.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Except } from 'type-fest';
+import {
+  FormattedTextField,
+  FormattedTextFieldProps,
+} from './FormattedTextField';
+import { isLength } from './validators';
+
+interface AlphaLowercaseFieldProps
+  extends Except<
+    FormattedTextFieldProps,
+    'accept' | 'formatInput' | 'replace' | 'validate'
+  > {
+  chars: number;
+}
+
+// A lower-cased alpha string field
+export const AlphaLowercaseField = ({
+  chars,
+  ...props
+}: AlphaLowercaseFieldProps) => (
+  <FormattedTextField
+    accept={/[a-zA-Z]/g}
+    formatInput={(value) =>
+      (value.match(/[a-zA-Z]+/g) || []).join('').substr(0, chars)
+    }
+    replace={(value) => value.toLowerCase()}
+    validate={isLength(chars)}
+    {...props}
+  />
+);

--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -7,12 +7,15 @@ import {
   FormControlProps,
   FormHelperText,
 } from '@material-ui/core';
-import React, { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 
-export type CheckboxFieldProps = FieldConfig<boolean> & {
-  name: string;
+export type CheckboxFieldProps = FieldConfig<
+  boolean,
+  false,
+  HTMLInputElement
+> & {
   helperText?: ReactNode;
 } & Omit<CheckboxProps, 'defaultValue' | 'value' | 'inputRef'> &
   Pick<FormControlLabelProps, 'label' | 'labelPlacement'> &
@@ -26,24 +29,25 @@ export type CheckboxFieldProps = FieldConfig<boolean> & {
     keepHelperTextSpacing?: boolean;
   };
 
-export const CheckboxField: FC<CheckboxFieldProps> = ({
+export function CheckboxField({
   label,
   labelPlacement,
   helperText,
-  defaultValue = false,
+  defaultValue: defaultValueProp,
   fullWidth,
   margin,
   variant,
   keepHelperTextSpacing,
   ...props
-}) => {
-  const { input, meta, ref, rest } = useField<boolean, HTMLInputElement>({
-    defaultValue,
-    ...props,
-  });
+}: CheckboxFieldProps) {
+  const defaultValue = defaultValueProp ?? false;
 
-  const inputValueIsValid =
-    (input.value as unknown) === false || (input.value as unknown) === true;
+  const { input, meta, ref, rest } = useField<boolean, false, HTMLInputElement>(
+    {
+      defaultValue,
+      ...props,
+    }
+  );
 
   return (
     <FormControl
@@ -63,7 +67,7 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
           <Checkbox
             {...rest}
             inputRef={ref}
-            checked={inputValueIsValid ? input.value : defaultValue}
+            checked={isBoolean(input.value) ? input.value : defaultValue}
             value={input.name}
             onChange={(e) => input.onChange(e.target.checked)}
             required={props.required}
@@ -75,4 +79,7 @@ export const CheckboxField: FC<CheckboxFieldProps> = ({
       </FormHelperText>
     </FormControl>
   );
-};
+}
+
+const isBoolean = (value: unknown): value is boolean =>
+  value === false || value === true;

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -14,7 +14,7 @@ import { ParsableDate } from '@material-ui/pickers/constants/prop-types';
 import { DateTime } from 'luxon';
 import React, { useRef } from 'react';
 import { Except } from 'type-fest';
-import { CalendarDate } from '../../util';
+import { CalendarDate, Nullable } from '../../util';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 import { required as requiredValidator, Validator } from './validators';
@@ -46,7 +46,7 @@ export const DateField = ({
   ...props
 }: DateFieldProps) => {
   const utils = useUtils();
-  const validator: Validator<DateTime | null> = (val) => {
+  const validator: Validator<Nullable<DateTime>> = (val) => {
     const allProps = {
       ...defaultRange,
       ...props,
@@ -66,7 +66,7 @@ export const DateField = ({
   const initialValue = useDate(initialValueProp);
   const defaultValue = useDate(defaultValueProp);
 
-  const { input, meta, ref, rest } = useField<DateTime | null>({
+  const { input, meta, ref, rest } = useField<DateTime, false>({
     isEqual: isDateEqual,
     ...props,
     defaultValue,

--- a/src/components/form/Dropzone.tsx
+++ b/src/components/form/Dropzone.tsx
@@ -10,8 +10,9 @@ import {
 } from '@material-ui/core';
 import { Clear as ClearIcon } from '@material-ui/icons';
 import clsx from 'clsx';
-import React, { FC, useMemo } from 'react';
+import React from 'react';
 import { useDropzone } from 'react-dropzone';
+import { Except } from 'type-fest';
 import { fileIcon } from '../files/fileTypes';
 import { FieldConfig, useField } from './useField';
 
@@ -36,24 +37,22 @@ const useStyles = makeStyles(({ palette, spacing }) => {
   };
 });
 
-export type DropzoneFieldProps<
-  FieldValue = File[]
-> = FieldConfig<FieldValue> & {
+export type DropzoneFieldProps = Except<FieldConfig<File, true>, 'multiple'> & {
   multiple?: boolean;
-  name: string;
 };
 
-export const DropzoneField: FC<DropzoneFieldProps> = ({
+export function DropzoneField({
   multiple = true,
   name: nameProp,
-}) => {
+}: DropzoneFieldProps) {
   const classes = useStyles();
 
-  // Memoize defaultValue to prevent re-renders when not changing.
-  const defaultValue = useMemo(() => [], []);
   const {
     input: { name, onChange, value: currentFiles },
-  } = useField<File[], HTMLInputElement>({ name: nameProp, defaultValue });
+  } = useField<File, true, HTMLInputElement>({
+    name: nameProp,
+    multiple: true, // always list for FF
+  });
 
   const onDrop = (acceptedFiles: File[]) => {
     const updatedFiles =
@@ -125,4 +124,4 @@ export const DropzoneField: FC<DropzoneFieldProps> = ({
       )}
     </>
   );
-};
+}

--- a/src/components/form/FormattedTextField.tsx
+++ b/src/components/form/FormattedTextField.tsx
@@ -50,7 +50,7 @@ export function FormattedTextField<FieldValue = string>({
   variant,
   ...props
 }: FormattedTextFieldProps<FieldValue>) {
-  const { input, meta, ref, rest } = useField(props);
+  const { input, meta, ref, rest } = useField<FieldValue, false>(props);
   const name = input.name;
 
   const [managedVal, setManagedVal] = useState<{
@@ -58,12 +58,12 @@ export function FormattedTextField<FieldValue = string>({
     parsed?: FieldValue;
   }>({
     raw: format ? format(input.value, name) : input.value,
-    parsed: input.value,
+    parsed: input.value ?? undefined,
   });
   const updateManagedVal = useCallback(() => {
     setManagedVal({
       raw: format ? format(input.value, name) : input.value,
-      parsed: input.value,
+      parsed: input.value ?? undefined,
     });
   }, [setManagedVal, format, name, input.value]);
   useEffect(() => {

--- a/src/components/form/NumberField.tsx
+++ b/src/components/form/NumberField.tsx
@@ -2,13 +2,14 @@ import { InputAdornment, makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import React from 'react';
 import { Except } from 'type-fest';
+import { Nullable } from '../../util';
 import {
   FormattedTextField,
   FormattedTextFieldProps,
 } from './FormattedTextField';
 
 export type NumberFieldProps = Except<
-  FormattedTextFieldProps<number | undefined>,
+  FormattedTextFieldProps<number>,
   'allowNull'
 > &
   Partial<FormattingOptions> & {
@@ -135,7 +136,7 @@ const formatNumber = ({
 };
 
 const formatValidNumber = (
-  string: string | number | undefined,
+  string: Nullable<string | number>,
   minimumFractionDigits: number,
   maximumFractionDigits: number
 ) => {
@@ -200,7 +201,7 @@ export const NumberField = ({
   const formatInput = formatNumber(formatting);
   const replace = replaceNumber(formatting);
   return (
-    <FormattedTextField<number | undefined>
+    <FormattedTextField<number>
       accept={/[\d-.]/g}
       formatInput={formatInput}
       replace={replace}

--- a/src/components/form/SelectField.tsx
+++ b/src/components/form/SelectField.tsx
@@ -2,8 +2,7 @@ import {
   FormControl,
   FormControlProps,
   FormHelperText,
-  FormLabel,
-  makeStyles,
+  InputLabel,
   MenuItem,
   Select,
 } from '@material-ui/core';
@@ -12,22 +11,16 @@ import * as React from 'react';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 
-const useStyles = makeStyles(({ typography }) => ({
-  fieldLabel: {
-    fontWeight: typography.weight.bold,
-  },
-}));
-
 export type SelectFieldProps<T = string> = FieldConfig<T> & {
   name: string;
-  selectOptions: SelectItem[];
+  selectOptions: readonly SelectItem[];
   helperText?: ReactNode;
-  label?: string;
+  label?: ReactNode;
 } & FormControlProps;
 
 interface SelectItem {
   value: any;
-  label: string;
+  label: ReactNode;
 }
 
 export const SelectField: FC<SelectFieldProps> = ({
@@ -36,7 +29,6 @@ export const SelectField: FC<SelectFieldProps> = ({
   helperText,
   ...props
 }) => {
-  const classes = useStyles();
   const { input, meta, rest } = useField(props);
 
   return (
@@ -46,10 +38,11 @@ export const SelectField: FC<SelectFieldProps> = ({
       error={showError(meta)}
       {...rest}
     >
-      {label && <FormLabel className={classes.fieldLabel}>{label}</FormLabel>}
+      {label && <InputLabel>{label}</InputLabel>}
       <Select
         autoFocus={rest.autoFocus}
         {...input}
+        label={label}
         onChange={(e) => input.onChange(e.target.value)}
       >
         {selectOptions.map(({ value, label }: SelectItem) => (

--- a/src/components/form/SelectField.tsx
+++ b/src/components/form/SelectField.tsx
@@ -5,53 +5,99 @@ import {
   InputLabel,
   MenuItem,
   Select,
+  SelectProps,
 } from '@material-ui/core';
-import { FC, ReactNode } from 'react';
+import { identity } from 'lodash';
+import { ReactNode } from 'react';
 import * as React from 'react';
+import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 
-export type SelectFieldProps<T = string> = FieldConfig<T> & {
-  name: string;
-  selectOptions: readonly SelectItem[];
-  helperText?: ReactNode;
+export type SelectFieldProps<T, Multiple extends boolean | undefined> = Except<
+  FieldConfig<T, Multiple>,
+  'allowNull' | 'isEqual'
+> & {
+  options: readonly T[];
+  getOptionLabel?: (option: T) => string;
+  // This can be a label to show an empty option or a rendered EnumOption.
+  defaultOption?: string | ReactNode;
   label?: ReactNode;
-} & FormControlProps;
+  helperText?: ReactNode;
+} & Pick<
+    FormControlProps,
+    'color' | 'fullWidth' | 'margin' | 'size' | 'variant'
+  > &
+  Pick<SelectProps, 'displayEmpty'>;
 
-interface SelectItem {
-  value: any;
-  label: ReactNode;
-}
+export function SelectField<T, Multiple extends boolean | undefined>({
+  // value handling
+  options,
+  getOptionLabel: getOptionLabelProp,
+  defaultOption,
+  multiple,
 
-export const SelectField: FC<SelectFieldProps> = ({
+  // display labels
   label,
-  selectOptions,
   helperText,
+
+  // FormControl props
+  color,
+  fullWidth,
+  margin,
+  size,
+  variant,
+
   ...props
-}) => {
-  const { input, meta, rest } = useField(props);
+}: SelectFieldProps<T, Multiple>) {
+  const getOptionLabel = getOptionLabelProp ?? identity;
+
+  const { input, meta, rest } = useField<T, Multiple>({
+    ...props,
+    multiple,
+    allowNull: !multiple,
+  });
 
   return (
     <FormControl
       disabled={meta.disabled}
       focused={meta.focused}
       error={showError(meta)}
-      {...rest}
+      color={color}
+      fullWidth={fullWidth}
+      margin={margin}
+      size={size}
+      variant={variant}
     >
       {label && <InputLabel>{label}</InputLabel>}
       <Select
         autoFocus={rest.autoFocus}
         {...input}
+        // convert null to empty string so Select shows the label for it.
+        // FF knows to convert empty string to null.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        value={input.value ?? meta.defaultValue ?? ''}
         label={label}
         onChange={(e) => input.onChange(e.target.value)}
+        multiple={multiple}
+        {...rest}
       >
-        {selectOptions.map(({ value, label }: SelectItem) => (
-          <MenuItem key={value} value={value}>
-            {label}
+        {defaultOption && (
+          <MenuItem value="">
+            {typeof defaultOption === 'string' ? (
+              <em>{defaultOption}</em>
+            ) : (
+              defaultOption
+            )}
+          </MenuItem>
+        )}
+        {options.map((option, index) => (
+          <MenuItem key={index} value={option as any}>
+            {getOptionLabel(option)}
           </MenuItem>
         ))}
       </Select>
       <FormHelperText>{getHelperText(meta, helperText)}</FormHelperText>
     </FormControl>
   );
-};
+}

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -7,9 +7,8 @@ import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 
-export type TextFieldProps<FieldValue = string> = FieldConfig<FieldValue> & {
-  name: string;
-} & Except<
+export type TextFieldProps<FieldValue = string> = FieldConfig<FieldValue> &
+  Except<
     MuiTextFieldProps,
     'defaultValue' | 'error' | 'value' | 'name' | 'inputRef'
   >;

--- a/src/components/form/VersesField.tsx
+++ b/src/components/form/VersesField.tsx
@@ -31,10 +31,9 @@ import { requiredArray } from './validators';
 
 type GenericScriptureRange = ScriptureRange | RawScriptureRange;
 
-type Val = Array<GenericScriptureRange | string> | [];
+type Val = GenericScriptureRange | string;
 
-export type VersesFieldProps = Except<FieldConfig<Val>, 'multiple'> & {
-  name: string;
+export type VersesFieldProps = Except<FieldConfig<Val, true>, 'multiple'> & {
   book: string;
 } & Pick<
     AutocompleteProps<GenericScriptureRange | string, true, false, true>,
@@ -92,7 +91,7 @@ export function VersesField({
   ...props
 }: VersesFieldProps) {
   const [errorCode, setErrorCode] = useState('');
-  const validateReference = (ranges: Val) => {
+  const validateReference = (ranges: readonly Val[]) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!ranges || ranges.length === 0) return undefined;
     // only the last needs to be validated since the others have been already
@@ -109,9 +108,10 @@ export function VersesField({
   const classes = useStyles();
 
   const [inputValue, setInputValue] = useState<string>('');
-  const { input, meta, ref, rest } = useField<Val>({
+  const { input, meta, ref, rest } = useField<Val, true>({
+    multiple: true,
     validate: [validateReference, required ? requiredArray : null],
-    parse: (value: Val | string): Val => {
+    parse: (value: readonly Val[] | string): readonly Val[] => {
       // need to call onChange in two cases
       // 1: on type (string) so we can show errors in real time
       // 2: on change when a new value is added to tags (string[])
@@ -147,7 +147,7 @@ export function VersesField({
     ...props,
     autoFocus,
   });
-  const [scriptureRanges, setScriptureRanges] = useState<Val>(
+  const [scriptureRanges, setScriptureRanges] = useState<readonly Val[]>(
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     input.value ?? []
   );
@@ -211,6 +211,7 @@ export function VersesField({
           );
         });
       }}
+      // @ts-expect-error typed as mutable even though its not needed
       value={scriptureRanges}
       inputValue={inputValue}
       onInputChange={(_, value) => {

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,3 +1,4 @@
+export * from './AlphaLowercaseField';
 export * from './Lookup/LookupField';
 export * from './CheckboxField';
 export * from './decorators';

--- a/src/components/form/validators.ts
+++ b/src/components/form/validators.ts
@@ -1,6 +1,7 @@
 import { FieldState } from 'final-form';
 import { Promisable } from 'type-fest';
 import isEmail from 'validator/lib/isEmail';
+import { Nullable } from '../../util';
 
 /**
  * A little stricter than upstream with the return type
@@ -28,11 +29,10 @@ export const compose = <Value>(
 export const required = (value: unknown) => (value ? undefined : 'Required');
 
 // setting null or undefined for value on Autocomplete {multiple} doesn't work, so use []
-export const requiredArray = <T>(value: readonly T[]) =>
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  value?.length > 0 ? undefined : 'Required';
+export const requiredArray = <T>(value: Nullable<readonly T[]>) =>
+  value && value.length > 0 ? undefined : 'Required';
 
-export const email = (value: string) =>
+export const email = (value: Nullable<string>) =>
   !value || isEmail(value) ? undefined : 'Invalid email';
 
 export const min = (min: number, error?: string) => (
@@ -43,10 +43,10 @@ export const max = (max: number, error?: string) => (
   val: number | null | undefined
 ) => (val != null && val > max ? error ?? 'Value is above maximum' : undefined);
 
-export const minLength = (min = 2) => (value: string) =>
+export const minLength = (min = 2) => (value: Nullable<string>) =>
   !value || value.length >= min
     ? undefined
     : `Must be ${min} or more characters`;
 
-export const isLength = (len: number) => (value: string) =>
+export const isLength = (len: number) => (value: Nullable<string>) =>
   !value || value.length === len ? undefined : `Must be ${len} characters`;

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -51,11 +51,6 @@ const decorators = [
   matchFieldIfSame(`language.name`, `language.displayName`),
 ];
 
-const sensitivitySelectOptions = SensitivityList.map((sensitivity) => ({
-  value: sensitivity,
-  label: sensitivity,
-}));
-
 export const LanguageForm = <T extends any>({
   language,
   ...rest
@@ -196,7 +191,7 @@ export const LanguageForm = <T extends any>({
                     <SelectField
                       label="Sensitivity"
                       name="sensitivity"
-                      selectOptions={sensitivitySelectOptions}
+                      options={SensitivityList}
                       defaultValue="High"
                     />
                   </Grid>

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -12,6 +12,7 @@ import {
   DialogFormProps,
 } from '../../../components/Dialog/DialogForm';
 import {
+  AlphaLowercaseField,
   CheckboxField,
   FieldGroup,
   FormattedTextField,
@@ -255,7 +256,8 @@ export const LanguageForm = <T extends any>({
                     <SecuredField obj={language?.ethnologue} name="code">
                       {(props) => (
                         <Grid item xs={12} sm={6}>
-                          <EthnologueCodeField
+                          <AlphaLowercaseField
+                            chars={3}
                             label="Ethnologue Code"
                             placeholder="Enter Ethnologue Code"
                             margin="none"
@@ -270,7 +272,8 @@ export const LanguageForm = <T extends any>({
                     >
                       {(props) => (
                         <Grid item xs={12} sm={6}>
-                          <EthnologueCodeField
+                          <AlphaLowercaseField
+                            chars={3}
                             label="Provisional Code"
                             placeholder="Enter Provisional Code"
                             margin="none"
@@ -329,23 +332,6 @@ export const LanguageForm = <T extends any>({
         );
       }}
     </DialogForm>
-  );
-};
-
-// A 3-character lower-cased alpha string
-const EthnologueCodeField = (props: FormattedTextFieldProps) => {
-  return (
-    <FormattedTextField
-      accept={/[a-zA-Z]/g}
-      formatInput={(value) =>
-        (value.match(/[a-zA-Z]+/g) || []).join('').substr(0, 3)
-      }
-      replace={(value) => value.toLowerCase()}
-      validate={(value) =>
-        !value || value.length === 3 ? undefined : `Must be 3 characters`
-      }
-      {...props}
-    />
   );
 };
 

--- a/src/scenes/Products/ProductForm/AccordionSection.tsx
+++ b/src/scenes/Products/ProductForm/AccordionSection.tsx
@@ -88,9 +88,9 @@ const useStyles = makeStyles(({ spacing, typography, breakpoints }) => ({
   },
 }));
 
-const productFieldMap: Partial<
-  Record<ProductTypes, ComponentType<FieldConfig<any, any>>>
-> = {
+type AnyFormFieldComponent = ComponentType<FieldConfig<any, any, any>>;
+
+const productFieldMap: Partial<Record<ProductTypes, AnyFormFieldComponent>> = {
   Film: FilmField,
   Story: StoryField,
   LiteracyMaterial: LiteracyMaterialField,

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -10,6 +10,11 @@ export const appProps: ThemeOptions['props'] = (_theme) => ({
     fullWidth: true,
     margin: 'dense',
   },
+  MuiFormControl: {
+    variant: 'filled',
+    fullWidth: true,
+    margin: 'dense',
+  },
   MuiFormLabel: {
     required: false, // no asterisk
   },
@@ -32,6 +37,7 @@ export const appOverrides: ThemeOptions['overrides'] = ({
   spacing,
   palette,
   typography,
+  shape,
 }) => {
   const primaryColorForText = palette.dark
     ? palette.primary.light
@@ -91,6 +97,18 @@ export const appOverrides: ThemeOptions['overrides'] = ({
         '&:-webkit-autofill': {
           // subtler blue on dark mode
           WebkitBoxShadow: palette.dark ? `0 0 0 100px #2e3d46 inset` : null,
+        },
+      },
+    },
+    MuiSelect: {
+      // Fix focused shade from not having same border radius
+      select: {
+        '&.MuiSelect-filled:focus': {
+          borderTopLeftRadius: shape.borderRadius,
+          borderTopRightRadius: shape.borderRadius,
+        },
+        '&.MuiSelect-outlined:focus': {
+          borderRadius: shape.borderRadius,
         },
       },
     },


### PR DESCRIPTION
- Improved `SelectField`
  - Style now matches `TextField` instead of half `EnumField` & half unstyled `TextField`
    Before / After (sensitivity is the select field. location name is for reference)
![Screen Shot 2021-01-27 at 8 49 34 PM](https://user-images.githubusercontent.com/932566/106082931-3fd89a00-60e1-11eb-923a-24570a1a09b3.png)  ![Screen Shot 2021-01-27 at 8 55 26 PM](https://user-images.githubusercontent.com/932566/106083365-02284100-60e2-11eb-913f-41f11fd3c003.png)

  - Fixed MUI style bug with focused border radius
  - Changed options API to match  `Autocomplete`, `Lookup`, and `Enum` fields
  where `options` is a list of values which can be combined with a function
  to get the label of the value.
- Moved handling multiple values into `useField` hook
  - FF's hook already had the multiple option it just wasn't being used very well.
  - Continuing with that we now apply "at least one item" validator and a default `defaultValue` of an empty list when `multiple` is `true`.
  - `compareBy` is a new option as a shortcut for the `isEqual` option.
  - Some Fields had a `getCompareBy` prop. This was renamed to `compareBy` as it's forwarded to the hook.
- Changed type of Field `value` to nullable when `multiple` is `false`.
  This more closely matches reality where the value could always be cleared, reset, etc before a form submission happens.
- Refactored `EthnologueCodeField` to generic `AlphaLowercaseField`