### PR TITLE
Fix partner sort to actually default to name asc like the UI says

### DIFF
--- a/src/components/Sort/useSort.ts
+++ b/src/components/Sort/useSort.ts
@@ -1,13 +1,20 @@
+import { isEmpty } from 'lodash';
 import { Order } from '../../api';
 import { makeQueryHandler, StringParam, withTransform } from '../../hooks';
 import { Nullable } from '../../util';
 import { SortValue } from './SortControl';
 
-export const useSort = <T>() => {
+export const useSort = <T>(
+  defaultSort?: keyof T,
+  defaultOrder: Order = 'ASC'
+) => {
   const [value, onChange] = useSortHandler();
   // Adapt output to have generic for sort value
   return {
-    value: value.sort,
+    value:
+      defaultSort && isEmpty(value.sort)
+        ? { sort: defaultSort, order: defaultOrder }
+        : value.sort,
     onChange: (next: Partial<SortValue<T>>) => {
       onChange({
         sort: next as SortValue<Record<string, any>>,

--- a/src/scenes/Partners/List/PartnerList.tsx
+++ b/src/scenes/Partners/List/PartnerList.tsx
@@ -2,14 +2,13 @@ import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import React, { FC } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Partner } from '../../../api';
 import { useNumberFormatter } from '../../../components/Formatters';
 import { ContentContainer } from '../../../components/Layout';
 import { List, useListQuery } from '../../../components/List';
 import { PartnerListItemCard as PartnerCard } from '../../../components/PartnerListItemCard';
 import { SortButtonDialog, useSort } from '../../../components/Sort';
 import { PartnersDocument } from './PartnerList.generated';
-import { PartnerSortOptions } from './PartnerSortOptions';
+import { PartnerSort, PartnerSortOptions } from './PartnerSortOptions';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({
   options: {
@@ -21,7 +20,7 @@ const useStyles = makeStyles(({ spacing, breakpoints }) => ({
 }));
 
 export const PartnerList: FC = () => {
-  const sort = useSort<Partner>();
+  const sort = useSort<PartnerSort>('name');
   const list = useListQuery(PartnersDocument, {
     listAt: (data) => data.partners,
     variables: {

--- a/src/scenes/Partners/List/PartnerSortOptions.tsx
+++ b/src/scenes/Partners/List/PartnerSortOptions.tsx
@@ -3,12 +3,10 @@ import * as React from 'react';
 import { Partner } from '../../../api';
 import { SortOption, SortOptionProps } from '../../../components/Sort';
 
+export type PartnerSort = Partner & { name: string }; // TODO how to sort across child relations
+
 // Alias component to define generic once
-const Option = SortOption as ComponentType<
-  SortOptionProps<
-    Partner & { name: string } // TODO how to sort across child relations
-  >
->;
+const Option = SortOption as ComponentType<SortOptionProps<PartnerSort>>;
 
 export const PartnerSortOptions = () => (
   <>


### PR DESCRIPTION
This happened because UI default is name asc, but the API is createdAt.