### PR TITLE
Fix language filters

### DIFF
--- a/src/components/form/SwitchField.tsx
+++ b/src/components/form/SwitchField.tsx
@@ -16,20 +16,24 @@ export type SwitchFieldProps = FieldConfig<boolean> & {
   helperText?: ReactNode;
 } & Omit<SwitchProps, 'defaultValue' | 'value' | 'inputRef'> &
   Pick<FormControlLabelProps, 'label' | 'labelPlacement'> &
-  Pick<FormControlProps, 'fullWidth' | 'margin' | 'variant'>;
+  Pick<FormControlProps, 'fullWidth' | 'margin' | 'variant'> & {
+    /** Treat the "off" UI state as null instead of false */
+    offIsNull?: boolean;
+  };
 
 export const SwitchField: FC<SwitchFieldProps> = ({
   label,
   labelPlacement,
   helperText,
-  defaultValue = false,
+  offIsNull,
   fullWidth,
   margin,
   variant,
   ...props
 }) => {
   const { input, meta, ref, rest } = useField({
-    defaultValue,
+    defaultValue: offIsNull ? null : false,
+    allowNull: offIsNull,
     ...props,
     type: 'checkbox',
   });
@@ -51,9 +55,13 @@ export const SwitchField: FC<SwitchFieldProps> = ({
           <Switch
             {...rest}
             inputRef={ref}
-            checked={input.checked}
+            checked={input.checked ?? (offIsNull ? false : undefined)}
             value={input.name}
-            onChange={(e) => input.onChange(e.target.checked)}
+            onChange={(e) => {
+              const checked = e.target.checked;
+              const newVal = checked || (offIsNull ? null : false);
+              input.onChange(newVal);
+            }}
             required={props.required}
           />
         }

--- a/src/scenes/Languages/List/LanguageFilterOptions.tsx
+++ b/src/scenes/Languages/List/LanguageFilterOptions.tsx
@@ -5,15 +5,14 @@ import {
   BooleanParam,
   EnumListParam,
   makeQueryHandler,
-  withDefault,
   withKey,
 } from '../../../hooks';
 
 export const useLanguageFilters = makeQueryHandler({
   sensitivity: EnumListParam(SensitivityList),
-  leastOfThese: withKey(withDefault(BooleanParam(), false), 'lot'),
-  isSignLanguage: withKey(withDefault(BooleanParam(), false), 'sign-language'),
-  isDialect: withKey(withDefault(BooleanParam(), false), 'dialect'),
+  leastOfThese: withKey(BooleanParam(), 'lot'),
+  isSignLanguage: withKey(BooleanParam(), 'sign-language'),
+  isDialect: withKey(BooleanParam(), 'dialect'),
 });
 
 export const LanguageFilterOptions = () => {
@@ -30,9 +29,14 @@ export const LanguageFilterOptions = () => {
       <SwitchField
         name="leastOfThese"
         label="Only Show Least Of These Partnerships"
+        offIsNull
       />
-      <SwitchField name="isSignLanguage" label="Only Show Sign Languages" />
-      <SwitchField name="isDialect" label="Only Show Dialects" />
+      <SwitchField
+        name="isSignLanguage"
+        label="Only Show Sign Languages"
+        offIsNull
+      />
+      <SwitchField name="isDialect" label="Only Show Dialects" offIsNull />
     </>
   );
 };


### PR DESCRIPTION
`false` in language filters changed in https://github.com/SeedCompany/cord-api-v3/commit/5cc3cac7 to mean "exclude items with this property" instead of "omit this filter".
I updated the form to omit these filters instead of sending `false`.