### PR TITLE
GraphQL ID lookup queries redirect to cached objects

### DIFF
--- a/src/api/typePolicies/deletes/deletes.codegen.ts
+++ b/src/api/typePolicies/deletes/deletes.codegen.ts
@@ -33,6 +33,4 @@ export const generateDeletes = (
       initializer: `handleDelete('${objName}')`,
     });
   }
-
-  file.fixMissingImports();
 };

--- a/src/api/typePolicies/id-lookup/field-policy.ts
+++ b/src/api/typePolicies/id-lookup/field-policy.ts
@@ -1,0 +1,33 @@
+import type { FieldPolicy } from '@apollo/client/cache/inmemory/policies';
+import type { GqlTypeMap } from '../../typeMap.generated';
+import { getIdArg, getPossibleTypes } from '../util';
+
+/**
+ * This type policy tells Apollo that this query operation returns the type
+ * (given) with the ID referenced.
+ * This allows a network operation to be saved if we've already cached the object.
+ * Note that Apollo also checks that all fields being asked for exist as well,
+ * so this only helps if the complete object needed was fetched another way.
+ */
+export const redirectToTypeById = (
+  typename: keyof GqlTypeMap
+): FieldPolicy => ({
+  read: (_, { args, toReference, readField }) => {
+    const id = getIdArg(args);
+
+    for (const possibleType of getPossibleTypes(typename)) {
+      const ref = toReference({
+        __typename: possibleType,
+        id,
+      });
+      // This is only to save a lookup so if the id field cannot be read,
+      // then the object is not cached and the redirect wouldn't save a network
+      // request.
+      if (ref && readField('id', ref)) {
+        return ref;
+      }
+    }
+
+    return undefined;
+  },
+});

--- a/src/api/typePolicies/id-lookup/id-lookup.codegen.ts
+++ b/src/api/typePolicies/id-lookup/id-lookup.codegen.ts
@@ -59,6 +59,4 @@ export const generateIdLookupRedirects = (
       initializer: `redirectToTypeById('${type.name}')`,
     });
   }
-
-  file.fixMissingImports();
 };

--- a/src/api/typePolicies/id-lookup/id-lookup.codegen.ts
+++ b/src/api/typePolicies/id-lookup/id-lookup.codegen.ts
@@ -1,0 +1,64 @@
+import {
+  GraphQLArgument,
+  GraphQLField,
+  GraphQLSchema,
+  isAbstractType,
+  isNonNullType,
+  isObjectType,
+  isScalarType,
+} from 'graphql';
+import {
+  GraphQLCompositeType,
+  GraphQLObjectType,
+  GraphQLOutputType,
+} from 'graphql/type/definition';
+import { ObjectLiteralExpression, SourceFile } from 'ts-morph';
+import { getOrCreateSubObjects } from '../../codeGenUtil/ts.util';
+
+const isId = (arg: GraphQLArgument | GraphQLField<unknown, unknown>) =>
+  arg.name === 'id' &&
+  isNonNullType(arg.type) &&
+  isScalarType(arg.type.ofType) &&
+  arg.type.ofType.name === 'ID';
+
+const isObjectWithId = (type: GraphQLOutputType): type is GraphQLObjectType =>
+  isObjectType(type) && Object.values(type.getFields()).some(isId);
+
+const isOutputTypeAnEntity = (
+  type: GraphQLOutputType,
+  schema: GraphQLSchema
+): type is GraphQLCompositeType =>
+  isObjectWithId(type) ||
+  (isAbstractType(type) && schema.getPossibleTypes(type).every(isObjectWithId));
+
+export const generateIdLookupRedirects = (
+  schema: GraphQLSchema,
+  file: SourceFile,
+  typePolicies: ObjectLiteralExpression
+) => {
+  const queries = schema.getQueryType();
+  if (!queries) {
+    return;
+  }
+  const queryPolicies = getOrCreateSubObjects(typePolicies, 'Query', 'fields');
+
+  for (const query of Object.values(queries.getFields())) {
+    const acceptsId = query.args.some(isId);
+    const type = isNonNullType(query.type) ? query.type.ofType : undefined;
+    if (
+      !acceptsId ||
+      !type ||
+      !isOutputTypeAnEntity(type, schema) ||
+      queryPolicies.getProperty(query.name)
+    ) {
+      continue;
+    }
+
+    queryPolicies.addPropertyAssignment({
+      name: query.name,
+      initializer: `redirectToTypeById('${type.name}')`,
+    });
+  }
+
+  file.fixMissingImports();
+};

--- a/src/api/typePolicies/lists/lists.codegen.ts
+++ b/src/api/typePolicies/lists/lists.codegen.ts
@@ -41,6 +41,4 @@ export const generateLists = (
       });
     }
   }
-
-  file.fixMissingImports();
 };

--- a/src/api/typePolicies/scalars/scalars.codegen.ts
+++ b/src/api/typePolicies/scalars/scalars.codegen.ts
@@ -10,11 +10,6 @@ export const generateScalars = (
   file: SourceFile,
   typePolicies: ObjectLiteralExpression
 ) => {
-  file.addImportDeclaration({
-    namedImports: ['optional', 'Parsers'],
-    moduleSpecifier: './scalars/scalars.parser',
-  });
-
   for (const val of getSchemaTypes(schema).filter(isObjectType)) {
     for (const field of Object.values(val.getFields())) {
       const { type, required } = resolveType(field);

--- a/src/api/typePolicies/typePolicies.codegen.ts
+++ b/src/api/typePolicies/typePolicies.codegen.ts
@@ -14,4 +14,6 @@ export const plugin = tsMorphPlugin(({ schema, file }) => {
   generateLists(schema, file, typePolicies);
   generateDeletes(schema, file, typePolicies);
   generateIdLookupRedirects(schema, file, typePolicies);
+
+  file.fixMissingImports();
 });

--- a/src/api/typePolicies/typePolicies.codegen.ts
+++ b/src/api/typePolicies/typePolicies.codegen.ts
@@ -1,6 +1,7 @@
 import { SyntaxKind } from 'ts-morph';
 import { tsMorphPlugin } from '../codeGenUtil/ts.util';
 import { generateDeletes } from './deletes/deletes.codegen';
+import { generateIdLookupRedirects } from './id-lookup/id-lookup.codegen';
 import { generateLists } from './lists/lists.codegen';
 import { generateScalars } from './scalars/scalars.codegen';
 
@@ -12,4 +13,5 @@ export const plugin = tsMorphPlugin(({ schema, file }) => {
   generateScalars(schema, file, typePolicies);
   generateLists(schema, file, typePolicies);
   generateDeletes(schema, file, typePolicies);
+  generateIdLookupRedirects(schema, file, typePolicies);
 });

--- a/src/api/typePolicies/util.ts
+++ b/src/api/typePolicies/util.ts
@@ -1,0 +1,20 @@
+import { possibleTypes as possibleTypeMap } from '../fragmentMatcher';
+import type { GqlTypeMap } from '../typeMap.generated';
+
+export const getIdArg = (args: Record<string, any> | null) => {
+  const id = args?.id;
+  if (!id) {
+    // This will only happen if a policy is manually connected incorrectly somewhere.
+    // This isn't referencing the operation variables either so there's no fear on
+    // different ways the operations could be defined across the app.
+    throw new Error(
+      `This policy must be used on a field with an \`id\` argument.`
+    );
+  }
+  return id;
+};
+
+export const getPossibleTypes = (typename: keyof GqlTypeMap) => [
+  typename,
+  ...((possibleTypeMap as Record<string, readonly string[]>)[typename] ?? []),
+];


### PR DESCRIPTION
Tell Apollo that these query operations return the type given with the ID referenced.
This allows a network operation to be saved if we've already cached the object.

For example,
```gql
query {
  user(id: "asdf") # --> use existing cached object: "User:asdf"
}
```

Note that Apollo also checks that all fields being asked for exist as well,
so this only helps if the complete object needed was fetched another way.