### PR TITLE
Avoid breaking change with user optional email

### DIFF
--- a/src/api/fragments/user.graphql
+++ b/src/api/fragments/user.graphql
@@ -2,7 +2,11 @@ fragment DisplayUser on User {
   id
   createdAt
   email {
-    ...securedString
+    # No fragement here to avoid breaking change.
+    # Type name is changing with https://github.com/SeedCompany/cord-api-v3/pull/2006
+    canEdit
+    canRead
+    value
   }
   realFirstName {
     ...securedString


### PR DESCRIPTION
Type name is changing with https://github.com/SeedCompany/cord-api-v3/pull/2006

Since the property names are not changing we can avoid the break by not having to specify the type name