### PR TITLE
Show 'click to edit' only if user has edit permissions

### DIFF
--- a/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
@@ -103,7 +103,11 @@ export const ProjectBudgetRecords: FC<ProjectBudgetRecordsProps> = (props) => {
         type: 'currency',
         editable: (_, rowData) => rowData.record.amount.canEdit,
         render: (rowData) =>
-          rowData.amount ? formatCurrency(Number(rowData.amount)) : blankAmount,
+          rowData.amount
+            ? formatCurrency(Number(rowData.amount))
+            : rowData.record.amount.canEdit
+            ? blankAmount
+            : undefined,
       },
     ],
     [formatCurrency]


### PR DESCRIPTION
UI part of [#2153](https://github.com/SeedCompany/cord-api-v3/issues/2153)