### PR TITLE
Don't bother trying to delete file when upload fails

### DIFF
--- a/src/components/Upload/Upload.graphql
+++ b/src/components/Upload/Upload.graphql
@@ -4,9 +4,3 @@ mutation RequestFileUpload {
     url
   }
 }
-
-mutation DeleteFileNode($id: ID!) {
-  deleteFileNode(id: $id) {
-    __typename
-  }
-}

--- a/src/components/Upload/useUploadFile.ts
+++ b/src/components/Upload/useUploadFile.ts
@@ -1,15 +1,11 @@
-import { useMutation } from '@apollo/client';
 import { Dispatch, useCallback } from 'react';
 import { getMimeType } from './getMimeType';
 import * as actions from './Reducer/uploadActions';
 import * as Types from './Reducer/uploadTypings';
-import { DeleteFileNodeDocument } from './Upload.graphql';
 
 export const useUploadFile = (
   dispatch: Dispatch<Types.UploadAction>
 ): ((uploadFile: Types.UploadFile, url: string) => void) => {
-  const [deleteFile] = useMutation(DeleteFileNodeDocument);
-
   const setUploadError = useCallback(
     (queueId: Types.UploadFile['queueId'], errorMessage: string) => {
       dispatch({
@@ -35,11 +31,10 @@ export const useUploadFile = (
         } catch (error) {
           setUploadError(file.queueId, 'Failed to save file');
           console.error(error);
-          await deleteFile({ variables: { id: file.uploadId } });
         }
       }
     },
-    [deleteFile, setUploadError, dispatch]
+    [setUploadError, dispatch]
   );
 
   // This should be rare, it's just there for completeness.


### PR DESCRIPTION
There was a period of time when this was useful,
but now esp with transaction rollbacks this is useless.