### PR TITLE
Update/Invalidate cache on partnership / date range changes

### DIFF
--- a/src/scenes/Partnerships/Create/CreatePartnership.tsx
+++ b/src/scenes/Partnerships/Create/CreatePartnership.tsx
@@ -6,6 +6,8 @@ import {
   CreatePartnership as CreatePartnershipType,
 } from '../../../api';
 import { PartnerLookupItem } from '../../../components/form/Lookup';
+import { callAll } from '../../../util';
+import { invalidateBudgetRecords } from '../InvalidateBudget';
 import { ProjectPartnershipsQuery } from '../List/PartnershipList.generated';
 import { PartnershipForm, PartnershipFormProps } from '../PartnershipForm';
 import { CreatePartnershipDocument } from './CreatePartnership.generated';
@@ -30,10 +32,17 @@ export const CreatePartnership = ({
   ...props
 }: CreatePartnershipProps) => {
   const [createPartnership] = useMutation(CreatePartnershipDocument, {
-    update: addItemToList({
-      listId: [project, 'partnerships'],
-      outputToItem: (res) => res.createPartnership.partnership,
-    }),
+    update: callAll(
+      addItemToList({
+        listId: [project, 'partnerships'],
+        outputToItem: (res) => res.createPartnership.partnership,
+      }),
+      invalidateBudgetRecords(
+        project,
+        undefined,
+        (res) => res.createPartnership.partnership
+      )
+    ),
   });
 
   return (

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -5,6 +5,8 @@ import { Except } from 'type-fest';
 import { removeItemFromList, UpdatePartnershipInput } from '../../../api';
 import { SubmitAction, SubmitButton } from '../../../components/form';
 import { PartnerLookupItem } from '../../../components/form/Lookup';
+import { callAll } from '../../../util';
+import { invalidateBudgetRecords } from '../InvalidateBudget/invalidateBudgetRecords';
 import { ProjectPartnershipsQuery } from '../List/PartnershipList.generated';
 import {
   hasManagingType,
@@ -62,12 +64,21 @@ const decorators = [clearFinancialReportingType];
 export const EditPartnership: FC<EditPartnershipProps> = (props) => {
   const { partnership, project } = props;
 
-  const [updatePartnership] = useMutation(UpdatePartnershipDocument);
+  const [updatePartnership] = useMutation(UpdatePartnershipDocument, {
+    update: invalidateBudgetRecords(
+      project,
+      partnership,
+      (res) => res.updatePartnership.partnership
+    ),
+  });
   const [deletePartnership] = useMutation(DeletePartnershipDocument, {
-    update: removeItemFromList({
-      listId: [project, 'partnerships'],
-      item: partnership,
-    }),
+    update: callAll(
+      removeItemFromList({
+        listId: [project, 'partnerships'],
+        item: partnership,
+      }),
+      invalidateBudgetRecords(project, partnership, undefined)
+    ),
   });
 
   const initialValues = useMemo(

--- a/src/scenes/Partnerships/InvalidateBudget/ProjectsBudget.graphql
+++ b/src/scenes/Partnerships/InvalidateBudget/ProjectsBudget.graphql
@@ -1,0 +1,25 @@
+fragment ProjectsBudgetForPartnershipChange on Project {
+  budget {
+    value {
+      id
+    }
+  }
+}
+
+fragment PartnershipToCheckBudgetChange on Partnership {
+  id
+  types {
+    value
+    canRead
+  }
+  mouEnd {
+    value
+    canRead
+    canEdit
+  }
+  mouStart {
+    value
+    canRead
+    canEdit
+  }
+}

--- a/src/scenes/Partnerships/InvalidateBudget/index.ts
+++ b/src/scenes/Partnerships/InvalidateBudget/index.ts
@@ -1,0 +1,1 @@
+export * from './invalidateBudgetRecords';

--- a/src/scenes/Partnerships/InvalidateBudget/invalidateBudgetRecords.ts
+++ b/src/scenes/Partnerships/InvalidateBudget/invalidateBudgetRecords.ts
@@ -1,0 +1,150 @@
+import { ApolloCache } from '@apollo/client';
+import { Modifier } from '@apollo/client/cache/core/types/common';
+import type { MutationUpdaterFn } from '@apollo/client/core';
+import { isFunction } from 'lodash';
+import { DateTime, Interval } from 'luxon';
+import { Project as ProjectShape, SecuredProp } from '../../../api';
+import {
+  PartnershipToCheckBudgetChangeFragment,
+  ProjectsBudgetForPartnershipChangeFragmentDoc as ProjectsBudget,
+} from './ProjectsBudget.generated';
+
+type Project = Pick<ProjectShape, 'id'>;
+type Partnership = PartnershipToCheckBudgetChangeFragment | undefined;
+
+/**
+ * Funding partnerships affect budget records.
+ * Invalidate budget records when they are changed.
+ */
+export const invalidateBudgetRecords = <R>(
+  project: Project,
+  previousOrFn: Partnership | ((res: R) => Partnership),
+  updatedOrFn: Partnership | ((res: R) => Partnership)
+): MutationUpdaterFn<R> => (cache: ApolloCache<unknown>, res) => {
+  const previous: Partnership = isFunction(previousOrFn)
+    ? res.data
+      ? previousOrFn(res.data)
+      : undefined
+    : previousOrFn;
+  const updated: Partnership = isFunction(updatedOrFn)
+    ? res.data
+      ? updatedOrFn(res.data)
+      : undefined
+    : updatedOrFn;
+
+  const change = determineChange(previous, updated);
+  if (change == null) {
+    console.log('No budget change needed for partnership change');
+    return;
+  }
+  if (change) {
+    console.log('Partnership changed budget in a destructive way');
+  } else {
+    console.log('Partnership changed budget in a non-destructive way');
+  }
+  doInvalidate(cache, project, change);
+};
+
+/**
+ * Returns boolean for whether the change is destructive or not, or null for no change.
+ */
+const determineChange = (previous: Partnership, updated: Partnership) => {
+  if (previous?.types.canRead === false || updated?.types.canRead === false) {
+    // If cannot read types, assume the worst
+    return true;
+  }
+  const prevFunding = isFunding(previous);
+  const nowFunding = isFunding(updated);
+
+  if (!prevFunding && nowFunding) {
+    // If adding a funding partnership, records are only added
+    return false;
+  }
+  if (!nowFunding && prevFunding) {
+    // If removing a funding partnership, records are removed
+    return true;
+  }
+  if (!previous || !updated) {
+    // partnership was added/removed but not in a way that affects records
+    return null;
+  }
+
+  // check date range to determine change
+  if (
+    !previous.mouStart.canRead ||
+    !previous.mouEnd.canRead ||
+    !updated.mouStart.canRead ||
+    !updated.mouEnd.canRead
+  ) {
+    // If cannot read times, assume the worst
+    return true;
+  }
+  const prev = interval(previous.mouStart, previous.mouEnd);
+  const now = interval(updated.mouStart, updated.mouEnd);
+
+  if (!prev) {
+    if (!now) {
+      return null;
+    } else {
+      // partnership now has a range, records will be added
+      return false;
+    }
+  }
+  if (!now) {
+    // partnership now doesn't have a range, records will be removed
+    return true;
+  }
+
+  if (prev.equals(now)) {
+    return null;
+  }
+
+  // If updated range is a subset of previous, then records could be removed.
+  // Otherwise records could only be added.
+  return prev.engulfs(now);
+};
+
+const isFunding = (partnership: Partnership) =>
+  partnership?.types.value.includes('Funding');
+
+const interval = (
+  start: SecuredProp<DateTime | string>,
+  end: SecuredProp<DateTime | string>
+) => {
+  const s = dt(start);
+  const e = dt(end);
+  return s && e ? Interval.fromDateTimes(s, e) : null;
+};
+
+// values straight from update result don't go through type policy reads,
+// thus they are not parsed to luxon objects.
+const dt = (prop: SecuredProp<DateTime | string>) =>
+  !prop.value
+    ? null
+    : typeof prop.value === 'string'
+    ? DateTime.fromISO(prop.value)
+    : prop.value;
+
+const doInvalidate = (
+  cache: ApolloCache<unknown>,
+  project: Project,
+  destructive: boolean
+) => {
+  const cached = cache.readFragment({
+    id: cache.identify(project),
+    fragment: ProjectsBudget,
+  });
+  const budget = cached?.budget.value;
+  if (!budget) {
+    return;
+  }
+
+  const invalidate: Modifier<unknown> = (_, { DELETE }) => DELETE;
+  cache.modify({
+    id: cache.identify(budget),
+    fields: {
+      ...(destructive ? { total: invalidate } : {}),
+      records: invalidate,
+    },
+  });
+};

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.graphql
@@ -54,4 +54,5 @@ fragment PartnershipForm on Partnership {
     canEdit
     canRead
   }
+  ...PartnershipToCheckBudgetChange
 }

--- a/src/scenes/Projects/DateRangeCache/CachedProjectDateRanges.graphql
+++ b/src/scenes/Projects/DateRangeCache/CachedProjectDateRanges.graphql
@@ -1,0 +1,65 @@
+fragment ProjectCachedEngagementDateRanges on Project {
+  id
+  mouStart {
+    canRead
+    value
+  }
+  mouEnd {
+    canRead
+    value
+  }
+  engagements {
+    items {
+      id
+      startDate {
+        canRead
+        value
+      }
+      endDate {
+        canRead
+        value
+      }
+      startDateOverride {
+        canRead
+        value
+      }
+      endDateOverride {
+        canRead
+        value
+      }
+    }
+  }
+}
+
+fragment ProjectCachedPartnershipDateRanges on Project {
+  id
+  mouStart {
+    canRead
+    value
+  }
+  mouEnd {
+    canRead
+    value
+  }
+  partnerships {
+    items {
+      id
+      mouStart {
+        canRead
+        value
+      }
+      mouEnd {
+        canRead
+        value
+      }
+      mouStartOverride {
+        canRead
+        value
+      }
+      mouEndOverride {
+        canRead
+        value
+      }
+    }
+  }
+}

--- a/src/scenes/Projects/DateRangeCache/index.ts
+++ b/src/scenes/Projects/DateRangeCache/index.ts
@@ -1,0 +1,1 @@
+export * from './updateCachedDateRanges';

--- a/src/scenes/Projects/DateRangeCache/updateCachedDateRanges.ts
+++ b/src/scenes/Projects/DateRangeCache/updateCachedDateRanges.ts
@@ -1,0 +1,84 @@
+import { ApolloCache } from '@apollo/client';
+import { DeepPartial } from 'ts-essentials';
+import { Project as ProjectShape, SecuredProp } from '../../../api';
+import { CalendarDate } from '../../../util';
+import {
+  ProjectCachedEngagementDateRangesFragmentDoc,
+  ProjectCachedPartnershipDateRangesFragmentDoc,
+} from './CachedProjectDateRanges.generated';
+
+type Project = Pick<ProjectShape, 'id'>;
+type SecuredDate = DeepPartial<
+  Pick<SecuredProp<CalendarDate>, 'value' | 'canRead'>
+>;
+
+export const updateEngagementDateRanges = (
+  cache: ApolloCache<unknown>,
+  project: Project
+) => {
+  const cached = cache.readFragment({
+    id: cache.identify(project),
+    fragment: ProjectCachedEngagementDateRangesFragmentDoc,
+    // We need override fields here but the engagement list doesn't have them.
+    // If the user visits/caches one of the engagements we need to update that one
+    // But without partial data, Apollo will correctly say that not all engagements
+    // fulfill the shape requested and thus return null.
+    // We want to allow some engagements to be missing data, and we'll account
+    // for that in our update logic.
+    returnPartialData: true,
+  });
+  if (!cached) {
+    return;
+  }
+  for (const eng of (cached as DeepPartial<typeof cached>).engagements?.items ??
+    []) {
+    if (!eng) {
+      continue;
+    }
+    updateDateCalcField(cache, eng, 'startDate', cached.mouStart);
+    updateDateCalcField(cache, eng, 'endDate', cached.mouEnd);
+  }
+};
+
+export const updatePartnershipsDateRanges = (
+  cache: ApolloCache<unknown>,
+  project: Project
+) => {
+  const partnerships = cache.readFragment({
+    id: cache.identify(project),
+    fragment: ProjectCachedPartnershipDateRangesFragmentDoc,
+  });
+  if (!partnerships) {
+    return;
+  }
+  for (const p of partnerships.partnerships.items) {
+    updateDateCalcField(cache, p, 'mouStart', partnerships.mouStart);
+    updateDateCalcField(cache, p, 'mouEnd', partnerships.mouEnd);
+  }
+};
+
+const updateDateCalcField = <Key extends string>(
+  cache: ApolloCache<unknown>,
+  obj: Partial<Record<Key | `${Key}Override`, SecuredDate>>,
+  key: Key,
+  fromProject: SecuredDate
+) => {
+  const calc = obj[key];
+  const override = obj[`${key}Override` as const];
+  if (!fromProject.canRead || !calc?.canRead || !override?.canRead) {
+    console.log('Not enough info to determine which fields need to be updated');
+    return;
+  }
+  if (override.value) {
+    return;
+  }
+  cache.modify({
+    id: cache.identify(obj),
+    fields: {
+      [key]: () => ({
+        ...obj[key],
+        value: fromProject.value,
+      }),
+    },
+  });
+};


### PR DESCRIPTION
Fixes #740 Fixes #801

- On project date range changes
  - Invalidate budget records which could be changed due to funding partnership's date range changing
  - Update partnership's & engagement's date ranges if they have not been overridden
- On funding partnership creation/deletion/changes
  - Invalidate budget records, which are based the funding partners date range
  - Invalidate budget total if the change is "destructive". i.e. if the partnership is no longer funding or the date range is shortened, this would cause records to be deleted. Thus the total could be affected. This is done conditionally as we don't want to reload the project overview page unless required.