### PR TITLE
Convert post shareability from boolean to enum. 

### DIFF
--- a/src/api/displayEnums.ts
+++ b/src/api/displayEnums.ts
@@ -16,6 +16,7 @@ import { Nullable } from '../util';
 import { MethodologyToApproach } from './approach';
 import {
   InternshipPosition,
+  PostShareability,
   ProductMedium,
   ProductMethodology,
   ProductPurpose,
@@ -73,3 +74,5 @@ export const displayProductTypes = (type: ProductTypes) =>
   type === 'DirectScriptureProduct'
     ? 'Scripture'
     : displayEnum<ProductTypes>()(type);
+
+export const displayPostShareability = displayEnum<PostShareability>();

--- a/src/components/posts/CreatePostForm/CreatePostForm.tsx
+++ b/src/components/posts/CreatePostForm/CreatePostForm.tsx
@@ -3,8 +3,12 @@ import { Grid, makeStyles } from '@material-ui/core';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { Form } from 'react-final-form';
-import { PostTypeList } from '../../../api';
-import { SelectField, SubmitButton, SwitchField, TextField } from '../../form';
+import {
+  displayPostShareability,
+  PostShareabilityList,
+  PostTypeList,
+} from '../../../api';
+import { SelectField, SubmitButton, TextField } from '../../form';
 import { minLength, required } from '../../form/validators';
 import { CreatePostDocument, CreatePostMutation } from './CreatePost.generated';
 
@@ -39,7 +43,7 @@ export const CreatePostForm = ({
       initialValues={{
         body: '',
         type: 'Note',
-        shareable: true,
+        shareability: 'Public',
       }}
       onSubmit={async (values) => {
         await createPost({
@@ -49,7 +53,7 @@ export const CreatePostForm = ({
                 parentId,
                 body: values.body,
                 type: values.type,
-                shareable: values.shareable,
+                shareability: values.shareability,
               },
             },
           },
@@ -83,7 +87,13 @@ export const CreatePostForm = ({
               />
             </Grid>
             <Grid item>
-              <SwitchField label="Public" name="shareable" />
+              <SelectField
+                label="Shareability"
+                name="shareability"
+                options={PostShareabilityList}
+                variant="outlined"
+                getOptionLabel={displayPostShareability}
+              />
             </Grid>
           </Grid>
           <TextField

--- a/src/components/posts/PostListItemCard/PostListItemCard.graphql
+++ b/src/components/posts/PostListItemCard/PostListItemCard.graphql
@@ -3,7 +3,7 @@ fragment PostListItemCard on Post {
   createdAt
   modifiedAt
   type
-  shareable
+  shareability
   body {
     canRead
     canEdit

--- a/src/components/posts/PostListItemCard/PostListItemCard.tsx
+++ b/src/components/posts/PostListItemCard/PostListItemCard.tsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles(({ spacing, typography }) => {
     shareability: {
       marginLeft: spacing(2),
     },
-    shareableLabel: {
+    shareabilityLabel: {
       fontWeight: typography.fontWeightBold,
       paddingRight: spacing(1),
     },
@@ -82,14 +82,14 @@ export const PostListItemCard: FC<PostListItemCardProps> = (props) => {
           <div className={classes.typeShareabilityRow}>
             <Typography variant="h4">{props.type}</Typography>
             <div className={classes.shareability}>
-              {props.shareable ? (
+              {props.shareability === 'Public' ? (
                 <Typography variant="body2">
-                  <span className={classes.shareableLabel}>PUBLIC</span>Can Be
-                  Shared Externally
+                  <span className={classes.shareabilityLabel}>PUBLIC</span>Can
+                  Be Shared Externally
                 </Typography>
               ) : (
                 <Typography variant="body2">
-                  <span className={classes.shareableLabel}>PRIVATE</span>For
+                  <span className={classes.shareabilityLabel}>PRIVATE</span>For
                   Internal Use Only
                 </Typography>
               )}


### PR DESCRIPTION
For now only `Post.sharebility = true` will show the "public" label on a post. Everything else will show the "private" label.

## Important Notes
* Must be merged immediately after backend PR https://github.com/SeedCompany/cord-api-v3/pull/1857 is merged.
* CI tests may fail until backend PR is merged due to data model changes
