### PR TITLE
Generate enum labels & allow API schema to define override

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "response-time": "^2.3.2",
     "rifm": "^0.12.1",
     "serialize-query-params": "^1.3.6",
+    "title-case": "^3.0.3",
     "ts-essentials": "^9.1.2",
     "validator": "^13.7.0",
     "xlsx": "^0.18.4"

--- a/src/api/schema/enumLists/enumLists.codegen.ts
+++ b/src/api/schema/enumLists/enumLists.codegen.ts
@@ -1,5 +1,6 @@
 import { GraphQLEnumType } from 'graphql';
-import { startCase } from 'lodash';
+import { lowerCase } from 'lodash';
+import { titleCase } from 'title-case';
 import {
   addExportedConst,
   tsMorphPlugin,
@@ -39,7 +40,7 @@ export const plugin = tsMorphPlugin(({ schema, file }) => {
                 ? /^\s*@label (.+)$/m.exec(val.description)?.[1]
                 : undefined
               )?.replace(/`/g, '\\`') ??
-              startCase(val.name).replace(/ And /g, ' & ');
+              titleCase(lowerCase(val.name)).replace(/ and /g, ' & ');
             writer.writeLine(`${val.name}: \`${label}\`,`);
           }
         }),

--- a/src/api/schema/enumLists/enumLists.codegen.ts
+++ b/src/api/schema/enumLists/enumLists.codegen.ts
@@ -38,7 +38,8 @@ export const plugin = tsMorphPlugin(({ schema, file }) => {
               (val.description
                 ? /^\s*@label (.+)$/m.exec(val.description)?.[1]
                 : undefined
-              )?.replace(/`/g, '\\`') ?? startCase(val.name);
+              )?.replace(/`/g, '\\`') ??
+              startCase(val.name).replace(/ And /g, ' & ');
             writer.writeLine(`${val.name}: \`${label}\`,`);
           }
         }),

--- a/src/common/displayEnums.ts
+++ b/src/common/displayEnums.ts
@@ -1,15 +1,8 @@
 import { startCase } from 'lodash';
 import {
-  LocationType,
-  PostShareability,
-  PostShareabilityLabels,
   ProductApproachLabels,
-  ProductMedium,
-  ProductMediumLabels,
   ProductMethodology,
   ProductMethodologyLabels,
-  ProgressMeasurement,
-  ScriptureRangeInput,
 } from '~/api/schema';
 import { ProductTypes } from '../scenes/Products/ProductForm/constants';
 import { Nullable } from '../util';
@@ -25,9 +18,6 @@ export const labelsFrom =
   (values: Nullable<readonly T[]>) =>
     (values ?? []).map((val) => labels[val]).join(', ');
 
-export const displayLocationType = (type: Nullable<LocationType>): string =>
-  !type ? '' : type === 'CrossBorderArea' ? 'Cross-Border Area' : type;
-
 export const displayMethodology = (methodology: ProductMethodology) =>
   methodology.includes('Other')
     ? 'Other'
@@ -38,19 +28,5 @@ export const displayMethodologyWithLabel = (methodology: ProductMethodology) =>
     ProductApproachLabels[MethodologyToApproach[methodology]]
   } - ${displayMethodology(methodology)}`;
 
-export const displayScripture = ({ start, end }: ScriptureRangeInput) =>
-  `${start.book} ${start.chapter}:${start.verse} -  ${end.chapter}:${end.verse}`;
-
-export const displayProductMedium = (medium: ProductMedium) =>
-  medium === 'EBook' ? 'E-Book' : ProductMediumLabels[medium];
-
 export const displayProductTypes = (type: ProductTypes) =>
   type === 'DirectScriptureProduct' ? 'Scripture' : startCase(type);
-
-export const displayPostShareability = (val: PostShareability) =>
-  val === 'ProjectTeam' || val === 'Membership'
-    ? 'Team Members'
-    : PostShareabilityLabels[val];
-
-export const displayProgressMeasurement = (value: ProgressMeasurement) =>
-  value === 'Boolean' ? 'Done / Not Done' : value;

--- a/src/common/displayEnums.ts
+++ b/src/common/displayEnums.ts
@@ -1,66 +1,29 @@
 import { startCase } from 'lodash';
 import {
-  EngagementStatus,
-  FinancialReportingType,
-  InternshipDomain,
-  InternshipPosition,
-  InternshipProgram,
   LocationType,
-  PartnershipAgreementStatus,
-  PartnerType,
   PostShareability,
-  ProductApproach,
+  PostShareabilityLabels,
+  ProductApproachLabels,
   ProductMedium,
+  ProductMediumLabels,
   ProductMethodology,
-  ProductStep,
+  ProductMethodologyLabels,
   ProgressMeasurement,
-  ProjectChangeRequestStatus,
-  ProjectChangeRequestType,
-  ProjectStatus,
-  ProjectStep,
-  Role,
   ScriptureRangeInput,
 } from '~/api/schema';
 import { ProductTypes } from '../scenes/Products/ProductForm/constants';
 import { Nullable } from '../util';
 import { MethodologyToApproach } from './approach';
 
-// Helper to display enums in a generic way
-const displayEnum =
-  <T extends string>() =>
-  (enumVal: Nullable<T>) =>
-    startCase(enumVal ?? undefined);
-const displayEnums =
-  <T extends string>(fn: (val: Nullable<T>) => string) =>
-  (items: readonly T[]) =>
-    items.map(fn).join(', ');
+export const labelFrom =
+  <T extends keyof any>(labels: Record<T, string>) =>
+  (value: Nullable<T>) =>
+    value ? labels[value] : '';
 
-export const displayStatus = displayEnum<ProjectStatus>();
-export const displayProjectStep = displayEnum<ProjectStep>();
-export const displayPartnershipStatus =
-  displayEnum<PartnershipAgreementStatus>();
-export const displayPartnerType = displayEnum<PartnerType>();
-export const displayFinancialReportingType =
-  displayEnum<FinancialReportingType>();
-export const displayEngagementStatus = displayEnum<EngagementStatus>();
-export const displayRole = displayEnum<Role>();
-export const displayRoles = displayEnums(displayRole);
-
-export const displayInternPosition = displayEnum<InternshipPosition>();
-export const displayInternProgram = displayEnum<InternshipProgram>();
-export const displayInternDomain = displayEnum<InternshipDomain>();
-export const displayPlanChangeStatus =
-  displayEnum<ProjectChangeRequestStatus>();
-export const displayProjectChangeRequestType =
-  displayEnum<ProjectChangeRequestType>();
-export const displayProjectChangeRequestTypes = displayEnums(
-  displayProjectChangeRequestType
-);
-export const PartnershipStatuses: PartnershipAgreementStatus[] = [
-  'NotAttached',
-  'AwaitingSignature',
-  'Signed',
-];
+export const labelsFrom =
+  <T extends keyof any>(labels: Record<T, string>) =>
+  (values: Nullable<readonly T[]>) =>
+    (values ?? []).map((val) => labels[val]).join(', ');
 
 export const displayLocationType = (type: Nullable<LocationType>): string =>
   !type ? '' : type === 'CrossBorderArea' ? 'Cross-Border Area' : type;
@@ -68,33 +31,26 @@ export const displayLocationType = (type: Nullable<LocationType>): string =>
 export const displayMethodology = (methodology: ProductMethodology) =>
   methodology.includes('Other')
     ? 'Other'
-    : displayEnum<ProductMethodology>()(methodology);
-
-export const displayApproach = displayEnum<ProductApproach>();
+    : ProductMethodologyLabels[methodology];
 
 export const displayMethodologyWithLabel = (methodology: ProductMethodology) =>
-  `${displayApproach(
-    MethodologyToApproach[methodology]
-  )} - ${displayMethodology(methodology)}`;
+  `${
+    ProductApproachLabels[MethodologyToApproach[methodology]]
+  } - ${displayMethodology(methodology)}`;
 
 export const displayScripture = ({ start, end }: ScriptureRangeInput) =>
   `${start.book} ${start.chapter}:${start.verse} -  ${end.chapter}:${end.verse}`;
 
 export const displayProductMedium = (medium: ProductMedium) =>
-  medium === 'EBook' ? 'E-Book' : displayEnum<ProductMedium>()(medium);
+  medium === 'EBook' ? 'E-Book' : ProductMediumLabels[medium];
 
 export const displayProductTypes = (type: ProductTypes) =>
-  type === 'DirectScriptureProduct'
-    ? 'Scripture'
-    : displayEnum<ProductTypes>()(type);
+  type === 'DirectScriptureProduct' ? 'Scripture' : startCase(type);
 
 export const displayPostShareability = (val: PostShareability) =>
   val === 'ProjectTeam' || val === 'Membership'
     ? 'Team Members'
-    : displayEnum()(val);
-
-export const displayProductStep = (step: Nullable<ProductStep>) =>
-  displayEnum<ProductStep>()(step).replace(' And ', ' & ');
+    : PostShareabilityLabels[val];
 
 export const displayProgressMeasurement = (value: ProgressMeasurement) =>
   value === 'Boolean' ? 'Done / Not Done' : value;

--- a/src/components/InternshipEngagementListItemCard/InternshipEngagementListItemCard.tsx
+++ b/src/components/InternshipEngagementListItemCard/InternshipEngagementListItemCard.tsx
@@ -7,9 +7,9 @@ import {
   Typography,
 } from '@material-ui/core';
 import clsx from 'clsx';
-import { startCase } from 'lodash';
 import * as React from 'react';
-import { displayEngagementStatus } from '../../api';
+import { EngagementStatusLabels, InternshipPositionLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { idForUrl } from '../Changeset';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { FormattedDate } from '../Formatters';
@@ -86,7 +86,9 @@ export const InternshipEngagementListItemCard = (
           {(country || position) && (
             <Grid item>
               {position && (
-                <Typography variant="body2">{startCase(position)}</Typography>
+                <Typography variant="body2">
+                  {InternshipPositionLabels[position]}
+                </Typography>
               )}
               {country && (
                 <Typography variant="body2" color="primary">
@@ -98,7 +100,7 @@ export const InternshipEngagementListItemCard = (
           <Grid item>
             <DisplaySimpleProperty
               label="Status"
-              value={displayEngagementStatus(props.status.value)}
+              value={labelFrom(EngagementStatusLabels)(props.status.value)}
             />
           </Grid>
           {endDate ? (
@@ -126,7 +128,7 @@ const getEndDate = (eng: InternshipEngagementListItemFragment) => {
   const terminal = status !== 'InDevelopment' && status !== 'Active';
   if (terminal && eng.completeDate.value) {
     return {
-      label: displayEngagementStatus(status) + ' Date',
+      label: `${labelFrom(EngagementStatusLabels)(status)} Date`,
       value: eng.completeDate.value,
     };
   }

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
@@ -8,7 +8,8 @@ import {
 } from '@material-ui/core';
 import clsx from 'clsx';
 import * as React from 'react';
-import { displayEngagementStatus } from '../../api';
+import { EngagementStatusLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { idForUrl } from '../Changeset';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { useNumberFormatter } from '../Formatters';
@@ -126,7 +127,7 @@ export const LanguageEngagementListItemCard = (
             />
             <DisplaySimpleProperty
               label="Status"
-              value={displayEngagementStatus(status.value)}
+              value={labelFrom(EngagementStatusLabels)(status.value)}
               wrap={(node) => <Grid item>{node}</Grid>}
             />
           </Grid>

--- a/src/components/LocationCard/LocationCard.tsx
+++ b/src/components/LocationCard/LocationCard.tsx
@@ -9,7 +9,8 @@ import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { FC } from 'react';
 import * as React from 'react';
-import { displayLocationType } from '../../api';
+import { LocationTypeLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { FormattedDateTime } from '../Formatters';
 import { ProgressButton } from '../ProgressButton';
 import { Redacted } from '../Redacted';
@@ -69,7 +70,7 @@ export const LocationCard: FC<LocationCardProps> = ({
             {loading ? (
               <Skeleton width="25%" />
             ) : locationType?.canRead === true ? (
-              displayLocationType(locationType.value)
+              labelFrom(LocationTypeLabels)(locationType.value)
             ) : (
               <Redacted
                 info="You don't have permission to view this location's type"

--- a/src/components/PartnershipCard/PartnershipCard.stories.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions';
 import { select, text } from '@storybook/addon-knobs';
 import React from 'react';
-import { FinancialReportingTypeList, PartnershipStatuses } from '../../api';
+import { FinancialReportingTypeList, PartnershipAgreementStatusList } from '~/api/schema';
 import { csv } from '../../util';
 import { date, dateTime } from '../knobs.stories';
 import { PartnershipCard } from './PartnershipCard';
@@ -44,10 +44,10 @@ export const WithData = () => {
       value: csv(text('Types', 'Managing, Funding')),
     },
     mouStatus: {
-      value: select('Mou Status', PartnershipStatuses, 'NotAttached'),
+      value: select('Mou Status', PartnershipAgreementStatusList, 'NotAttached'),
     },
     agreementStatus: {
-      value: select('Mou Status', PartnershipStatuses, 'NotAttached'),
+      value: select('Mou Status', PartnershipAgreementStatusList, 'NotAttached'),
     },
     financialReportingType: {
       value: select(

--- a/src/components/PartnershipCard/PartnershipCard.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.tsx
@@ -11,9 +11,10 @@ import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import React, { FC } from 'react';
 import {
-  displayFinancialReportingType,
-  displayPartnershipStatus,
-} from '../../api';
+  FinancialReportingTypeLabels,
+  PartnershipAgreementStatusLabels,
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { FormattedDateRange, FormattedDateTime } from '../Formatters';
 import { Redacted } from '../Redacted';
@@ -87,7 +88,7 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
           <Grid item>
             <DisplaySimpleProperty
               label="Financial Reporting Type"
-              value={displayFinancialReportingType(
+              value={labelFrom(FinancialReportingTypeLabels)(
                 partnership?.financialReportingType.value
               )}
               loading={!partnership}
@@ -98,7 +99,7 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
           <Grid item>
             <DisplaySimpleProperty
               label="Agreement Status"
-              value={displayPartnershipStatus(
+              value={labelFrom(PartnershipAgreementStatusLabels)(
                 partnership?.agreementStatus.value
               )}
               loading={!partnership}
@@ -108,7 +109,9 @@ export const PartnershipCard: FC<PartnershipCardProps> = ({
           <Grid item>
             <DisplaySimpleProperty
               label="MOU Status"
-              value={displayPartnershipStatus(partnership?.mouStatus.value)}
+              value={labelFrom(PartnershipAgreementStatusLabels)(
+                partnership?.mouStatus.value
+              )}
               loading={!partnership}
               loadingWidth="40%"
             />

--- a/src/components/ProjectChangeRequestListItem/ProjectChangeRequestListItem.tsx
+++ b/src/components/ProjectChangeRequestListItem/ProjectChangeRequestListItem.tsx
@@ -9,7 +9,8 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import * as React from 'react';
-import { displayProjectChangeRequestTypes } from '../../api';
+import { ProjectChangeRequestTypeLabels } from '~/api/schema';
+import { labelsFrom } from '~/common';
 import { useProjectId } from '../../scenes/Projects/useProjectId';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { FormattedDateTime } from '../Formatters';
@@ -70,7 +71,7 @@ export const ProjectChangeRequestListItem = ({
             {!data ? (
               <Skeleton width="100%" />
             ) : (
-              displayProjectChangeRequestTypes(data.types.value)
+              labelsFrom(ProjectChangeRequestTypeLabels)(data.types.value)
             )}
           </Typography>
         </Typography>

--- a/src/components/ProjectListItemCard/ProjectListItemCard.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { FC } from 'react';
 import * as React from 'react';
-import { displayStatus } from '../../api';
+import { ProjectStatusLabels } from '~/api/schema';
 import { ProjectListQueryVariables } from '../../scenes/Projects/List/projects.graphql';
 import { getProjectUrl } from '../../scenes/Projects/useProjectId';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
@@ -152,7 +152,7 @@ export const ProjectListItemCard: FC<ProjectListItemCardProps> = ({
               ) : (
                 <DisplaySimpleProperty
                   label="Status"
-                  value={displayStatus(project.projectStatus)}
+                  value={ProjectStatusLabels[project.projectStatus]}
                 />
               )}
             </Grid>

--- a/src/components/ProjectMemberCard/ProjectMemberCard.tsx
+++ b/src/components/ProjectMemberCard/ProjectMemberCard.tsx
@@ -9,7 +9,8 @@ import {
 import { Skeleton } from '@material-ui/lab';
 import { FC } from 'react';
 import * as React from 'react';
-import { displayRoles } from '../../api';
+import { RoleLabels } from '~/api/schema';
+import { labelsFrom } from '~/common';
 import { Avatar } from '../Avatar';
 import { useDateTimeFormatter } from '../Formatters';
 import { ProjectMemberCardFragment } from './ProjectMember.graphql';
@@ -50,7 +51,6 @@ export const ProjectMemberCard: FC<ProjectMemberCardProps> = ({
   const classes = useStyles();
   const dateTimeFormatter = useDateTimeFormatter();
 
-  const rolesString = displayRoles(projectMember?.roles.value ?? []);
   const createdAtString = dateTimeFormatter(projectMember?.createdAt);
 
   return (
@@ -83,7 +83,7 @@ export const ProjectMemberCard: FC<ProjectMemberCardProps> = ({
             {!projectMember ? (
               <Skeleton variant="text" width="25%" />
             ) : (
-              rolesString
+              labelsFrom(RoleLabels)(projectMember.roles.value)
             )}
           </Typography>
         </div>

--- a/src/components/posts/PostForm/PostForm.tsx
+++ b/src/components/posts/PostForm/PostForm.tsx
@@ -2,11 +2,12 @@ import { Grid } from '@material-ui/core';
 import { without } from 'lodash';
 import React from 'react';
 import {
-  displayPostShareability,
   PostShareability,
+  PostShareabilityLabels,
   PostShareabilityList,
   PostTypeList,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -61,7 +62,7 @@ export const PostForm = <T, R = void>({
           name="shareability"
           options={shareabilityList(includeMembership)}
           variant="outlined"
-          getOptionLabel={displayPostShareability}
+          getOptionLabel={labelFrom(PostShareabilityLabels)}
           defaultValue={'Internal'}
         />
       </Grid>

--- a/src/components/posts/PostListItemCard/PostListItemCard.tsx
+++ b/src/components/posts/PostListItemCard/PostListItemCard.tsx
@@ -11,7 +11,8 @@ import { MoreVert } from '@material-ui/icons';
 import clsx from 'clsx';
 import { useState } from 'react';
 import * as React from 'react';
-import { canEditAny, displayPostShareability } from '../../../api';
+import { PostShareabilityLabels } from '~/api/schema';
+import { canEditAny } from '~/common';
 import { square } from '../../../util';
 import { useDialog } from '../../Dialog';
 import { FormattedDateTime } from '../../Formatters';
@@ -123,7 +124,7 @@ export const PostListItemCard = ({
                       ? 'PUBLIC'
                       : 'PRIVATE'}
                   </span>
-                  {displayPostShareability(post.shareability)}
+                  {PostShareabilityLabels[post.shareability]}
                 </Typography>
               </div>
             </div>

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -3,16 +3,19 @@ import { setIn } from 'final-form';
 import { compact, keyBy, pick, startCase } from 'lodash';
 import React, { ComponentType, FC, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
+import { invalidateProps } from '~/api';
 import {
-  displayInternDomain,
-  displayInternPosition,
-  displayInternProgram,
-  invalidateProps,
-  MethodologyToApproach,
+  InternshipDomainLabels,
+  InternshipPositionLabels,
+  InternshipProgramLabels,
   UpdateInternshipEngagement,
   UpdateLanguageEngagement,
-} from '~/api';
-import { DisplayLocationFragment } from '~/common';
+} from '~/api/schema';
+import {
+  DisplayLocationFragment,
+  labelFrom,
+  MethodologyToApproach,
+} from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -119,11 +122,11 @@ const fieldMapping: Record<
         groupBy={(p) => {
           const option = groups[p];
           return compact([
-            displayInternProgram(option?.program),
-            displayInternDomain(option?.domain),
+            labelFrom(InternshipProgramLabels)(option?.program),
+            labelFrom(InternshipDomainLabels)(option?.domain),
           ]).join(' - ');
         }}
-        getOptionLabel={displayInternPosition}
+        getOptionLabel={labelFrom(InternshipPositionLabels)}
       />
     );
   },

--- a/src/scenes/Engagement/EditEngagement/EngagementWorkflowDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EngagementWorkflowDialog.tsx
@@ -3,11 +3,12 @@ import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import React from 'react';
 import { Except } from 'type-fest';
 import {
-  displayEngagementStatus,
   EngagementStatus,
+  EngagementStatusLabels,
   EngagementStatusList,
   TransitionType,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -107,9 +108,9 @@ export const EngagementWorkflowDialog = ({
       <Grid container direction="column" spacing={1}>
         {transitions.map((transition, i) => (
           <Tooltip
-            title={`This will change the engagement status to ${displayEngagementStatus(
-              transition.to
-            )}`}
+            title={`This will change the engagement status to ${
+              EngagementStatusLabels[transition.to]
+            }`}
             key={i}
           >
             <Grid item>
@@ -145,7 +146,7 @@ export const EngagementWorkflowDialog = ({
               name="engagement.status"
               label="Override Status"
               options={EngagementStatusList}
-              getOptionLabel={displayEngagementStatus}
+              getOptionLabel={labelFrom(EngagementStatusLabels)}
             />
           </>
         ) : (

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -2,7 +2,8 @@ import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
 import { DateRange } from '@material-ui/icons';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
-import { displayEngagementStatus, displayInternPosition } from '../../../api';
+import { EngagementStatusLabels, InternshipPositionLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { DataButton } from '../../../components/DataButton';
 import { DefinedFileCard } from '../../../components/DefinedFileCard';
 import { useDialog } from '../../../components/Dialog';
@@ -133,7 +134,7 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                   secured={engagement.status}
                   redacted="You do not have permission to view the engagement's status"
                   onClick={() => openWorkflow(engagement)}
-                  children={displayEngagementStatus}
+                  children={labelFrom(EngagementStatusLabels)}
                 />
               </Grid>
               <Grid item>
@@ -151,7 +152,7 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                   secured={engagement.position}
                   empty="Enter Intern Position"
                   redacted="You do not have permission to view intern position"
-                  children={displayInternPosition}
+                  children={labelFrom(InternshipPositionLabels)}
                   onClick={() => show('position')}
                 />
               </Grid>

--- a/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
@@ -8,7 +8,8 @@ import {
 import { DateRange, Edit } from '@material-ui/icons';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
-import { canEditAny, displayEngagementStatus } from '../../../../api';
+import { EngagementStatusLabels } from '~/api/schema';
+import { canEditAny, labelFrom } from '~/common';
 import { BooleanProperty } from '../../../../components/BooleanProperty';
 import { DataButton } from '../../../../components/DataButton';
 import { useDialog } from '../../../../components/Dialog';
@@ -148,7 +149,7 @@ export const LanguageEngagementHeader = ({
             secured={engagement.status}
             redacted="You do not have permission to view the engagement's status"
             onClick={() => openWorkflow(engagement)}
-            children={displayEngagementStatus}
+            children={labelFrom(EngagementStatusLabels)}
           />
         </Grid>
         <Grid item>

--- a/src/scenes/Engagement/LanguageEngagement/ProgressAndPlanning/ProgressAndPlanning.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/ProgressAndPlanning/ProgressAndPlanning.tsx
@@ -3,11 +3,10 @@ import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { pick } from 'lodash';
 import React from 'react';
 import {
-  ApproachMethodologies,
-  displayApproach,
-  displayMethodology,
   ProductMethodology as Methodology,
-} from '../../../../api';
+  ProductApproachLabels,
+} from '~/api/schema';
+import { ApproachMethodologies, displayMethodology } from '~/common';
 import { DefinedFileCard } from '../../../../components/DefinedFileCard';
 import { useDialog } from '../../../../components/Dialog';
 import { DialogForm } from '../../../../components/Dialog/DialogForm';
@@ -106,7 +105,7 @@ export const PlanningSpreadsheet = ({ engagement }: Props) => {
             }).map(([approach, methodologies]) => (
               <div key={approach} className={classes.section}>
                 <Typography className={classes.label}>
-                  {displayApproach(approach)}
+                  {ProductApproachLabels[approach]}
                 </Typography>
                 {methodologies.map((option: Methodology) => (
                   <EnumOption

--- a/src/scenes/Locations/Detail/LocationDetail.tsx
+++ b/src/scenes/Locations/Detail/LocationDetail.tsx
@@ -6,7 +6,8 @@ import clsx from 'clsx';
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
-import { canEditAny, displayLocationType } from '../../../api';
+import { LocationTypeLabels } from '~/api/schema';
+import { canEditAny, labelFrom } from '~/common';
 import { useDialog } from '../../../components/Dialog';
 import {
   DisplaySimpleProperty,
@@ -115,7 +116,7 @@ export const LocationDetail = () => {
           </div>
           <DisplayProperty
             label="Type"
-            value={displayLocationType(location?.type.value)}
+            value={labelFrom(LocationTypeLabels)(location?.type.value)}
             loading={!location}
           />
           <DisplayProperty

--- a/src/scenes/Locations/LocationForm/LocationForm.tsx
+++ b/src/scenes/Locations/LocationForm/LocationForm.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { Merge } from 'type-fest';
 import {
   CreateLocation,
-  displayLocationType,
+  LocationTypeLabels,
   LocationTypeList,
   UpdateLocation,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -74,7 +75,7 @@ export const LocationForm = <CreateOrUpdateInput, R extends any>({
             <SelectField
               label="Type"
               options={LocationTypeList}
-              getOptionLabel={displayLocationType}
+              getOptionLabel={labelFrom(LocationTypeLabels)}
               defaultValue={LocationTypeList[0]}
               required
               margin="none"

--- a/src/scenes/Partners/Detail/PartnerTypesCard.tsx
+++ b/src/scenes/Partners/Detail/PartnerTypesCard.tsx
@@ -10,11 +10,8 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import React, { FC } from 'react';
-import {
-  canEditAny,
-  displayFinancialReportingType,
-  displayPartnerType,
-} from '../../../api';
+import { FinancialReportingTypeLabels, PartnerTypeLabels } from '~/api/schema';
+import { canEditAny, labelsFrom } from '~/common';
 import { Redacted } from '../../../components/Redacted';
 import { PartnerDetailsFragment } from './PartnerDetail.graphql';
 
@@ -79,8 +76,7 @@ export const PartnerTypesCard: FC<PartnerTypesCardProps> = ({
                 {!partner ? (
                   <Skeleton width="75%" />
                 ) : partner.types.canRead ? (
-                  partner.types.value.map(displayPartnerType).join(', ') ||
-                  'None'
+                  labelsFrom(PartnerTypeLabels)(partner.types.value) || 'None'
                 ) : (
                   <Redacted
                     info="You don't have permission to view the partner's types"
@@ -99,9 +95,9 @@ export const PartnerTypesCard: FC<PartnerTypesCardProps> = ({
                 </Typography>
                 <Typography variant="h4">
                   {partner.financialReportingTypes.canRead ? (
-                    partner.financialReportingTypes.value
-                      .map(displayFinancialReportingType)
-                      .join(', ')
+                    labelsFrom(FinancialReportingTypeLabels)(
+                      partner.financialReportingTypes.value
+                    )
                   ) : (
                     <Redacted
                       info="You don't have permission to view the partner's financial reporting types"

--- a/src/scenes/Partners/Edit/EditPartner.tsx
+++ b/src/scenes/Partners/Edit/EditPartner.tsx
@@ -4,11 +4,12 @@ import onFieldChange from 'final-form-calculate';
 import React, { ComponentType, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
 import {
-  displayFinancialReportingType,
+  FinancialReportingTypeLabels,
   FinancialReportingTypeList,
   PartnerTypeList,
   UpdatePartner,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -95,7 +96,7 @@ const fieldMapping: Record<
         options={FinancialReportingTypeList}
         multiple
         {...props}
-        getLabel={displayFinancialReportingType}
+        getLabel={labelFrom(FinancialReportingTypeLabels)}
       />
     ) : null,
   address: ({ props }) => (

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -2,14 +2,15 @@ import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
 import React from 'react';
 import {
-  displayFinancialReportingType,
-  displayPartnershipStatus,
+  FinancialReportingTypeLabels,
   PartnershipAgreementStatus,
+  PartnershipAgreementStatusLabels,
   PartnershipAgreementStatusList,
   PartnerType,
   PeriodType,
   PeriodTypeList,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -119,7 +120,7 @@ export const PartnershipForm = <T extends PartnershipFormValues>({
                       options={
                         lookupPartnerFinType || currentPartnerFinTypes || []
                       }
-                      getLabel={displayFinancialReportingType}
+                      getLabel={labelFrom(FinancialReportingTypeLabels)}
                       {...props}
                     />
                   )}
@@ -185,6 +186,6 @@ const AgreementStatusField = (
   <EnumField
     {...props}
     options={PartnershipAgreementStatusList}
-    getLabel={displayPartnershipStatus}
+    getLabel={labelFrom(PartnershipAgreementStatusLabels)}
   />
 );

--- a/src/scenes/Products/Detail/ProductInfo.tsx
+++ b/src/scenes/Products/Detail/ProductInfo.tsx
@@ -8,11 +8,8 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import React, { ReactNode } from 'react';
-import {
-  displayMethodologyWithLabel,
-  displayProductMedium,
-  displayProductStep,
-} from '../../../api';
+import { ProductStepLabels } from '~/api/schema';
+import { displayMethodologyWithLabel, displayProductMedium } from '~/common';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
@@ -130,7 +127,7 @@ export const ProductInfo = ({ product }: { product?: Product }) => {
                 {product.steps.value.map((step) => (
                   <ListItem key={step} disableGutters>
                     <ListItemText
-                      primary={displayProductStep(step)}
+                      primary={ProductStepLabels[step]}
                       className={classes.listItem}
                     />
                   </ListItem>

--- a/src/scenes/Products/Detail/ProductInfo.tsx
+++ b/src/scenes/Products/Detail/ProductInfo.tsx
@@ -8,8 +8,8 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import React, { ReactNode } from 'react';
-import { ProductStepLabels } from '~/api/schema';
-import { displayMethodologyWithLabel, displayProductMedium } from '~/common';
+import { ProductMediumLabels, ProductStepLabels } from '~/api/schema';
+import { displayMethodologyWithLabel } from '~/common';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
@@ -52,7 +52,7 @@ export const ProductInfo = ({ product }: { product?: Product }) => {
               {product.mediums.value.map((medium) => (
                 <ListItem key={medium} disableGutters>
                   <ListItemText
-                    primary={displayProductMedium(medium)}
+                    primary={ProductMediumLabels[medium]}
                     secondary={
                       ppm[medium]?.partner.value?.organization.value?.name
                         .value ? (

--- a/src/scenes/Products/Detail/Progress/StepEditDialog.tsx
+++ b/src/scenes/Products/Detail/Progress/StepEditDialog.tsx
@@ -3,7 +3,7 @@ import { Alert } from '@material-ui/lab';
 import { isBoolean } from 'lodash';
 import React, { useMemo } from 'react';
 import { Except } from 'type-fest';
-import { displayProductStep, ProgressMeasurement } from '../../../../api';
+import { ProductStepLabels, ProgressMeasurement } from '~/api/schema';
 import {
   DialogForm,
   DialogFormProps,
@@ -54,7 +54,7 @@ export const StepEditDialog = ({
 
   return (
     <DialogForm<StepFormValues>
-      title={displayProductStep(step.step)}
+      title={ProductStepLabels[step.step]}
       {...props}
       initialValues={initialValues}
       onSubmit={async (data) => {

--- a/src/scenes/Products/Detail/Progress/StepProgress.tsx
+++ b/src/scenes/Products/Detail/Progress/StepProgress.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import React from 'react';
-import { displayProductStep, ProgressMeasurement } from '../../../../api';
+import { ProductStepLabels, ProgressMeasurement } from '~/api/schema';
 import { StepProgressFragment } from './ProductProgress.graphql';
 import { ProgressIcon } from './ProgressIcon';
 
@@ -48,7 +48,7 @@ export const StepProgress = ({
               className={classes.infoArea}
             >
               <Grid item component={Typography} variant="h4">
-                {displayProductStep(step)}
+                {ProductStepLabels[step]}
               </Grid>
               <Grid item component={Typography} variant="body2">
                 {!completed.canRead

--- a/src/scenes/Products/ProductForm/MediumsSection.tsx
+++ b/src/scenes/Products/ProductForm/MediumsSection.tsx
@@ -1,6 +1,7 @@
 import { ToggleButton } from '@material-ui/lab';
 import React from 'react';
-import { displayProductMedium, ProductMediumList } from '../../../api';
+import { ProductMediumLabels, ProductMediumList } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { EnumField } from '../../../components/form';
 import { SectionProps } from './ProductFormFields';
 import { SecuredAccordion } from './SecuredAccordion';
@@ -13,7 +14,7 @@ export const MediumsSection = ({ values, accordionState }: SectionProps) => (
     renderCollapsed={() =>
       values.product?.mediums?.map((medium) => (
         <ToggleButton selected key={medium} value={medium}>
-          {displayProductMedium(medium)}
+          {ProductMediumLabels[medium]}
         </ToggleButton>
       ))
     }
@@ -22,7 +23,7 @@ export const MediumsSection = ({ values, accordionState }: SectionProps) => (
       <EnumField
         multiple
         options={ProductMediumList}
-        getLabel={displayProductMedium}
+        getLabel={labelFrom(ProductMediumLabels)}
         variant="toggle-split"
         {...props}
       />

--- a/src/scenes/Products/ProductForm/MethodologySection.tsx
+++ b/src/scenes/Products/ProductForm/MethodologySection.tsx
@@ -1,12 +1,12 @@
 import { Typography } from '@material-ui/core';
 import { ToggleButton } from '@material-ui/lab';
 import React from 'react';
+import { ProductApproachLabels } from '~/api/schema';
 import {
   ApproachMethodologies,
-  displayApproach,
   displayMethodology,
   displayMethodologyWithLabel,
-} from '../../../api';
+} from '~/common';
 import { EnumField, EnumOption } from '../../../components/form';
 import { entries } from '../../../util';
 import { useStyles } from './DefaultAccordion';
@@ -36,7 +36,7 @@ export const MethodologySection = ({
           {entries(ApproachMethodologies).map(([approach, methodologies]) => (
             <div key={approach} className={classes.section}>
               <Typography className={classes.label}>
-                {displayApproach(approach)}
+                {ProductApproachLabels[approach]}
               </Typography>
               {methodologies.map((option) => (
                 <EnumOption

--- a/src/scenes/Products/ProductForm/PartnershipProducingMediumsSection.tsx
+++ b/src/scenes/Products/ProductForm/PartnershipProducingMediumsSection.tsx
@@ -1,6 +1,6 @@
 import { List, ListItem, Typography } from '@material-ui/core';
 import React from 'react';
-import { displayProductMedium, ProductMedium } from '../../../api';
+import { ProductMedium, ProductMediumLabels } from '~/api/schema';
 import { AutocompleteField } from '../../../components/form';
 import { PartnershipForLabelFragment } from '../Detail/ProductDetail.graphql';
 import { SectionProps } from './ProductFormFields';
@@ -34,7 +34,7 @@ export const PartnershipProducingMediumsSection = ({
             ?.filter((medium) => values.product?.producingMediums?.[medium])
             .map((medium) => (
               <ListItem key={medium}>
-                <Typography>{displayProductMedium(medium)}</Typography>
+                <Typography>{ProductMediumLabels[medium]}</Typography>
                 <Typography variant="caption" color="textSecondary">
                   &nbsp;via&nbsp;
                 </Typography>
@@ -62,7 +62,7 @@ export const PartnershipProducingMediumsSection = ({
               key={medium}
               name={`producingMediums.${medium}`}
               disabled={!engagement.partnershipsProducingMediums.canEdit}
-              label={displayProductMedium(medium)}
+              label={ProductMediumLabels[medium]}
               options={engagement.project.partnerships.items}
               getOptionLabel={(partnership: PartnershipForLabelFragment) =>
                 partnership.partner.value?.organization.value?.name.value ??

--- a/src/scenes/Products/ProductForm/ProgressMeasurementSection.tsx
+++ b/src/scenes/Products/ProductForm/ProgressMeasurementSection.tsx
@@ -1,7 +1,7 @@
 import { ToggleButton } from '@material-ui/lab';
 import React from 'react';
-import { ProgressMeasurement } from '~/api/schema';
-import { displayProgressMeasurement } from '~/common';
+import { ProgressMeasurement, ProgressMeasurementLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { EnumField } from '../../../components/form';
 import { SectionProps } from './ProductFormFields';
 import { SecuredAccordion } from './SecuredAccordion';
@@ -30,7 +30,7 @@ export const ProgressMeasurementSection = ({
       renderCollapsed={() =>
         progressStepMeasurement && (
           <ToggleButton selected value={progressStepMeasurement}>
-            {displayProgressMeasurement(progressStepMeasurement)}
+            {ProgressMeasurementLabels[progressStepMeasurement]}
           </ToggleButton>
         )
       }
@@ -39,7 +39,7 @@ export const ProgressMeasurementSection = ({
         <EnumField
           required
           options={measurementOptions}
-          getLabel={displayProgressMeasurement}
+          getLabel={labelFrom(ProgressMeasurementLabels)}
           variant="toggle-split"
           {...props}
         />

--- a/src/scenes/Products/ProductForm/StepsSection.tsx
+++ b/src/scenes/Products/ProductForm/StepsSection.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from '@apollo/client';
 import { ToggleButton } from '@material-ui/lab';
 import React, { useEffect } from 'react';
-import { displayProductStep } from '../../../api';
+import { ProductStepLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { EnumField } from '../../../components/form';
 import { AvailableProductStepsDocument as AvailableSteps } from './ProductForm.graphql';
 import { SectionProps } from './ProductFormFields';
@@ -44,7 +45,7 @@ export const StepsSection = ({
       renderCollapsed={() =>
         steps?.map((step) => (
           <ToggleButton selected key={step} value={step}>
-            {displayProductStep(step)}
+            {ProductStepLabels[step]}
           </ToggleButton>
         ))
       }
@@ -54,7 +55,7 @@ export const StepsSection = ({
           {...props}
           multiple
           options={availableSteps}
-          getLabel={displayProductStep}
+          getLabel={labelFrom(ProductStepLabels)}
           variant="toggle-split"
         />
       )}

--- a/src/scenes/ProgressReports/Detail/ProductTable.tsx
+++ b/src/scenes/ProgressReports/Detail/ProductTable.tsx
@@ -1,7 +1,7 @@
 import { sortBy, uniq } from 'lodash';
 import { Column } from 'material-table';
 import React, { useMemo } from 'react';
-import { displayProductStep, ProductStep } from '../../../api';
+import { ProductStep, ProductStepLabels } from '~/api/schema';
 import { Link } from '../../../components/Routing';
 import { Table } from '../../../components/Table';
 import { bookIndexFromName } from '../../../util/biblejs';
@@ -49,7 +49,7 @@ export const ProductTable = ({ products, category }: ProductTableProps) => {
         step === 'ExegesisAndFirstDraft' ? (
           <>Exegesis&nbsp;& First&nbsp;Draft</>
         ) : (
-          displayProductStep(step)
+          ProductStepLabels[step]
         ),
       field: step,
       render: (row: RowData) =>

--- a/src/scenes/Projects/ChangeRequest/Create/CreateProjectChangeRequest.tsx
+++ b/src/scenes/Projects/ChangeRequest/Create/CreateProjectChangeRequest.tsx
@@ -1,12 +1,13 @@
 import { useMutation } from '@apollo/client';
 import React from 'react';
 import { Except } from 'type-fest';
+import { addItemToList } from '~/api';
 import {
-  addItemToList,
   CreateProjectChangeRequestInput,
-  displayProjectChangeRequestType,
+  ProjectChangeRequestTypeLabels,
   ProjectChangeRequestTypeList,
-} from '../../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -65,7 +66,7 @@ export const CreateProjectChangeRequest = ({
       <AutocompleteField
         multiple
         options={ProjectChangeRequestTypeList}
-        getOptionLabel={displayProjectChangeRequestType}
+        getOptionLabel={labelFrom(ProjectChangeRequestTypeLabels)}
         name="types"
         label="Types"
         variant="outlined"

--- a/src/scenes/Projects/ChangeRequest/Update/UpdateProjectChangeRequest.tsx
+++ b/src/scenes/Projects/ChangeRequest/Update/UpdateProjectChangeRequest.tsx
@@ -1,14 +1,15 @@
 import { useMutation } from '@apollo/client';
 import React from 'react';
 import { Except } from 'type-fest';
+import { removeItemFromList } from '~/api';
 import {
-  displayPlanChangeStatus,
-  displayProjectChangeRequestType,
+  ProjectChangeRequestStatusLabels,
   ProjectChangeRequestStatusList,
+  ProjectChangeRequestTypeLabels,
   ProjectChangeRequestTypeList,
-  removeItemFromList,
   UpdateProjectChangeRequestInput,
-} from '../../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -118,7 +119,7 @@ export const UpdateProjectChangeRequest = ({
       <AutocompleteField
         multiple
         options={ProjectChangeRequestTypeList}
-        getOptionLabel={displayProjectChangeRequestType}
+        getOptionLabel={labelFrom(ProjectChangeRequestTypeLabels)}
         name="types"
         label="Types"
         variant="outlined"
@@ -135,7 +136,7 @@ export const UpdateProjectChangeRequest = ({
       />
       <AutocompleteField
         options={ProjectChangeRequestStatusList}
-        getOptionLabel={displayPlanChangeStatus}
+        getOptionLabel={labelFrom(ProjectChangeRequestStatusLabels)}
         name="status"
         label="Status"
         variant="outlined"

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -1,11 +1,12 @@
 import { Tooltip } from '@material-ui/core';
 import * as React from 'react';
 import {
-  displayStatus,
+  ProjectStatusLabels,
   ProjectStatusList,
   ProjectTypeList,
   SensitivityList,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import { EnumField, SwitchField } from '../../../components/form';
 import {
   BooleanParam,
@@ -33,7 +34,7 @@ export const ProjectFilterOptions = () => {
         label="Status"
         multiple
         options={ProjectStatusList}
-        getLabel={displayStatus}
+        getLabel={labelFrom(ProjectStatusLabels)}
         defaultOption="Show All"
         layout="two-column"
       />

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -3,12 +3,13 @@ import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
 import React, { useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
+import { addItemToList } from '~/api';
 import {
-  addItemToList,
   CreateProjectMember as CreateProjectMemberInput,
-  displayRole,
+  RoleLabels,
   RoleList,
-} from '../../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -98,7 +99,7 @@ export const CreateProjectMember = ({
               disabled={!canRead || !userRoles}
               multiple
               options={RoleList}
-              getOptionLabel={displayRole}
+              getOptionLabel={labelFrom(RoleLabels)}
               name="roles"
               label="Roles"
               helperText={

--- a/src/scenes/Projects/Members/Update/UpdateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Update/UpdateProjectMember.tsx
@@ -3,12 +3,9 @@ import { Container } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import React from 'react';
 import { Except } from 'type-fest';
-import {
-  displayRole,
-  removeItemFromList,
-  RoleList,
-  UpdateProjectMemberInput,
-} from '../../../../api';
+import { removeItemFromList } from '~/api';
+import { RoleLabels, RoleList, UpdateProjectMemberInput } from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -117,7 +114,7 @@ export const UpdateProjectMember = ({
             fullWidth
             multiple
             options={RoleList}
-            getOptionLabel={displayRole}
+            getOptionLabel={labelFrom(RoleLabels)}
             name="roles"
             label="Roles"
             getOptionDisabled={(option) => !availableRoles.includes(option)}

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -6,7 +6,8 @@ import clsx from 'clsx';
 import React, { FC } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Helmet } from 'react-helmet-async';
-import { displayProjectStep } from '../../../api';
+import { ProjectStepLabels } from '~/api/schema';
+import { labelFrom } from '~/common';
 import { BudgetOverviewCard } from '../../../components/BudgetOverviewCard';
 import { CardGroup } from '../../../components/CardGroup';
 import { ChangesetPropertyBadge } from '../../../components/Changeset';
@@ -426,7 +427,7 @@ export const ProjectOverview: FC = () => {
               <ChangesetPropertyBadge
                 current={projectOverviewData?.project}
                 prop="step"
-                labelBy={displayProjectStep}
+                labelBy={labelFrom(ProjectStepLabels)}
               >
                 <DataButton
                   loading={!projectOverviewData}
@@ -437,7 +438,9 @@ export const ProjectOverview: FC = () => {
                     openWorkflow(projectOverviewData.project)
                   }
                 >
-                  {displayProjectStep(projectOverviewData?.project.step.value)}
+                  {labelFrom(ProjectStepLabels)(
+                    projectOverviewData?.project.step.value
+                  )}
                 </DataButton>
               </ChangesetPropertyBadge>
             </Grid>

--- a/src/scenes/Projects/Update/ProjectWorkflowDialog.tsx
+++ b/src/scenes/Projects/Update/ProjectWorkflowDialog.tsx
@@ -3,11 +3,12 @@ import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import React from 'react';
 import { Except } from 'type-fest';
 import {
-  displayProjectStep,
   ProjectStep,
+  ProjectStepLabels,
   ProjectStepList,
   TransitionType,
-} from '../../../api';
+} from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -92,9 +93,9 @@ export const ProjectWorkflowDialog = ({
           <Tooltip
             title={
               transition.disabledReason ??
-              `This will change the project step to ${displayProjectStep(
-                transition.to
-              )}`
+              `This will change the project step to ${
+                ProjectStepLabels[transition.to]
+              }`
             }
             key={i}
           >
@@ -132,7 +133,7 @@ export const ProjectWorkflowDialog = ({
               name="project.step"
               label="Override Step"
               options={ProjectStepList}
-              getOptionLabel={displayProjectStep}
+              getOptionLabel={labelFrom(ProjectStepLabels)}
             />
           </>
         ) : (

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -7,7 +7,8 @@ import React, { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { useInterval } from 'react-use';
-import { canEditAny, displayRoles } from '../../../api';
+import { RoleLabels } from '~/api/schema';
+import { canEditAny, labelsFrom } from '~/common';
 import { useDialog } from '../../../components/Dialog';
 import {
   DisplaySimpleProperty,
@@ -108,7 +109,7 @@ export const UserDetail = () => {
           />
           <DisplayProperty
             label="Roles"
-            value={user?.roles.value && displayRoles(user.roles.value)}
+            value={labelsFrom(RoleLabels)(user?.roles.value)}
             loading={!user}
           />
           <DisplayProperty

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -1,7 +1,8 @@
 import { Grid } from '@material-ui/core';
 import { memoize } from 'lodash';
 import React from 'react';
-import { displayRole, RoleList } from '../../../api';
+import { RoleLabels, RoleList } from '~/api/schema';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -138,7 +139,7 @@ export const UserForm = <T, R = void>({
             <AutocompleteField
               multiple
               options={RoleList}
-              getOptionLabel={displayRole}
+              getOptionLabel={labelFrom(RoleLabels)}
               label="Roles"
               variant="outlined"
               disabled={!powers?.includes('GrantRole')}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6573,6 +6573,7 @@ __metadata:
     rimraf: ^3.0.2
     seedrandom: ^3.0.5
     serialize-query-params: ^1.3.6
+    title-case: ^3.0.3
     ts-essentials: ^9.1.2
     ts-morph: ^14.0.0
     ts-node: ^10.7.0


### PR DESCRIPTION
Related to #1106

API schema can define custom labels like this:
```gql
enum ProgressVarianceReason {
  """
  How do you do, fellow developer?
  @label Late or delayed partner reporting
  """
  PartnerReporting
}
```

TBD whether this has a significant bundle size impact. I confirmed that unused ones are still stripped out, so I don't believe it will be major.

I also replaced most of the old `displayEnum` helper functions with these new generated maps.
After the API schema communicates these label "exceptions" more of the remaining display functions can be removed.