### PR TITLE
New JSX runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,11 @@
 {
-  "presets": ["razzle/babel"],
+  "presets": [
+    ["razzle/babel", {
+      "preset-react": {
+        "runtime": "automatic"
+      }
+    }]
+  ],
   "plugins": [
     ["transform-rename-import", {
       "replacements": [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,24 @@ const roots = fs
 
 /** @type import('@seedcompany/eslint-plugin/dist/rules/no-restricted-imports').ImportRestriction[] */
 const restrictedImports = [
+  {
+    path: 'react',
+    importNames: 'default',
+    message: [
+      'Import specific things instead.',
+      'Also the global import is no longer necessary for JSX compilation.',
+    ].join('\n'),
+  },
+  {
+    path: 'react',
+    importNames: ['FC', 'FunctionalComponent'],
+    message: [
+      'This is deprecated as is the implicit children prop.',
+      'Declare type for props explicitly on the first argument instead.',
+      'We also have a ChildrenProp type shortcut.',
+    ].join('\n'),
+  },
+
   // As noted in https://github.com/mui-org/material-ui/releases/tag/v4.5.1
   {
     path: '@material-ui/styles',
@@ -71,10 +89,6 @@ const config = {
   plugins: ['@seedcompany'],
   extends: ['plugin:@seedcompany/react'],
   rules: {
-    // TODO Remove with React 18
-    'react/jsx-uses-react': 'warn',
-    'react/react-in-jsx-scope': 'warn',
-
     // TODO Remove and fix
     // Allow `extends any` for TSX
     // This makes the distinction that it's a generic instead of JSX

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,7 +6,7 @@ import {
 } from 'express';
 import { Request } from 'jest-express/lib/request';
 import { Response } from 'jest-express/lib/response';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { StaticRouter } from 'react-router-dom/server';
 import { ChildrenProp } from '~/common';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { ThemeProvider } from '@material-ui/core';
 import { LocalizationProvider } from '@material-ui/pickers';
 import LogRocket from 'logrocket';
 import setupLogRocketReact from 'logrocket-react';
-import * as React from 'react';
 import { ApolloProvider } from './api';
 import { Nest } from './components/Nest';
 import { SnackbarProvider } from './components/Snackbar';

--- a/src/api/client/ApolloProvider.tsx
+++ b/src/api/client/ApolloProvider.tsx
@@ -2,7 +2,6 @@ import {
   ApolloProvider as BaseApolloProvider,
   getApolloContext,
 } from '@apollo/client';
-import * as React from 'react';
 import { useContext, useState } from 'react';
 import { ChildrenProp } from '~/common';
 import { createClient } from './createClient';

--- a/src/api/client/links/renderErrors.link.tsx
+++ b/src/api/client/links/renderErrors.link.tsx
@@ -2,7 +2,7 @@ import { ErrorHandler } from '@apollo/client/link/error';
 import { IconButton } from '@material-ui/core';
 import { Close } from '@material-ui/icons';
 import { ProviderContext as Snackbar, useSnackbar } from 'notistack';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 
 export const useErrorRendererRef = () => {
   // Using ref to store error handler function, so it can be swapped on each

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,10 +1,9 @@
 import { loadableReady } from '@loadable/component';
 import Cookies from 'js-cookie';
 import { Settings, Zone } from 'luxon';
-import React from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import ReactDOM from 'react-dom';
+import { hydrate } from 'react-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter } from 'react-router-dom';
 import { basePathOfUrl } from '~/common';
@@ -40,10 +39,14 @@ if (process.env.NODE_ENV !== 'production') {
     // Do hacking to show dates easier
     await import('./common/hacky-inspect-dates');
 
-    const whyDidYouRender = await import(
-      '@welldone-software/why-did-you-render'
-    );
-    whyDidYouRender.default(React);
+    // Setup why did you render
+    const [React, whyDidYouRender] = await Promise.all([
+      import('react').then((m) => m.default),
+      import('@welldone-software/why-did-you-render').then((m) => m.default),
+    ]);
+    whyDidYouRender(React, {
+      // ...WDYR options
+    });
   };
   setup.push(devSetUp());
 }
@@ -64,7 +67,7 @@ const clientOnlyProviders = [
 ];
 
 void Promise.all(setup).then(() => {
-  ReactDOM.hydrate(
+  hydrate(
     <Nest elements={clientOnlyProviders}>
       <App />
     </Nest>,

--- a/src/common/approach.tsx
+++ b/src/common/approach.tsx
@@ -4,7 +4,7 @@ import {
   PlayCircleFilled,
   Translate,
 } from '@material-ui/icons';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { ProductApproach, ProductMethodology } from '~/api/schema.graphql';
 import { entries, mapFromList } from './array-helpers';
 

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 import { CreateNewFolder } from '@material-ui/icons';
 import { select } from '@storybook/addon-knobs';
-import * as React from 'react';
 import { Avatar as A, AvatarProps } from './Avatar';
 
 export default {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -4,7 +4,6 @@ import {
   AvatarProps as MuiAvatarProps,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import * as React from 'react';
 
 export interface AvatarProps extends MuiAvatarProps {
   loading?: boolean;

--- a/src/components/BadgeWithTooltip/BadgeWithTooltip.tsx
+++ b/src/components/BadgeWithTooltip/BadgeWithTooltip.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { ReactElement, ReactNode } from 'react';
+import { Children, ReactElement, ReactNode } from 'react';
 
 /**
  * Allows a badge to have a tooltip.
@@ -26,7 +25,7 @@ export const BadgeWithTooltip = ({
   tooltip: (content: ReactElement) => ReactElement;
   children: ReactNode;
 }) => {
-  const children = React.Children.toArray(childrenProp);
+  const children = Children.toArray(childrenProp);
   return (
     <span {...props}>
       {children.slice(0, -1)}

--- a/src/components/BooleanProperty/BooleanProperty.tsx
+++ b/src/components/BooleanProperty/BooleanProperty.tsx
@@ -1,6 +1,6 @@
 import { Chip, ChipProps, makeStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Except, SetRequired } from 'type-fest';
 import { SecuredProp } from '~/common';
 import { Redacted } from '../Redacted';

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,5 +1,4 @@
 import { Breadcrumbs as BreadCrumbs } from '@material-ui/core';
-import React from 'react';
 import { AddCurrentPath } from '../Routing/decorators.stories';
 import { Breadcrumb } from './Breadcrumb';
 

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,7 +2,6 @@ import { Typography } from '@material-ui/core';
 import { To } from 'history';
 import { isString } from 'lodash';
 import { forwardRef, ReactNode } from 'react';
-import * as React from 'react';
 import { useMatch } from 'react-router-dom';
 import { Link, LinkProps } from '../Routing';
 

--- a/src/components/Breadcrumb/SecuredBreadcrumb.tsx
+++ b/src/components/Breadcrumb/SecuredBreadcrumb.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from '@material-ui/lab';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { Nullable, SecuredProp } from '~/common';
 import { Redacted, RedactedProps } from '../Redacted';

--- a/src/components/BudgetOverviewCard/BudgetOverviewCard.stories.tsx
+++ b/src/components/BudgetOverviewCard/BudgetOverviewCard.stories.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@material-ui/core';
 import { boolean, number } from '@storybook/addon-knobs';
-import React from 'react';
 import { dateTime } from '../knobs.stories';
 import { BudgetOverviewFragment } from './BudgetOverview.graphql';
 import { BudgetOverviewCard as BOC } from './BudgetOverviewCard';

--- a/src/components/BudgetOverviewCard/BudgetOverviewCard.tsx
+++ b/src/components/BudgetOverviewCard/BudgetOverviewCard.tsx
@@ -1,5 +1,4 @@
 import { AccountBalance } from '@material-ui/icons';
-import * as React from 'react';
 import {
   FieldOverviewCard,
   FieldOverviewCardProps,

--- a/src/components/CardGroup/CardGroup.stories.tsx
+++ b/src/components/CardGroup/CardGroup.stories.tsx
@@ -1,5 +1,4 @@
 import { Group, GroupWork } from '@material-ui/icons';
-import React from 'react';
 import { MemberListSummary } from '../MemberListSummary';
 import { members } from '../MemberListSummary/MemberListSummary.stories';
 import { CardGroup as CG } from './CardGroup';

--- a/src/components/CardGroup/CardGroup.tsx
+++ b/src/components/CardGroup/CardGroup.tsx
@@ -1,6 +1,5 @@
 import { Card, CardProps, makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { Children, Fragment } from 'react';
 import { applyBreakpoint, BreakpointAt } from '~/common';
 import { ResponsiveDivider } from '../ResponsiveDivider';

--- a/src/components/Changeset/ChangesetBadge.tsx
+++ b/src/components/Changeset/ChangesetBadge.tsx
@@ -12,7 +12,6 @@ import {
 } from '@material-ui/icons';
 import clsx from 'clsx';
 import { startCase } from 'lodash';
-import * as React from 'react';
 import { cloneElement, isValidElement, ReactElement, ReactNode } from 'react';
 import { simpleSwitch, UseStyles } from '~/common';
 import { BadgeWithTooltip } from '../BadgeWithTooltip';

--- a/src/components/Changeset/ChangesetBanner.tsx
+++ b/src/components/Changeset/ChangesetBanner.tsx
@@ -5,7 +5,6 @@ import {
   Edit as EditIcon,
 } from '@material-ui/icons';
 import { Alert, AlertTitle } from '@material-ui/lab';
-import * as React from 'react';
 import { IconButton } from '../IconButton';
 
 const useStyles = makeStyles(({ spacing, breakpoints }) => ({

--- a/src/components/Changeset/ChangesetContext.tsx
+++ b/src/components/Changeset/ChangesetContext.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client';
-import * as React from 'react';
 import { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { ChildrenProp } from '~/common';

--- a/src/components/Changeset/ChangesetDiffContext.tsx
+++ b/src/components/Changeset/ChangesetDiffContext.tsx
@@ -1,5 +1,4 @@
 import { useApolloClient } from '@apollo/client';
-import * as React from 'react';
 import { createContext, useCallback, useContext, useMemo } from 'react';
 import { Entity } from '~/api';
 import { ChildrenProp, IdFragment, mapFromList, Nullable } from '~/common';

--- a/src/components/Changeset/ChangesetModificationWarning.tsx
+++ b/src/components/Changeset/ChangesetModificationWarning.tsx
@@ -1,6 +1,5 @@
 import { ChangeHistory as ChangeIcon } from '@material-ui/icons';
 import { Alert } from '@material-ui/lab';
-import * as React from 'react';
 
 interface Props {
   variant?: 'modifying' | 'ignoring';

--- a/src/components/Changeset/ChangesetPropertyBadge.tsx
+++ b/src/components/Changeset/ChangesetPropertyBadge.tsx
@@ -1,5 +1,4 @@
 import { identity } from 'lodash';
-import * as React from 'react';
 import { ReactNode } from 'react';
 import { Entity } from '~/api';
 import { UnsecuredProp, unwrapSecured } from '~/common';

--- a/src/components/Changeset/PropertyDiff.tsx
+++ b/src/components/Changeset/PropertyDiff.tsx
@@ -1,6 +1,5 @@
 import { fade, Grid, makeStyles, Typography } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { ReactNode } from 'react';
 
 const useStyles = makeStyles(({ palette, shape, spacing }) => ({

--- a/src/components/CreateButton/CreateButton.stories.tsx
+++ b/src/components/CreateButton/CreateButton.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { CreateButton as CB } from './CreateButton';
 
 export default { title: 'Components/Buttons' };

--- a/src/components/CreateButton/CreateButton.tsx
+++ b/src/components/CreateButton/CreateButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ErrorButton, ErrorButtonProps } from '../ErrorButton';
 
 export type CreateButtonProps = ErrorButtonProps;

--- a/src/components/DataButton/DataButton.tsx
+++ b/src/components/DataButton/DataButton.tsx
@@ -6,7 +6,6 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { isFunction } from 'lodash';
-import * as React from 'react';
 import { ReactNode } from 'react';
 import { SecuredProp } from '~/common';
 import { Redacted } from '../Redacted';

--- a/src/components/Debug/Code.tsx
+++ b/src/components/Debug/Code.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import React from 'react';
 import { ChildrenProp } from '~/common';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/components/DefinedFileCard/DefinedFileCard.stories.tsx
+++ b/src/components/DefinedFileCard/DefinedFileCard.stories.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@material-ui/core';
 import { boolean, text } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
-import React from 'react';
 import { dateTime } from '../knobs.stories';
 import { DefinedFileCard as Card } from './DefinedFileCard';
 

--- a/src/components/DefinedFileCard/DefinedFileCard.tsx
+++ b/src/components/DefinedFileCard/DefinedFileCard.tsx
@@ -13,7 +13,7 @@ import {
 } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import { DateTime } from 'luxon';
-import React, { forwardRef, ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { CreateDefinedFileVersionInput } from '~/api/schema.graphql';
 import { SecuredProp } from '~/common';

--- a/src/components/Dialog/DialogForm.stories.tsx
+++ b/src/components/Dialog/DialogForm.stories.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@material-ui/core';
 import { useEffect, useState } from 'react';
-import * as React from 'react';
 import { sleep } from '../../util';
 import { SubmitError, TextField } from '../form';
 import { DialogForm as DF } from './DialogForm';

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -10,7 +10,7 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import { FormApi } from 'final-form';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import {
   Form,
   FormProps,

--- a/src/components/Dialog/DialogTitle.tsx
+++ b/src/components/Dialog/DialogTitle.tsx
@@ -9,7 +9,6 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { Cancel } from '@material-ui/icons';
-import * as React from 'react';
 
 const styles = (theme: Theme) =>
   createStyles({

--- a/src/components/Dialog/useDialog.stories.tsx
+++ b/src/components/Dialog/useDialog.stories.tsx
@@ -9,7 +9,6 @@ import {
   ListItemText,
   Typography,
 } from '@material-ui/core';
-import * as React from 'react';
 import { useDialog } from './useDialog';
 
 export default {

--- a/src/components/DisplaySimpleProperty/DisplaySimpleProperty.stories.tsx
+++ b/src/components/DisplaySimpleProperty/DisplaySimpleProperty.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean, select, text } from '@storybook/addon-knobs';
-import * as React from 'react';
 import { DisplaySimpleProperty as DSP } from './DisplaySimpleProperty';
 
 export default {

--- a/src/components/DisplaySimpleProperty/DisplaySimpleProperty.tsx
+++ b/src/components/DisplaySimpleProperty/DisplaySimpleProperty.tsx
@@ -1,6 +1,6 @@
 import { Typography, TypographyProps } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 export type DisplaySimplePropertyProps = TypographyProps & {
   label?: string;

--- a/src/components/EngagementBreadcrumb/EngagementBreadcrumb.tsx
+++ b/src/components/EngagementBreadcrumb/EngagementBreadcrumb.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { Nullable } from '~/common';
 import { SecuredBreadcrumb, SecuredBreadcrumbProps } from '../Breadcrumb';

--- a/src/components/Error/Error.stories.tsx
+++ b/src/components/Error/Error.stories.tsx
@@ -1,7 +1,6 @@
 import { ApolloError } from '@apollo/client';
 import { boolean } from '@storybook/addon-knobs';
 import { GraphQLError } from 'graphql';
-import React from 'react';
 import { Error as ErrorComponent } from './Error';
 
 export default { title: 'Components/Error' };

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -2,7 +2,7 @@ import { ApolloError } from '@apollo/client';
 import { Button, Grid, makeStyles, Typography } from '@material-ui/core';
 import clsx from 'clsx';
 import { isPlainObject } from 'lodash';
-import React, { ElementType, isValidElement, ReactNode } from 'react';
+import { ElementType, isValidElement, ReactNode } from 'react';
 import { getErrorInfo } from '~/api';
 import { ButtonLink, StatusCode, useNavigate } from '../Routing';
 import { ErrorRenderers, renderError } from './error-handling';

--- a/src/components/Error/NotFoundPage.tsx
+++ b/src/components/Error/NotFoundPage.tsx
@@ -1,5 +1,4 @@
 import { Typography } from '@material-ui/core';
-import React from 'react';
 import { Route } from 'react-router-dom';
 import { ChildrenProp } from '~/common';
 import { StatusCode } from '../Routing';

--- a/src/components/ErrorButton/ErrorButton.stories.tsx
+++ b/src/components/ErrorButton/ErrorButton.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { ErrorButton as EB } from './ErrorButton';
 
 export default { title: 'Components/Buttons' };

--- a/src/components/ErrorButton/ErrorButton.tsx
+++ b/src/components/ErrorButton/ErrorButton.tsx
@@ -1,6 +1,5 @@
 import { Button, ButtonProps, fade, makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import React from 'react';
 import { Except } from 'type-fest';
 
 const useStyles = makeStyles(({ palette }) => ({

--- a/src/components/Fab/Fab.tsx
+++ b/src/components/Fab/Fab.tsx
@@ -10,7 +10,6 @@ import { Skeleton } from '@material-ui/lab';
 import { CSSProperties } from '@material-ui/styles';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
-import * as React from 'react';
 import { Except } from 'type-fest';
 
 const colorStyle = (color: PaletteColor): CSSProperties => ({

--- a/src/components/FieldOverviewCard/FieldOverviewCard.stories.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.stories.tsx
@@ -2,7 +2,6 @@ import { Box } from '@material-ui/core';
 import { AccountBalance } from '@material-ui/icons';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { dateTime } from '../knobs.stories';
 import { AddCurrentPath } from '../Routing/decorators.stories';
 import { FieldOverviewCard as Card } from './FieldOverviewCard';

--- a/src/components/FieldOverviewCard/FieldOverviewCard.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.tsx
@@ -14,7 +14,6 @@ import clsx from 'clsx';
 import { To } from 'history';
 import { DateTime } from 'luxon';
 import { ReactNode } from 'react';
-import * as React from 'react';
 import { useDateTimeFormatter } from '../Formatters';
 import { HugeIcon, HugeIconProps } from '../Icons';
 import { ButtonLink, CardActionAreaLink } from '../Routing';

--- a/src/components/Filter/FilterButtonDialog.tsx
+++ b/src/components/Filter/FilterButtonDialog.tsx
@@ -1,6 +1,5 @@
 import { Badge, Button } from '@material-ui/core';
 import { ReactNode } from 'react';
-import * as React from 'react';
 import { keys } from '~/common';
 import { useDialog } from '../Dialog';
 import { DialogForm } from '../Dialog/DialogForm';

--- a/src/components/Formatters/FormattedDate.tsx
+++ b/src/components/Formatters/FormattedDate.tsx
@@ -1,6 +1,5 @@
 import { Tooltip } from '@material-ui/core';
 import { DateTime, DateTimeFormatOptions } from 'luxon';
-import * as React from 'react';
 import { MergeExclusive } from 'type-fest';
 import { DateRange } from '~/api/schema.graphql';
 import { CalendarDate, Nullable } from '~/common';

--- a/src/components/FundingAccountCard/FundingAccountCard.stories.tsx
+++ b/src/components/FundingAccountCard/FundingAccountCard.stories.tsx
@@ -1,6 +1,5 @@
 import { number, text } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
-import React from 'react';
 import { FundingAccountCard as Card } from './FundingAccountCard';
 
 export default { title: 'Components' };

--- a/src/components/FundingAccountCard/FundingAccountCard.tsx
+++ b/src/components/FundingAccountCard/FundingAccountCard.tsx
@@ -6,7 +6,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { FormattedDateTime } from '../Formatters';
 import { FundingAccountCardFragment } from './FundingAccountCard.graphql';

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -10,7 +10,6 @@ import { Skeleton } from '@material-ui/lab';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { CSSProperties } from '@material-ui/styles';
 import clsx from 'clsx';
-import * as React from 'react';
 import { forwardRef } from 'react';
 import { Except } from 'type-fest';
 

--- a/src/components/Icons/ChatBubbleIcon.tsx
+++ b/src/components/Icons/ChatBubbleIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const ChatBubbleIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 45 44">

--- a/src/components/Icons/CordIcon.tsx
+++ b/src/components/Icons/CordIcon.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, SvgIcon, SvgIconProps } from '@material-ui/core';
-import React from 'react';
 
 const useStyles = makeStyles(() => ({
   root: {

--- a/src/components/Icons/HugeIcon.stories.tsx
+++ b/src/components/Icons/HugeIcon.stories.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@material-ui/core';
 import { Home } from '@material-ui/icons';
-import * as React from 'react';
 import { CordIcon } from './CordIcon';
 import { HugeIcon } from './HugeIcon';
 

--- a/src/components/Icons/HugeIcon.tsx
+++ b/src/components/Icons/HugeIcon.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, SvgIconProps } from '@material-ui/core';
 import { cloneElement, isValidElement, ReactElement } from 'react';
-import * as React from 'react';
 import { Avatar, AvatarProps } from '../Avatar';
 
 const useStyles = makeStyles(({ palette }) => ({

--- a/src/components/Icons/OptionsIcon.tsx
+++ b/src/components/Icons/OptionsIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const OptionsIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 57 57">

--- a/src/components/Icons/PencilCircledIcon.tsx
+++ b/src/components/Icons/PencilCircledIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const PencilCircledIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 25 25">

--- a/src/components/Icons/PeopleJoinedIcon.tsx
+++ b/src/components/Icons/PeopleJoinedIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const PeopleJoinedIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 40 40">

--- a/src/components/Icons/PlantIcon.tsx
+++ b/src/components/Icons/PlantIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const PlantIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 16 17">

--- a/src/components/Icons/PresetInventoryIconFilled.tsx
+++ b/src/components/Icons/PresetInventoryIconFilled.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 import { forwardRef } from 'react';
 
 export const PresetInventoryIconFilled = forwardRef<

--- a/src/components/Icons/PresetInventoryIconOutlined.tsx
+++ b/src/components/Icons/PresetInventoryIconOutlined.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const PresetInventoryIconOutlined = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 24 24">

--- a/src/components/Icons/PushPinIconFilled.tsx
+++ b/src/components/Icons/PushPinIconFilled.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const PushPinIconFilled = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 24 24">

--- a/src/components/Icons/PushPinIconOutlined.tsx
+++ b/src/components/Icons/PushPinIconOutlined.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const PushPinIconOutlined = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 24 24">

--- a/src/components/Icons/ReportIcon.tsx
+++ b/src/components/Icons/ReportIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const ReportIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 31 37">

--- a/src/components/Icons/ScriptIcon.tsx
+++ b/src/components/Icons/ScriptIcon.tsx
@@ -1,5 +1,4 @@
 import { SvgIcon, SvgIconProps } from '@material-ui/core';
-import * as React from 'react';
 
 export const ScriptIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 16 17">

--- a/src/components/InternshipEngagementListItemCard/InternshipEngagementListItemCard.stories.tsx
+++ b/src/components/InternshipEngagementListItemCard/InternshipEngagementListItemCard.stories.tsx
@@ -1,5 +1,4 @@
 import { text } from '@storybook/addon-knobs';
-import React from 'react';
 import { EngagementStatus } from '../../api';
 import { date } from '../knobs.stories';
 import { InternshipEngagementListItemCard as Card } from './InternshipEngagementListItemCard';

--- a/src/components/InternshipEngagementListItemCard/InternshipEngagementListItemCard.tsx
+++ b/src/components/InternshipEngagementListItemCard/InternshipEngagementListItemCard.tsx
@@ -7,7 +7,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import {
   EngagementStatusLabels,
   InternshipPositionLabels,

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.stories.tsx
@@ -1,5 +1,4 @@
 import { number, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { EngagementStatus } from '../../api';
 import { LanguageEngagementListItemCard as Card } from './LanguageEngagementListItemCard';
 

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
@@ -7,7 +7,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { EngagementStatusLabels } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { idForUrl } from '../Changeset';

--- a/src/components/LanguageListItemCard/LanguageListItemCard.stories.tsx
+++ b/src/components/LanguageListItemCard/LanguageListItemCard.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { LanguageListItemFragment } from './LanguageListItem.graphql';
 import { LanguageListItemCard } from './LanguageListItemCard';
 

--- a/src/components/LanguageListItemCard/LanguageListItemCard.tsx
+++ b/src/components/LanguageListItemCard/LanguageListItemCard.tsx
@@ -7,7 +7,6 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
 import { LanguagesQueryVariables } from '../../scenes/Languages/List/languages.graphql';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
 import { useNumberFormatter } from '../Formatters';

--- a/src/components/Layout/ContentContainer.tsx
+++ b/src/components/Layout/ContentContainer.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import React from 'react';
 import { ChildrenProp } from '~/common';
 
 const useStyles = makeStyles(({ spacing }) => ({

--- a/src/components/LinearProgressBar/LinearProgressBar.tsx
+++ b/src/components/LinearProgressBar/LinearProgressBar.tsx
@@ -1,5 +1,4 @@
 import { Box, LinearProgress, Typography } from '@material-ui/core';
-import * as React from 'react';
 import { ProgressMeasurement } from '~/api/schema.graphql';
 
 interface LinearProgressBarProps {

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -2,7 +2,6 @@ import { ButtonProps, Grid, GridProps, makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { times } from 'lodash';
 import { ReactNode, RefObject, useRef } from 'react';
-import * as React from 'react';
 import { Entity, isNetworkRequestInFlight, PaginatedListOutput } from '~/api';
 import { UseStyles } from '~/common';
 import { usePersistedScroll } from '../../hooks/usePersistedScroll';

--- a/src/components/LocationCard/LocationCard.stories.tsx
+++ b/src/components/LocationCard/LocationCard.stories.tsx
@@ -1,6 +1,5 @@
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
-import React from 'react';
 import { LocationTypeList } from '../../api';
 import { LocationCard as Card } from './LocationCard';
 import { LocationCardFragment } from './LocationCard.graphql';

--- a/src/components/LocationCard/LocationCard.tsx
+++ b/src/components/LocationCard/LocationCard.tsx
@@ -7,7 +7,6 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
 import { LocationTypeLabels } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { FormattedDateTime } from '../Formatters';

--- a/src/components/MemberListSummary/MemberListSummary.stories.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.stories.tsx
@@ -1,7 +1,6 @@
 import { Card } from '@material-ui/core';
 import { Group } from '@material-ui/icons';
 import { number, text } from '@storybook/addon-knobs';
-import React from 'react';
 import seedRandom from 'seedrandom';
 import {
   MemberListSummary,

--- a/src/components/MemberListSummary/MemberListSummary.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.tsx
@@ -2,7 +2,6 @@ import { CardContent, Grid, makeStyles, Typography } from '@material-ui/core';
 import { AvatarGroup, Skeleton } from '@material-ui/lab';
 import { To } from 'history';
 import { compact } from 'lodash';
-import * as React from 'react';
 import { listOrPlaceholders } from '~/common';
 import { Avatar } from '../Avatar';
 import { HugeIcon, HugeIconProps } from '../Icons';

--- a/src/components/MethodologiesCard/MethodologiesCard.stories.tsx
+++ b/src/components/MethodologiesCard/MethodologiesCard.stories.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@material-ui/core';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { SecuredMethodologies } from '../../api';
 import { csv } from '../../util';
 import { MethodologiesCard as Card } from './MethodologiesCard';

--- a/src/components/MethodologiesCard/MethodologiesCard.tsx
+++ b/src/components/MethodologiesCard/MethodologiesCard.tsx
@@ -8,7 +8,6 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import React from 'react';
 import {
   ApproachIcons,
   displayMethodology,

--- a/src/components/Nest.tsx
+++ b/src/components/Nest.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ReactElement } from 'react';
+import { cloneElement, ReactElement } from 'react';
 import { ChildrenProp } from '~/common';
 
 export const Nest = ({

--- a/src/components/OrganizationListItemCard/OrganizationListItemCard.stories.tsx
+++ b/src/components/OrganizationListItemCard/OrganizationListItemCard.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean, text } from '@storybook/addon-knobs';
-import * as React from 'react';
 import { OrganizationListItemFragment } from './OrganizationListItem.graphql';
 import { OrganizationListItemCard as OLIC } from './OrganizationListItemCard';
 

--- a/src/components/OrganizationListItemCard/OrganizationListItemCard.tsx
+++ b/src/components/OrganizationListItemCard/OrganizationListItemCard.tsx
@@ -8,7 +8,6 @@ import {
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { random } from 'lodash';
-import React from 'react';
 import { CardActionAreaLink } from '../Routing';
 import { OrganizationListItemFragment } from './OrganizationListItem.graphql';
 

--- a/src/components/PartnerListItemCard/PartnerListItemCard.tsx
+++ b/src/components/PartnerListItemCard/PartnerListItemCard.tsx
@@ -8,7 +8,6 @@ import {
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { random } from 'lodash';
-import React from 'react';
 import { PartnersQueryVariables } from '../../scenes/Partners/List/PartnerList.graphql';
 import { CardActionAreaLink } from '../Routing';
 import { TogglePinButton } from '../TogglePinButton';

--- a/src/components/PartnershipCard/PartnershipCard.stories.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { FinancialReportingTypeList, PartnershipAgreementStatusList } from '~/api/schema.graphql';
 import { csv } from '~/common';
 import { date, dateTime } from '../knobs.stories';

--- a/src/components/PartnershipCard/PartnershipCard.tsx
+++ b/src/components/PartnershipCard/PartnershipCard.tsx
@@ -9,7 +9,6 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import React from 'react';
 import {
   FinancialReportingTypeLabels,
   PartnershipAgreementStatusLabels,

--- a/src/components/PartnershipCard/PartnershipPrimaryIcon.tsx
+++ b/src/components/PartnershipCard/PartnershipPrimaryIcon.tsx
@@ -1,7 +1,6 @@
 import { makeStyles, SvgIconProps, Tooltip } from '@material-ui/core';
 import { Star } from '@material-ui/icons';
 import clsx from 'clsx';
-import * as React from 'react';
 
 const useStyles = makeStyles(() => ({
   primary: {

--- a/src/components/PartnershipSummary/PartnershipSummary.stories.tsx
+++ b/src/components/PartnershipSummary/PartnershipSummary.stories.tsx
@@ -1,6 +1,5 @@
 import { Card } from '@material-ui/core';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { PartnershipSummary as PS } from './PartnershipSummary';
 import { PartnershipSummaryFragment } from './PartnershipSummary.graphql';
 import { PartnershipItemFragment } from './PartnershpItem.graphql';

--- a/src/components/PartnershipSummary/PartnershipSummary.tsx
+++ b/src/components/PartnershipSummary/PartnershipSummary.tsx
@@ -1,5 +1,4 @@
 import { makeStyles } from '@material-ui/core';
-import * as React from 'react';
 import { PeopleJoinedIcon } from '../Icons';
 import { MemberListSummary, MemberSummaryItem } from '../MemberListSummary';
 import { PartnershipSummaryFragment } from './PartnershipSummary.graphql';

--- a/src/components/PeriodicReports/DropOverlay.tsx
+++ b/src/components/PeriodicReports/DropOverlay.tsx
@@ -1,7 +1,6 @@
 import { makeStyles, Typography } from '@material-ui/core';
 import { Cancel, CloudUpload } from '@material-ui/icons';
 import clsx from 'clsx';
-import React from 'react';
 import { SecuredPeriodicReportFragment } from './PeriodicReport.graphql';
 import { ReportLabel } from './ReportLabel';
 

--- a/src/components/PeriodicReports/PeriodicReportCard.tsx
+++ b/src/components/PeriodicReports/PeriodicReportCard.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import { AssignmentOutlined, BarChart, ShowChart } from '@material-ui/icons';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { ReportType } from '~/api/schema.graphql';
 import { Many, simpleSwitch } from '~/common';

--- a/src/components/PeriodicReports/PeriodicReportRow.tsx
+++ b/src/components/PeriodicReports/PeriodicReportRow.tsx
@@ -1,5 +1,4 @@
 import { MTableBodyRow } from 'material-table';
-import React from 'react';
 import { PaperTooltip } from '../PaperTooltip';
 import { ReportRow } from './PeriodicReportsTable';
 

--- a/src/components/PeriodicReports/PeriodicReportsList.tsx
+++ b/src/components/PeriodicReports/PeriodicReportsList.tsx
@@ -1,5 +1,5 @@
 import { Breadcrumbs, makeStyles, Typography } from '@material-ui/core';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { ReportType } from '~/api/schema.graphql';
 import { Breadcrumb } from '../Breadcrumb';

--- a/src/components/PeriodicReports/PeriodicReportsTable.tsx
+++ b/src/components/PeriodicReports/PeriodicReportsTable.tsx
@@ -4,7 +4,7 @@ import { Many, without } from 'lodash';
 import { DateTime } from 'luxon';
 import { Column } from 'material-table';
 import { useSnackbar } from 'notistack';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Except } from 'type-fest';
 import { CalendarDate } from '~/common';
 import { SkipPeriodicReportDialog } from '../../scenes/Projects/Reports/SkipPeriodicReportDialog';

--- a/src/components/PeriodicReports/ReportInfo.tsx
+++ b/src/components/PeriodicReports/ReportInfo.tsx
@@ -3,7 +3,7 @@ import { SkipNextRounded } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import { omit } from 'lodash';
 import { DateTime } from 'luxon';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { FormattedDate, FormattedDateTime } from '../Formatters';
 import { PaperTooltip } from '../PaperTooltip';
 import { Redacted } from '../Redacted';

--- a/src/components/PeriodicReports/ReportLabel.tsx
+++ b/src/components/PeriodicReports/ReportLabel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CalendarDate, isSecured, Nullable } from '~/common';
 import { Redacted } from '../Redacted';
 import {

--- a/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
+++ b/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { Edit } from '@material-ui/icons';
 import { useSnackbar } from 'notistack';
-import * as React from 'react';
 import { getErrorInfo, isErrorCode } from '~/api';
 import { ProductStepLabels } from '~/api/schema.graphql';
 import { CalendarDate } from '~/common';

--- a/src/components/Picture/Picture.tsx
+++ b/src/components/Picture/Picture.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { toFinite } from 'lodash';
-import React, { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useMountedState } from 'react-use';
 import { Merge } from 'type-fest';

--- a/src/components/PictureSizes/PictureSizes.tsx
+++ b/src/components/PictureSizes/PictureSizes.tsx
@@ -1,9 +1,4 @@
-import React, {
-  createContext,
-  ReactNode,
-  useContext,
-  useDebugValue,
-} from 'react';
+import { createContext, ReactNode, useContext, useDebugValue } from 'react';
 
 const PictureSizesContext = createContext('100vw');
 

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -13,7 +13,6 @@ import {
   Movie,
   SvgIconComponent,
 } from '@material-ui/icons';
-import React from 'react';
 import { idForUrl } from '../Changeset';
 import { HugeIcon } from '../Icons';
 import { CardActionAreaLink } from '../Routing';

--- a/src/components/ProgressButton/ProgressButton.stories.tsx
+++ b/src/components/ProgressButton/ProgressButton.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { ProgressButton as PB } from './ProgressButton';
 
 export default { title: 'Components/Buttons' };

--- a/src/components/ProgressButton/ProgressButton.tsx
+++ b/src/components/ProgressButton/ProgressButton.tsx
@@ -7,7 +7,6 @@ import {
   PropTypes,
   useTheme,
 } from '@material-ui/core';
-import * as React from 'react';
 import { ErrorButton } from '../ErrorButton';
 
 const useStyles = makeStyles({

--- a/src/components/ProjectBreadcrumb/ProjectBreadcrumb.tsx
+++ b/src/components/ProjectBreadcrumb/ProjectBreadcrumb.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
 import { Nullable } from '~/common';
 import { getProjectUrl } from '../../scenes/Projects/useProjectId';
 import { Breadcrumb, BreadcrumbProps } from '../Breadcrumb';

--- a/src/components/ProjectChangeRequestListItem/ProjectChangeRequestListItem.tsx
+++ b/src/components/ProjectChangeRequestListItem/ProjectChangeRequestListItem.tsx
@@ -8,7 +8,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import * as React from 'react';
 import { ProjectChangeRequestTypeLabels } from '~/api/schema.graphql';
 import { labelsFrom } from '~/common';
 import { useProjectId } from '../../scenes/Projects/useProjectId';

--- a/src/components/ProjectChangeRequestSummary/ProjectChangeRequestSummary.tsx
+++ b/src/components/ProjectChangeRequestSummary/ProjectChangeRequestSummary.tsx
@@ -1,5 +1,4 @@
 import { ChangeHistory } from '@material-ui/icons';
-import * as React from 'react';
 import { FieldOverviewCard } from '../FieldOverviewCard';
 import { useNumberFormatter } from '../Formatters';
 import { ProjectChangeRequestSummaryFragment } from './ProjectChangeRequestSummary.graphql';

--- a/src/components/ProjectListItemCard/ProjectListItemCard.stories.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.stories.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@material-ui/core';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import {
   ProjectStatusList,
   ProjectStepList,

--- a/src/components/ProjectListItemCard/ProjectListItemCard.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.tsx
@@ -7,7 +7,6 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
 import { ProjectStatusLabels } from '~/api/schema.graphql';
 import { ProjectListQueryVariables } from '../../scenes/Projects/List/projects.graphql';
 import { getProjectUrl } from '../../scenes/Projects/useProjectId';

--- a/src/components/ProjectMemberCard/ProjectMemberCard.stories.tsx
+++ b/src/components/ProjectMemberCard/ProjectMemberCard.stories.tsx
@@ -2,7 +2,6 @@ import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import { sampleSize } from 'lodash';
 import { DateTime } from 'luxon';
-import React from 'react';
 import { RoleList } from '../../api';
 import { ProjectMemberCardFragment } from './ProjectMember.graphql';
 import { ProjectMemberCard as ProjectMemberCardComponent } from './ProjectMemberCard';

--- a/src/components/ProjectMemberCard/ProjectMemberCard.tsx
+++ b/src/components/ProjectMemberCard/ProjectMemberCard.tsx
@@ -7,7 +7,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import * as React from 'react';
 import { RoleLabels } from '~/api/schema.graphql';
 import { labelsFrom } from '~/common';
 import { Avatar } from '../Avatar';

--- a/src/components/ProjectMembersSummary/ProjectMembersSummary.stories.tsx
+++ b/src/components/ProjectMembersSummary/ProjectMembersSummary.stories.tsx
@@ -1,5 +1,4 @@
 import { Card } from '@material-ui/core';
-import React from 'react';
 import {
   ProjectMembersSummary,
   ProjectMembersSummaryProps,

--- a/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
+++ b/src/components/ProjectMembersSummary/ProjectMembersSummary.tsx
@@ -1,5 +1,4 @@
 import { Group } from '@material-ui/icons';
-import * as React from 'react';
 import { MemberListSummary, MemberSummaryItem } from '../MemberListSummary';
 import { ProjectMemberListFragment } from './ProjectMembersSummary.graphql';
 

--- a/src/components/Redacted/Redacted.tsx
+++ b/src/components/Redacted/Redacted.tsx
@@ -1,7 +1,6 @@
 import { makeStyles, Tooltip, TooltipProps } from '@material-ui/core';
 import { Skeleton, SkeletonProps } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { ChildrenProp } from '~/common';
 

--- a/src/components/Routing/ButtonLink.stories.tsx
+++ b/src/components/Routing/ButtonLink.stories.tsx
@@ -1,5 +1,4 @@
 import { select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { ButtonLink, ButtonLinkProps } from './ButtonLink';
 
 export default {

--- a/src/components/Routing/ButtonLink.tsx
+++ b/src/components/Routing/ButtonLink.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonProps } from '@material-ui/core';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { Link, LinkProps } from 'react-router-dom';
 import { Merge } from 'type-fest';

--- a/src/components/Routing/CardActionAreaLink.stories.tsx
+++ b/src/components/Routing/CardActionAreaLink.stories.tsx
@@ -1,5 +1,4 @@
 import { Box, Card, CardContent, Grid, Typography } from '@material-ui/core';
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { CardActionAreaLink } from './CardActionAreaLink';
 

--- a/src/components/Routing/CardActionAreaLink.tsx
+++ b/src/components/Routing/CardActionAreaLink.tsx
@@ -1,5 +1,4 @@
 import { CardActionArea, CardActionAreaProps } from '@material-ui/core';
-import * as React from 'react';
 import { forwardRef } from 'react';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { Link, LinkProps } from 'react-router-dom';

--- a/src/components/Routing/Link.stories.tsx
+++ b/src/components/Routing/Link.stories.tsx
@@ -1,5 +1,4 @@
 import { select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Link, LinkProps } from './Link';
 
 export default {

--- a/src/components/Routing/Link.tsx
+++ b/src/components/Routing/Link.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { Link as MUILink, LinkProps as MUILinkProps } from '@material-ui/core';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { Link as RRLink, LinkProps as RRLinkProps } from 'react-router-dom';
 import { Merge } from 'type-fest';

--- a/src/components/Routing/ListItemLink.stories.tsx
+++ b/src/components/Routing/ListItemLink.stories.tsx
@@ -1,6 +1,5 @@
 import { List, ListItemIcon, ListItemText } from '@material-ui/core';
 import { Home as HomeIcon, Launch, Lock } from '@material-ui/icons';
-import React from 'react';
 import { ListItemLink as LIL } from './ListItemLink';
 
 export default { title: 'Components/Routing' };

--- a/src/components/Routing/ListItemLink.tsx
+++ b/src/components/Routing/ListItemLink.tsx
@@ -1,5 +1,5 @@
 import { ListItem, ListItemProps } from '@material-ui/core';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { Link, LinkProps, useMatch } from 'react-router-dom';
 import { assert } from 'ts-essentials';

--- a/src/components/Routing/MenuItemLink.stories.tsx
+++ b/src/components/Routing/MenuItemLink.stories.tsx
@@ -1,5 +1,4 @@
 import { MenuList, Paper } from '@material-ui/core';
-import React from 'react';
 import { MenuItemLink as MIL } from './MenuItemLink';
 
 export default { title: 'Components/Routing' };

--- a/src/components/Routing/MenuItemLink.tsx
+++ b/src/components/Routing/MenuItemLink.tsx
@@ -1,5 +1,5 @@
 import { MenuItem, MenuItemProps } from '@material-ui/core';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { Link, LinkProps } from 'react-router-dom';
 import { assert } from 'ts-essentials';

--- a/src/components/Routing/Navigate.tsx
+++ b/src/components/Routing/Navigate.tsx
@@ -1,5 +1,4 @@
 import type { Path, To } from 'history';
-import * as React from 'react';
 import { createContext, ReactElement, useContext } from 'react';
 import type {
   NavigateFunction,

--- a/src/components/Routing/decorators.stories.tsx
+++ b/src/components/Routing/decorators.stories.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@material-ui/core';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Code } from '../Debug';
 

--- a/src/components/Sensitivity/Sensitivity.stories.tsx
+++ b/src/components/Sensitivity/Sensitivity.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean, select } from '@storybook/addon-knobs';
-import React from 'react';
 import { Sensitivity as SensitivityComponent } from './Sensitivity';
 
 export default { title: 'Components' };

--- a/src/components/Sensitivity/Sensitivity.tsx
+++ b/src/components/Sensitivity/Sensitivity.tsx
@@ -3,7 +3,6 @@ import { VerifiedUserOutlined } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { meanBy } from 'lodash';
-import * as React from 'react';
 import { Sensitivity as SensitivityType } from '~/api/schema.graphql';
 
 const possible: SensitivityType[] = ['Low', 'Medium', 'High'];

--- a/src/components/Sensitivity/SensitivityIcon.tsx
+++ b/src/components/Sensitivity/SensitivityIcon.tsx
@@ -1,7 +1,6 @@
 import { colors, makeStyles, SvgIconProps, Tooltip } from '@material-ui/core';
 import { VerifiedUser } from '@material-ui/icons';
 import clsx from 'clsx';
-import * as React from 'react';
 import { Sensitivity as SensitivityType } from '~/api/schema.graphql';
 
 const useStyles = makeStyles(({ palette }) => ({

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -3,7 +3,6 @@ import { Close } from '@material-ui/icons';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { OptionsObject, useSnackbar } from 'notistack';
-import * as React from 'react';
 
 export default {
   title: 'Components/Snackbar',

--- a/src/components/Snackbar/SnackbarProvider.tsx
+++ b/src/components/Snackbar/SnackbarProvider.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 import { Report as ErrorIcon } from '@material-ui/icons';
 import { SnackbarProvider as BaseSnackbarProvider } from 'notistack';
-import * as React from 'react';
 import { ChildrenProp } from '~/common';
 
 const useStyles = makeStyles(({ palette }) => ({

--- a/src/components/Sort/SortButtonDialog.tsx
+++ b/src/components/Sort/SortButtonDialog.tsx
@@ -1,6 +1,5 @@
 import { Button, Dialog, DialogContent } from '@material-ui/core';
 import { useEffect, useState } from 'react';
-import * as React from 'react';
 import { useDialog } from '../Dialog';
 import { DialogTitle } from '../Dialog/DialogTitle';
 import { SortControl, SortControlProps } from './SortControl';

--- a/src/components/Sort/SortControl.tsx
+++ b/src/components/Sort/SortControl.tsx
@@ -1,7 +1,6 @@
 import { RadioGroup } from '@material-ui/core';
 import { isString } from 'lodash';
 import { ReactNode } from 'react';
-import * as React from 'react';
 import { Order } from '~/api/schema.graphql';
 
 export interface SortValue<T> {

--- a/src/components/Sort/SortOption.tsx
+++ b/src/components/Sort/SortOption.tsx
@@ -6,7 +6,6 @@ import {
   useRadioGroup,
 } from '@material-ui/core';
 import { ReactNode } from 'react';
-import * as React from 'react';
 import { Order } from '~/api/schema.graphql';
 
 const useStyles = makeStyles(({ typography, spacing }) => ({

--- a/src/components/Table/ChangesetAwareTable.tsx
+++ b/src/components/Table/ChangesetAwareTable.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
 import { Components, MTableBodyRow } from 'material-table';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { ChangesetBadge, DiffMode } from '../Changeset';
 import { Cell, Container, Table, TableProps } from './Table';
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Table as TableComponent } from './Table';
 
 export default { title: 'Components/Table' };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -18,7 +18,7 @@ import MaterialTable, {
   MaterialTableProps,
   MTableCell,
 } from 'material-table';
-import React, { forwardRef, useMemo } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { Merge } from 'type-fest';
 
 export type TableProps<RowData extends Record<string, any>> = Merge<

--- a/src/components/Table/TableLoading.tsx
+++ b/src/components/Table/TableLoading.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import * as React from 'react';
 
 const useStyles = makeStyles(({ shape }) => ({
   loading: {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,5 +1,5 @@
 import loadable, { LoadableComponentMethods } from '@loadable/component';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import {
   ChangesetAwareTableProps,
   ChangesetRowData,

--- a/src/components/TogglePinButton/TogglePinButton.tsx
+++ b/src/components/TogglePinButton/TogglePinButton.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { makeStyles, Theme, Tooltip, TooltipProps } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList, ListIdentifier, removeItemFromList } from '~/api';
 import { IconButton, IconButtonProps } from '../IconButton';

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,6 +1,5 @@
 import { Typography as TP, TypographyVariant } from '@material-ui/core';
 import { boolean, select } from '@storybook/addon-knobs';
-import React from 'react';
 
 export default { title: 'Components' };
 

--- a/src/components/Upload/DraggablePaper.tsx
+++ b/src/components/Upload/DraggablePaper.tsx
@@ -1,5 +1,5 @@
 import { Paper, PaperProps } from '@material-ui/core';
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import Draggable, { DraggableData, DraggableEvent } from 'react-draggable';
 import { useWindowSize } from 'react-use';
 

--- a/src/components/Upload/DropzoneOverlay.tsx
+++ b/src/components/Upload/DropzoneOverlay.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, Typography } from '@material-ui/core';
 import clsx from 'clsx';
-import React from 'react';
 
 /**
  * This component requires a parent with a `position` value,

--- a/src/components/Upload/UploadContext.tsx
+++ b/src/components/Upload/UploadContext.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, {
+import {
   createContext,
   useCallback,
   useContext,

--- a/src/components/Upload/UploadFilesForm.tsx
+++ b/src/components/Upload/UploadFilesForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Except } from 'type-fest';
 import { DialogForm, DialogFormProps } from '../Dialog/DialogForm';
 import { DropzoneField, SubmitError } from '../form';

--- a/src/components/Upload/UploadItem.stories.tsx
+++ b/src/components/Upload/UploadItem.stories.tsx
@@ -1,7 +1,6 @@
 import { Card } from '@material-ui/core';
 import { action } from '@storybook/addon-actions';
 import { number, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { UploadItem as UI } from './UploadItem';
 
 export default { title: 'Components/Upload/UploadItem' };

--- a/src/components/Upload/UploadItem.tsx
+++ b/src/components/Upload/UploadItem.tsx
@@ -8,7 +8,6 @@ import {
   Cancel as CancelIcon,
   CheckCircle as CheckIcon,
 } from '@material-ui/icons';
-import React from 'react';
 import { UploadFile } from './Reducer';
 
 const useStyles = makeStyles(({ palette, spacing }) => ({

--- a/src/components/Upload/UploadItems.tsx
+++ b/src/components/Upload/UploadItems.tsx
@@ -1,5 +1,4 @@
 import { Box, makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import { UploadFile, UploadState } from './Reducer/uploadTypings';
 import { UploadItem } from './UploadItem';
 

--- a/src/components/Upload/UploadManager.tsx
+++ b/src/components/Upload/UploadManager.tsx
@@ -12,7 +12,7 @@ import {
   Minimize as MinimizeIcon,
 } from '@material-ui/icons';
 import clsx from 'clsx';
-import React, { memo, ReactNode, useState } from 'react';
+import { memo, ReactNode, useState } from 'react';
 import { useMountedState } from 'react-use';
 import { ChildrenProp } from '~/common';
 import { useSession } from '../Session';

--- a/src/components/Upload/UploadManagerContext.tsx
+++ b/src/components/Upload/UploadManagerContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
 import { ChildrenProp } from '~/common';
 
 const initialUploadManagerContext = {

--- a/src/components/UserListItemCard/LandscapeCard.stories.tsx
+++ b/src/components/UserListItemCard/LandscapeCard.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { UserListItemCardLandscape as UserCard } from './LandscapeCard';
 import { generateUserListItem } from './PortraitCard.stories';
 

--- a/src/components/UserListItemCard/LandscapeCard.tsx
+++ b/src/components/UserListItemCard/LandscapeCard.tsx
@@ -1,7 +1,6 @@
 import { Card, CardContent, makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import * as React from 'react';
 import { square } from '~/common';
 import { UsersQueryVariables } from '../../scenes/Users/List/users.graphql';
 import { Avatar } from '../Avatar';

--- a/src/components/UserListItemCard/PortraitCard.stories.tsx
+++ b/src/components/UserListItemCard/PortraitCard.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { UserListItemCardPortrait as UserCard } from './PortraitCard';
 import { UserListItemFragment } from './UserListItem.graphql';
 

--- a/src/components/UserListItemCard/PortraitCard.tsx
+++ b/src/components/UserListItemCard/PortraitCard.tsx
@@ -8,7 +8,6 @@ import {
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { ReactNode } from 'react';
-import * as React from 'react';
 import { square } from '~/common';
 import { Avatar } from '../Avatar';
 import { ButtonLink, CardActionAreaLink } from '../Routing';

--- a/src/components/files/FileActions/DeleteFile.tsx
+++ b/src/components/files/FileActions/DeleteFile.tsx
@@ -1,6 +1,5 @@
 import { MutationFunctionOptions, useMutation } from '@apollo/client';
 import { Typography } from '@material-ui/core';
-import React from 'react';
 import { Except } from 'type-fest';
 import { DialogForm, DialogFormProps } from '../../Dialog/DialogForm';
 import { SubmitError } from '../../form';

--- a/src/components/files/FileActions/FileActionsContext.tsx
+++ b/src/components/files/FileActions/FileActionsContext.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   useCallback,
   useContext,

--- a/src/components/files/FileActions/FileActionsMenu.tsx
+++ b/src/components/files/FileActions/FileActionsMenu.tsx
@@ -19,7 +19,7 @@ import {
   Event as UpdateDate,
 } from '@material-ui/icons';
 import { startCase } from 'lodash';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { IconButton, IconButtonProps } from '../../IconButton';
 import { FileAction } from './FileAction.enum';

--- a/src/components/files/FileActions/FileVersions.tsx
+++ b/src/components/files/FileActions/FileVersions.tsx
@@ -10,7 +10,7 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import { FileActionItem, PermittedActions } from '../FileActions';
 import {
   FileVersionItem_FileVersion_Fragment as FileVersion,
@@ -60,12 +60,12 @@ export const FileVersions = (props: FileVersionsProps) => {
       <List dense>
         {loading
           ? [0, 1, 2].map((item) => (
-              <React.Fragment key={item}>
+              <Fragment key={item}>
                 <div className={classes.skeleton}>
                   <Skeleton variant="rect" width={400} height={50} />
                 </div>
                 {item < 2 && <Divider />}
-              </React.Fragment>
+              </Fragment>
             ))
           : versions.map((version, index) => (
               <Fragment key={version.id}>

--- a/src/components/files/FileActions/RenameFile.tsx
+++ b/src/components/files/FileActions/RenameFile.tsx
@@ -1,5 +1,4 @@
 import { MutationFunctionOptions, useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { RenameFileInput } from '~/api/schema.graphql';
 import { DialogForm, DialogFormProps } from '../../Dialog/DialogForm';

--- a/src/components/files/FilePreview/CsvPreview.tsx
+++ b/src/components/files/FilePreview/CsvPreview.tsx
@@ -1,5 +1,5 @@
 import Papa, { ParseResult } from 'papaparse';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 import {

--- a/src/components/files/FilePreview/EmailPreview.tsx
+++ b/src/components/files/FilePreview/EmailPreview.tsx
@@ -2,7 +2,6 @@ import MsgReader from '@freiraum/msgreader';
 import { makeStyles, Typography } from '@material-ui/core';
 import parseHtml from 'html-react-parser';
 import { DateTime } from 'luxon';
-import * as React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { mapFromList } from '~/common';
 import { FormattedDateTime } from '../../Formatters';

--- a/src/components/files/FilePreview/ExcelPreview.tsx
+++ b/src/components/files/FilePreview/ExcelPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import * as XLSX from 'xlsx';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';

--- a/src/components/files/FilePreview/FilePreview.tsx
+++ b/src/components/files/FilePreview/FilePreview.tsx
@@ -9,7 +9,7 @@ import {
   Grid,
   makeStyles,
 } from '@material-ui/core';
-import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import { saveAs } from '../../../common/FileSaver';
 import { NonDirectoryActionItem } from '../FileActions';
 import {

--- a/src/components/files/FilePreview/HtmlPreview.tsx
+++ b/src/components/files/FilePreview/HtmlPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 

--- a/src/components/files/FilePreview/NativePreview.tsx
+++ b/src/components/files/FilePreview/NativePreview.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 

--- a/src/components/files/FilePreview/PdfPreview.tsx
+++ b/src/components/files/FilePreview/PdfPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Document, DocumentProps, Page, pdfjs } from 'react-pdf';
 import { useFileActions } from '../FileActions/FileActionsContext';
 import { PreviewerProps } from './FilePreview';

--- a/src/components/files/FilePreview/PlainTextPreview.tsx
+++ b/src/components/files/FilePreview/PlainTextPreview.tsx
@@ -1,5 +1,5 @@
 import { makeStyles } from '@material-ui/core';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 

--- a/src/components/files/FilePreview/PreviewError.tsx
+++ b/src/components/files/FilePreview/PreviewError.tsx
@@ -1,5 +1,4 @@
 import { Grid, makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 
 const useStyles = makeStyles(({ breakpoints }) => ({
   text: {

--- a/src/components/files/FilePreview/PreviewLoading.tsx
+++ b/src/components/files/FilePreview/PreviewLoading.tsx
@@ -1,5 +1,4 @@
 import { CircularProgress, Grid, makeStyles } from '@material-ui/core';
-import React from 'react';
 
 const useStyles = makeStyles(() => ({
   container: {

--- a/src/components/files/FilePreview/PreviewNotSupported.tsx
+++ b/src/components/files/FilePreview/PreviewNotSupported.tsx
@@ -1,6 +1,5 @@
 import { Button, makeStyles, ModalProps, Typography } from '@material-ui/core';
 import { CloudDownload } from '@material-ui/icons';
-import React from 'react';
 import { NonDirectoryActionItem } from '../FileActions';
 import { useDownloadFile } from '../hooks';
 

--- a/src/components/files/FilePreview/PreviewPagination.tsx
+++ b/src/components/files/FilePreview/PreviewPagination.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@material-ui/core';
 import { Pagination, PaginationProps } from '@material-ui/lab';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { ChildrenProp } from '~/common';
 import { useFileActions } from '../FileActions';
 

--- a/src/components/files/FilePreview/RtfPreview.tsx
+++ b/src/components/files/FilePreview/RtfPreview.tsx
@@ -1,6 +1,6 @@
 import * as rtfToHTML from '@iarna/rtf-to-html';
 import parse from 'html-react-parser';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 

--- a/src/components/files/FilePreview/SpreadsheetView.tsx
+++ b/src/components/files/FilePreview/SpreadsheetView.tsx
@@ -1,5 +1,5 @@
 import { makeStyles, Tab, Tabs } from '@material-ui/core';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { XLSX$Utils } from 'xlsx';
 import { useFileActions } from '../FileActions';
 

--- a/src/components/files/FilePreview/WordPreview.tsx
+++ b/src/components/files/FilePreview/WordPreview.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import parse from 'html-react-parser';
 import mammoth, { MammothOptions } from 'mammoth';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { PreviewerProps } from './FilePreview';
 import { PreviewLoading } from './PreviewLoading';
 

--- a/src/components/files/FileVersionItem/FileVersionItem.stories.tsx
+++ b/src/components/files/FileVersionItem/FileVersionItem.stories.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@material-ui/core';
 import { optionsKnob, text } from '@storybook/addon-knobs';
 import { DateTime } from 'luxon';
-import React from 'react';
 import { FileAction } from '../FileActions';
 import { FileVersionItem as FVI } from './FileVersionItem';
 

--- a/src/components/files/FileVersionItem/FileVersionItem.tsx
+++ b/src/components/files/FileVersionItem/FileVersionItem.tsx
@@ -5,7 +5,6 @@ import {
   ListItemText,
   makeStyles,
 } from '@material-ui/core';
-import React from 'react';
 import { useDateTimeFormatter } from '../../Formatters';
 import {
   FileActionsPopup as ActionsMenu,

--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.stories.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.stories.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@material-ui/core';
 import { boolean, number } from '@storybook/addon-knobs';
-import React from 'react';
 import { FilesOverviewCard as Card } from './FilesOverviewCard';
 
 export default { title: 'components' };

--- a/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
+++ b/src/components/files/FilesOverviewCard/FilesOverviewCard.tsx
@@ -1,5 +1,4 @@
 import { LibraryBooksOutlined } from '@material-ui/icons';
-import React from 'react';
 import {
   FieldOverviewCard,
   FieldOverviewCardProps,

--- a/src/components/form/AlphaLowercaseField.tsx
+++ b/src/components/form/AlphaLowercaseField.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   FormattedTextField,
   FormattedTextFieldProps,

--- a/src/components/form/AutocompleteField.stories.tsx
+++ b/src/components/form/AutocompleteField.stories.tsx
@@ -1,7 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
 import { startCase } from 'lodash';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { csv } from '../../util';
 import { AutocompleteField } from './AutocompleteField';

--- a/src/components/form/AutocompleteField.tsx
+++ b/src/components/form/AutocompleteField.tsx
@@ -7,7 +7,7 @@ import {
 } from '@material-ui/core';
 import { Autocomplete, AutocompleteProps, Value } from '@material-ui/lab';
 import { identity } from 'lodash';
-import React, { useCallback, useLayoutEffect } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
 import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';

--- a/src/components/form/CheckboxField.stories.tsx
+++ b/src/components/form/CheckboxField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { CheckboxField as CB } from './CheckboxField';
 

--- a/src/components/form/CheckboxField.tsx
+++ b/src/components/form/CheckboxField.tsx
@@ -7,7 +7,7 @@ import {
   FormControlProps,
   FormHelperText,
 } from '@material-ui/core';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 

--- a/src/components/form/DateField.stories.tsx
+++ b/src/components/form/DateField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { date } from '../knobs.stories';
 import { DateField } from './DateField';

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -13,7 +13,7 @@ import { ParsableDate } from '@material-ui/pickers/constants/prop-types';
 import type { SharedPickerProps } from '@material-ui/pickers/Picker/makePickerWithState';
 import type { ResponsiveWrapper } from '@material-ui/pickers/wrappers/ResponsiveWrapper';
 import { DateTime } from 'luxon';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Except } from 'type-fest';
 import { CalendarDate, Nullable } from '~/common';
 import { FieldConfig, useField } from './useField';

--- a/src/components/form/Dropzone.stories.tsx
+++ b/src/components/form/Dropzone.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { DropzoneField as DF } from './Dropzone';
 
 export default { title: 'Components/Forms/Fields' };

--- a/src/components/form/Dropzone.tsx
+++ b/src/components/form/Dropzone.tsx
@@ -10,7 +10,6 @@ import {
 } from '@material-ui/core';
 import { Clear as ClearIcon } from '@material-ui/icons';
 import clsx from 'clsx';
-import React from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Except } from 'type-fest';
 import { fileIcon } from '../files/fileTypes';

--- a/src/components/form/EmailField.stories.tsx
+++ b/src/components/form/EmailField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { EmailField } from './EmailField';
 import { FieldSpy } from './FieldSpy';

--- a/src/components/form/EmailField.tsx
+++ b/src/components/form/EmailField.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Except } from 'type-fest';
 import {
   FormattedTextField,

--- a/src/components/form/EnumField.stories.tsx
+++ b/src/components/form/EnumField.stories.tsx
@@ -2,7 +2,6 @@ import { Box } from '@material-ui/core';
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { startCase } from 'lodash';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { Except } from 'type-fest';
 import { csv } from '../../util';

--- a/src/components/form/EnumField.tsx
+++ b/src/components/form/EnumField.tsx
@@ -14,7 +14,6 @@ import {
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import clsx from 'clsx';
 import { sortBy } from 'lodash';
-import * as React from 'react';
 import {
   createContext,
   FocusEvent,

--- a/src/components/form/FieldGroup.stories.tsx
+++ b/src/components/form/FieldGroup.stories.tsx
@@ -1,6 +1,5 @@
 import { TextField } from '@material-ui/core';
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { FieldGroup as FG } from './FieldGroup';
 

--- a/src/components/form/FieldGroup.tsx
+++ b/src/components/form/FieldGroup.tsx
@@ -1,5 +1,5 @@
 import { compact } from 'lodash';
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 import { ChildrenProp } from '~/common';
 
 export const FieldGroupContext = createContext('');

--- a/src/components/form/FieldSpy.tsx
+++ b/src/components/form/FieldSpy.tsx
@@ -1,5 +1,5 @@
 import { getIn } from 'final-form';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm, useFormState } from 'react-final-form';
 import { Code } from '../Debug';
 

--- a/src/components/form/FormattedTextField.stories.tsx
+++ b/src/components/form/FormattedTextField.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { FormattedTextField } from './FormattedTextField';
 

--- a/src/components/form/FormattedTextField.tsx
+++ b/src/components/form/FormattedTextField.tsx
@@ -1,6 +1,6 @@
 import { TextField, TextFieldProps } from '@material-ui/core';
 import { identity } from 'lodash';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRifm } from 'rifm';
 import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';

--- a/src/components/form/Lookup/EthnoArt/EthnoArtField.stories.tsx
+++ b/src/components/form/Lookup/EthnoArt/EthnoArtField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/Film/FilmField.stories.tsx
+++ b/src/components/form/Lookup/Film/FilmField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/Language/LanguageField.stories.tsx
+++ b/src/components/form/Lookup/Language/LanguageField.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/Location/LocationFields.stories.tsx
+++ b/src/components/form/Lookup/Location/LocationFields.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/LookupField.tsx
+++ b/src/components/form/Lookup/LookupField.tsx
@@ -14,7 +14,7 @@ import {
   Value,
 } from '@material-ui/lab';
 import { camelCase, last, uniqBy, upperFirst } from 'lodash';
-import React, {
+import {
   ComponentType,
   useCallback,
   useEffect,

--- a/src/components/form/Lookup/Organization/OrganizationField.stories.tsx
+++ b/src/components/form/Lookup/Organization/OrganizationField.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/Project/ProjectFields.stories.tsx
+++ b/src/components/form/Lookup/Project/ProjectFields.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/Story/StoryField.stories.tsx
+++ b/src/components/form/Lookup/Story/StoryField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/Lookup/User/User.stories.tsx
+++ b/src/components/form/Lookup/User/User.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { ChildrenProp } from '~/common';
 import { FieldSpy } from '../../FieldSpy';

--- a/src/components/form/NumberField.stories.tsx
+++ b/src/components/form/NumberField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { Code } from '../Debug';
 import { NumberField } from './NumberField';

--- a/src/components/form/NumberField.tsx
+++ b/src/components/form/NumberField.tsx
@@ -1,6 +1,5 @@
 import { InputAdornment, makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import React from 'react';
 import { Except } from 'type-fest';
 import { Nullable } from '~/common';
 import {

--- a/src/components/form/PasswordField.stories.tsx
+++ b/src/components/form/PasswordField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { PasswordField as PF } from './PasswordField';
 

--- a/src/components/form/PasswordField.tsx
+++ b/src/components/form/PasswordField.tsx
@@ -1,6 +1,6 @@
 import { IconButton, IconButtonProps, InputAdornment } from '@material-ui/core';
 import { Visibility, VisibilityOff } from '@material-ui/icons';
-import React, { ComponentType, useState } from 'react';
+import { ComponentType, useState } from 'react';
 import { Except } from 'type-fest';
 import { TextField, TextFieldProps } from './TextField';
 

--- a/src/components/form/SelectField.tsx
+++ b/src/components/form/SelectField.tsx
@@ -9,7 +9,6 @@ import {
 } from '@material-ui/core';
 import { identity } from 'lodash';
 import { ReactNode } from 'react';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';

--- a/src/components/form/SubmitButton.stories.tsx
+++ b/src/components/form/SubmitButton.stories.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@material-ui/core';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { sleep } from '../../util';
 import { SubmitButton as SB, SubmitAction } from './SubmitButton';

--- a/src/components/form/SubmitButton.tsx
+++ b/src/components/form/SubmitButton.tsx
@@ -1,7 +1,6 @@
 import { FORM_ERROR, setIn } from 'final-form';
 import { cloneDeep, omit } from 'lodash';
-import { useMemo } from 'react';
-import * as React from 'react';
+import { Children, useMemo } from 'react';
 import { useForm, useFormState } from 'react-final-form';
 import { ProgressButton, ProgressButtonProps } from '../ProgressButton';
 
@@ -116,7 +115,7 @@ export const SubmitButton = ({
       }
       progress={spinner && submitting && values.submitAction === action}
     >
-      {React.Children.count(children) ? children : 'Submit'}
+      {Children.count(children) ? children : 'Submit'}
     </ProgressButton>
   );
 };

--- a/src/components/form/SubmitError.tsx
+++ b/src/components/form/SubmitError.tsx
@@ -1,5 +1,4 @@
 import { Typography, TypographyProps } from '@material-ui/core';
-import * as React from 'react';
 import { useFormState } from 'react-final-form';
 
 /**

--- a/src/components/form/SwitchField.stories.tsx
+++ b/src/components/form/SwitchField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { SwitchField } from './SwitchField';
 

--- a/src/components/form/SwitchField.tsx
+++ b/src/components/form/SwitchField.tsx
@@ -7,7 +7,7 @@ import {
   Switch,
   SwitchProps,
 } from '@material-ui/core';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
 

--- a/src/components/form/TextField.stories.tsx
+++ b/src/components/form/TextField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { TextField as TF } from './TextField';
 

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -2,7 +2,6 @@ import {
   TextField as MuiTextField,
   TextFieldProps as MuiTextFieldProps,
 } from '@material-ui/core';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';

--- a/src/components/form/VersesField.stories.tsx
+++ b/src/components/form/VersesField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { SubmitButton } from '.';
 import { books } from '../../common/biblejs';

--- a/src/components/form/VersesField.tsx
+++ b/src/components/form/VersesField.tsx
@@ -11,7 +11,7 @@ import {
   AutocompleteRenderInputParams,
 } from '@material-ui/lab';
 import { isEqual, uniqWith } from 'lodash';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Except } from 'type-fest';
 import {
   formatScriptureRange,

--- a/src/components/form/YearField.stories.tsx
+++ b/src/components/form/YearField.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
-import React from 'react';
 import { Form } from 'react-final-form';
 import { FieldSpy } from './FieldSpy';
 import { YearField } from './YearField';

--- a/src/components/form/YearField.tsx
+++ b/src/components/form/YearField.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { NumberField, NumberFieldProps } from './NumberField';
 import { max, min } from './validators';
 

--- a/src/components/posts/CreatePost/CreatePost.tsx
+++ b/src/components/posts/CreatePost/CreatePost.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreatePostInput } from '~/api/schema.graphql';

--- a/src/components/posts/DeletePost/DeletePost.tsx
+++ b/src/components/posts/DeletePost/DeletePost.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { Typography } from '@material-ui/core';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { removeItemFromList } from '../../../api';
 import { DialogForm, DialogFormProps } from '../../Dialog/DialogForm';

--- a/src/components/posts/EditPost/EditPost.tsx
+++ b/src/components/posts/EditPost/EditPost.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdatePostInput } from '~/api/schema.graphql';
 import { PostForm, PostFormProps } from '../PostForm';

--- a/src/components/posts/PostForm/PostForm.tsx
+++ b/src/components/posts/PostForm/PostForm.tsx
@@ -1,6 +1,5 @@
 import { Grid } from '@material-ui/core';
 import { without } from 'lodash';
-import React from 'react';
 import {
   PostShareability,
   PostShareabilityLabels,

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -1,6 +1,5 @@
 import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { useDialog } from '../Dialog';
 import { Fab } from '../Fab';

--- a/src/components/posts/PostListItemCard/PostListItemCard.tsx
+++ b/src/components/posts/PostListItemCard/PostListItemCard.tsx
@@ -10,7 +10,6 @@ import {
 import { MoreVert } from '@material-ui/icons';
 import clsx from 'clsx';
 import { useState } from 'react';
-import * as React from 'react';
 import { PostShareabilityLabels } from '~/api/schema.graphql';
 import { canEditAny, square } from '~/common';
 import { useDialog } from '../../Dialog';

--- a/src/components/posts/PostListItemCard/PostListItemMenu.tsx
+++ b/src/components/posts/PostListItemCard/PostListItemMenu.tsx
@@ -7,7 +7,6 @@ import {
   MenuProps,
 } from '@material-ui/core';
 import { Delete as DeleteIcon, Edit as EditIcon } from '@material-ui/icons';
-import React from 'react';
 
 interface PostListItemMenuProps extends Partial<MenuProps> {
   onEdit: () => void;

--- a/src/scenes/Authentication/AuthContent.tsx
+++ b/src/scenes/Authentication/AuthContent.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 const useStyles = makeStyles(({ spacing }) => ({
   root: {

--- a/src/scenes/Authentication/AuthLayout.tsx
+++ b/src/scenes/Authentication/AuthLayout.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, ThemeProvider } from '@material-ui/core';
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { ChildrenProp } from '~/common';
 import { Picture } from '../../components/Picture';

--- a/src/scenes/Authentication/AuthWaiting.tsx
+++ b/src/scenes/Authentication/AuthWaiting.tsx
@@ -1,5 +1,4 @@
 import { CircularProgress } from '@material-ui/core';
-import React from 'react';
 import { AuthContent } from './AuthContent';
 
 export const AuthWaiting = () => (

--- a/src/scenes/Authentication/ChangePassword/ChangePassword.stories.tsx
+++ b/src/scenes/Authentication/ChangePassword/ChangePassword.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ChangePassword as Form } from './ChangePassword';
 
 export default { title: 'Components' };

--- a/src/scenes/Authentication/ChangePassword/ChangePassword.tsx
+++ b/src/scenes/Authentication/ChangePassword/ChangePassword.tsx
@@ -2,7 +2,6 @@ import { useMutation } from '@apollo/client';
 import { Grid, makeStyles } from '@material-ui/core';
 import { Mutator } from 'final-form';
 import { useSnackbar } from 'notistack';
-import * as React from 'react';
 import { Except } from 'type-fest';
 import { MutationChangePasswordArgs } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Authentication/ForgotPassword/ForgotPassword.tsx
+++ b/src/scenes/Authentication/ForgotPassword/ForgotPassword.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Except } from 'type-fest';
 import { handleFormError } from '../../../api';

--- a/src/scenes/Authentication/ForgotPassword/ForgotPasswordForm.stories.tsx
+++ b/src/scenes/Authentication/ForgotPassword/ForgotPasswordForm.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { ForgotPasswordForm as Form } from './ForgotPasswordForm';
 
 export default { title: 'Scenes/Authentication/ForgotPassword' };

--- a/src/scenes/Authentication/ForgotPassword/ForgotPasswordForm.tsx
+++ b/src/scenes/Authentication/ForgotPassword/ForgotPasswordForm.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import { Form, FormProps } from 'react-final-form';
 import {
   EmailField,

--- a/src/scenes/Authentication/ForgotPassword/ForgotPasswordSuccess.tsx
+++ b/src/scenes/Authentication/ForgotPassword/ForgotPasswordSuccess.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import { ButtonLink } from '../../../components/Routing';
 import { AuthContent } from '../AuthContent';
 

--- a/src/scenes/Authentication/Login/Login.stories.tsx
+++ b/src/scenes/Authentication/Login/Login.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { LoginForm as Form } from './LoginForm';
 
 export default { title: 'Scenes/Authentication/Login' };

--- a/src/scenes/Authentication/Login/Login.tsx
+++ b/src/scenes/Authentication/Login/Login.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { FORM_ERROR } from 'final-form';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useSearchParams } from 'react-router-dom';
 import { useMountedState } from 'react-use';

--- a/src/scenes/Authentication/Login/LoginForm.tsx
+++ b/src/scenes/Authentication/Login/LoginForm.tsx
@@ -2,7 +2,7 @@ import { makeStyles, Typography } from '@material-ui/core';
 import clsx from 'clsx';
 import { Decorator, Mutator } from 'final-form';
 import { sample } from 'lodash';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Form, FormProps } from 'react-final-form';
 import { LoginInput } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Authentication/Logout/Logout.tsx
+++ b/src/scenes/Authentication/Logout/Logout.tsx
@@ -1,5 +1,4 @@
 import { useApolloClient, useMutation } from '@apollo/client';
-import * as React from 'react';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthWaiting } from '../AuthWaiting';

--- a/src/scenes/Authentication/Register/Register.stories.tsx
+++ b/src/scenes/Authentication/Register/Register.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { RegisterForm as Form } from './RegisterForm';
 
 export default { title: 'Scenes/Authentication/Register' };

--- a/src/scenes/Authentication/Register/Register.tsx
+++ b/src/scenes/Authentication/Register/Register.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { DateTime } from 'luxon';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Except } from 'type-fest';

--- a/src/scenes/Authentication/Register/RegisterForm.tsx
+++ b/src/scenes/Authentication/Register/RegisterForm.tsx
@@ -1,6 +1,5 @@
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { Decorator, Mutator } from 'final-form';
-import React from 'react';
 import { Form, FormProps } from 'react-final-form';
 import { RegisterInput } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Authentication/ResetPassword/ResetPassword.stories.tsx
+++ b/src/scenes/Authentication/ResetPassword/ResetPassword.stories.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { ResetPasswordForm as Form } from './ResetPasswordForm';
 
 export default { title: 'Scenes/Authentication/ResetPassword' };

--- a/src/scenes/Authentication/ResetPassword/ResetPassword.tsx
+++ b/src/scenes/Authentication/ResetPassword/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { Except } from 'type-fest';

--- a/src/scenes/Authentication/ResetPassword/ResetPasswordForm.tsx
+++ b/src/scenes/Authentication/ResetPassword/ResetPasswordForm.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, Typography } from '@material-ui/core';
 import { Decorator, Mutator } from 'final-form';
-import React from 'react';
 import { Form, FormProps } from 'react-final-form';
 import {
   blurOnSubmit,

--- a/src/scenes/Authentication/ResetPassword/ResetPasswordSuccess.tsx
+++ b/src/scenes/Authentication/ResetPassword/ResetPasswordSuccess.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import { ButtonLink } from '../../../components/Routing';
 import { AuthContent } from '../AuthContent';
 

--- a/src/scenes/Engagement/CeremonyCard/CeremonyCard.stories.tsx
+++ b/src/scenes/Engagement/CeremonyCard/CeremonyCard.stories.tsx
@@ -1,5 +1,4 @@
 import { boolean, select } from '@storybook/addon-knobs';
-import React from 'react';
 import { date } from '../../../components/knobs.stories';
 import { CeremonyCard as Card } from './CeremonyCard';
 

--- a/src/scenes/Engagement/CeremonyCard/CeremonyCard.tsx
+++ b/src/scenes/Engagement/CeremonyCard/CeremonyCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { UpdateCeremonyInput } from '~/api/schema.graphql';
 import { canEditAny } from '~/common';
 import { useDialog } from '../../../components/Dialog';

--- a/src/scenes/Engagement/CeremonyCard/CeremonyPlanned.tsx
+++ b/src/scenes/Engagement/CeremonyCard/CeremonyPlanned.tsx
@@ -10,7 +10,6 @@ import {
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { useSnackbar } from 'notistack';
-import * as React from 'react';
 import {
   CeremonyCardFragment,
   UpdateCeremonyDocument,

--- a/src/scenes/Engagement/CeremonyCard/LargeDate.tsx
+++ b/src/scenes/Engagement/CeremonyCard/LargeDate.tsx
@@ -2,7 +2,6 @@ import { makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
 import { useState } from 'react';
-import * as React from 'react';
 import { CalendarDate, Nullable, SecuredProp } from '~/common';
 import { useDateFormatter } from '../../../components/Formatters';
 import { Redacted } from '../../../components/Redacted';

--- a/src/scenes/Engagement/Delete/DeleteEngagement.tsx
+++ b/src/scenes/Engagement/Delete/DeleteEngagement.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { Tooltip, Typography } from '@material-ui/core';
 import { DeleteOutline } from '@material-ui/icons';
-import * as React from 'react';
 import { removeItemFromList } from '~/api';
 import { callAll } from '~/common';
 import {

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { setIn } from 'final-form';
 import { compact, keyBy, pick, startCase } from 'lodash';
-import React, { ComponentType, useMemo } from 'react';
+import { ComponentType, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
 import { invalidateProps } from '~/api';
 import {

--- a/src/scenes/Engagement/EditEngagement/EngagementWorkflowDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EngagementWorkflowDialog.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
-import React from 'react';
 import { Except } from 'type-fest';
 import {
   EngagementStatus,

--- a/src/scenes/Engagement/Engagement.tsx
+++ b/src/scenes/Engagement/Engagement.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client';
-import React from 'react';
 import { useChangesetAwareIdFromUrl } from '../../components/Changeset';
 import { NotFoundPage } from '../../components/Error';
 import { EngagementDocument } from './Engagement.graphql';

--- a/src/scenes/Engagement/EngagementDetailLoading.tsx
+++ b/src/scenes/Engagement/EngagementDetailLoading.tsx
@@ -1,7 +1,6 @@
 import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import { Breadcrumb } from '../../components/Breadcrumb';
 import { DataButton } from '../../components/DataButton';
 import { Fab } from '../../components/Fab';

--- a/src/scenes/Engagement/Engagements.tsx
+++ b/src/scenes/Engagement/Engagements.tsx
@@ -1,5 +1,4 @@
 import loadable from '@loadable/component';
-import React from 'react';
 import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { splicePath } from '~/common';
 import { ChangesetContext } from '../../components/Changeset';

--- a/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import {

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -1,6 +1,5 @@
 import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
 import { DateRange } from '@material-ui/icons';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import {
   EngagementStatusLabels,

--- a/src/scenes/Engagement/InternshipEngagement/MentorCard/MentorCard.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/MentorCard/MentorCard.tsx
@@ -6,7 +6,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import * as React from 'react';
 import { ReactElement, ReactNode } from 'react';
 import { square } from '~/common';
 import { Avatar } from '../../../../components/Avatar';

--- a/src/scenes/Engagement/LanguageEngagement/Ceremony/CeremonyForm.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Ceremony/CeremonyForm.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { isEqual, noop } from 'lodash';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Form, FormSpy } from 'react-final-form';
 import { UpdateCeremonyInput } from '~/api/schema.graphql';
 import { DateField, FieldGroup } from '../../../../components/form';

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { callAll } from '~/common';

--- a/src/scenes/Engagement/LanguageEngagement/DatesForm/DatesForm.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/DatesForm/DatesForm.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { isEqual, noop } from 'lodash';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Form, FormSpy } from 'react-final-form';
 import { UpdateLanguageEngagementInput as UpdateEngagementInput } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
@@ -6,7 +6,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { DateRange, Edit } from '@material-ui/icons';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { EngagementStatusLabels } from '~/api/schema.graphql';
 import { canEditAny, labelFrom, Many } from '~/common';

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -1,6 +1,5 @@
 import { Card, Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import React from 'react';
 import { Fab } from '../../../components/Fab';
 import { ResponsiveDivider } from '../../../components/ResponsiveDivider';
 import { Link } from '../../../components/Routing';

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/EthnoArt/CreateEthnoArt.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/EthnoArt/CreateEthnoArt.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreateEthnoArtInput } from '~/api/schema.graphql';

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Film/CreateFilm.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreateFilmInput } from '~/api/schema.graphql';

--- a/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Product/Producibles/Story/CreateStory.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreateStoryInput } from '~/api/schema.graphql';

--- a/src/scenes/Engagement/LanguageEngagement/ProgressAndPlanning/ProgressAndPlanning.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/ProgressAndPlanning/ProgressAndPlanning.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { pick } from 'lodash';
-import React from 'react';
 import {
   ProductMethodology as Methodology,
   ProductApproachLabels,

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Navigate } from '../../components/Routing';
 
 export const Home = () => <Navigate to="/projects" replace />;

--- a/src/scenes/Languages/Create/CreateLanguage.tsx
+++ b/src/scenes/Languages/Create/CreateLanguage.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreateLanguage as CreateLanguageType } from '~/api/schema.graphql';

--- a/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
+++ b/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
@@ -5,7 +5,6 @@ import {
   NotInterested,
 } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import * as React from 'react';
 import { Redacted } from '../../../../components/Redacted';
 import { Link } from '../../../../components/Routing';
 import { FirstScriptureFragment } from './FirstScripture.graphql';

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQuery } from '@apollo/client';
 import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add, Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { removeItemFromList } from '~/api';

--- a/src/scenes/Languages/Detail/LanguagePostList.tsx
+++ b/src/scenes/Languages/Detail/LanguagePostList.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useListQuery } from '../../../components/List';
 import { PostableIdFragment } from '../../../components/posts/PostableId.graphql';
 import { PostList } from '../../../components/posts/PostList';

--- a/src/scenes/Languages/Detail/LeastOfThese/LeastOfThese.tsx
+++ b/src/scenes/Languages/Detail/LeastOfThese/LeastOfThese.tsx
@@ -1,5 +1,4 @@
 import { Grid } from '@material-ui/core';
-import React from 'react';
 import { BooleanProperty } from '../../../../components/BooleanProperty';
 import { PaperTooltip } from '../../../../components/PaperTooltip';
 import { LeastOfTheseFragment } from './LeastOfThese.graphql';

--- a/src/scenes/Languages/Edit/AddLocationToLanguageForm.tsx
+++ b/src/scenes/Languages/Edit/AddLocationToLanguageForm.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { DisplayLocationFragment } from '~/common';
 import {

--- a/src/scenes/Languages/Edit/EditLanguage.tsx
+++ b/src/scenes/Languages/Edit/EditLanguage.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdateLanguage } from '~/api/schema.graphql';
 import { CalendarDate } from '~/common';

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -1,6 +1,6 @@
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { setIn } from 'final-form';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import {
   CreateLanguage,

--- a/src/scenes/Languages/Languages.tsx
+++ b/src/scenes/Languages/Languages.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '../../components/Error';
 import { LanguageDetail } from './Detail';

--- a/src/scenes/Languages/List/LanguageFilterOptions.tsx
+++ b/src/scenes/Languages/List/LanguageFilterOptions.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { SensitivityList } from '~/api/schema.graphql';
 import { EnumField, SwitchField } from '../../../components/form';
 import {

--- a/src/scenes/Languages/List/LanguageList.tsx
+++ b/src/scenes/Languages/List/LanguageList.tsx
@@ -13,7 +13,7 @@ import {
   TabPanel,
 } from '@material-ui/lab';
 import { omit, pickBy } from 'lodash';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Language } from '~/api/schema.graphql';
 import { simpleSwitch } from '~/common';

--- a/src/scenes/Languages/List/LanguageSortOptions.stories.tsx
+++ b/src/scenes/Languages/List/LanguageSortOptions.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Language } from '../../../api';
 import { SortButtonDialog, SortValue } from '../../../components/Sort';
 import { LanguageSortOptions } from './LanguageSortOptions';

--- a/src/scenes/Languages/List/LanguageSortOptions.tsx
+++ b/src/scenes/Languages/List/LanguageSortOptions.tsx
@@ -1,5 +1,4 @@
 import { ComponentType } from 'react';
-import * as React from 'react';
 import { Language } from '~/api/schema.graphql';
 import { SortOption, SortOptionProps } from '../../../components/Sort';
 

--- a/src/scenes/Locations/Create/CreateLocation.tsx
+++ b/src/scenes/Locations/Create/CreateLocation.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import { CreateLocation as CreateLocationType } from '~/api/schema.graphql';
 import { ButtonLink } from '../../../components/Routing';

--- a/src/scenes/Locations/Detail/LocationDetail.tsx
+++ b/src/scenes/Locations/Detail/LocationDetail.tsx
@@ -3,7 +3,6 @@ import { makeStyles, Typography } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { LocationTypeLabels } from '~/api/schema.graphql';

--- a/src/scenes/Locations/Edit/EditLocation.tsx
+++ b/src/scenes/Locations/Edit/EditLocation.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdateLocation } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Locations/LocationForm/FundingAccount/CreateFundingAccount.tsx
+++ b/src/scenes/Locations/LocationForm/FundingAccount/CreateFundingAccount.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { CreateFundingAccountInput } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Locations/LocationForm/LocationForm.tsx
+++ b/src/scenes/Locations/LocationForm/LocationForm.tsx
@@ -1,5 +1,4 @@
 import { Grid } from '@material-ui/core';
-import React from 'react';
 import { Merge } from 'type-fest';
 import {
   CreateLocation,

--- a/src/scenes/Locations/Locations.tsx
+++ b/src/scenes/Locations/Locations.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '../../components/Error';
 import { LocationDetail } from './Detail';

--- a/src/scenes/Organizations/Create/CreateOrganization.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganization.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import {
   CreateOrganizationDocument,

--- a/src/scenes/Organizations/Create/CreateOrganizationForm.stories.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganizationForm.stories.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@material-ui/core';
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { useDialog } from '../../../components/Dialog';
 import { CreateOrganizationForm as Form } from './CreateOrganizationForm';
 

--- a/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
+++ b/src/scenes/Organizations/Create/CreateOrganizationForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CreateOrganizationInput } from '~/api/schema.graphql';
 import {
   DialogForm,

--- a/src/scenes/Partners/Create/CreatePartner.tsx
+++ b/src/scenes/Partners/Create/CreatePartner.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';

--- a/src/scenes/Partners/Create/CreatePartnerForm.tsx
+++ b/src/scenes/Partners/Create/CreatePartnerForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   DialogForm,
   DialogFormProps,

--- a/src/scenes/Partners/Detail/AddressCard.tsx
+++ b/src/scenes/Partners/Detail/AddressCard.tsx
@@ -8,7 +8,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import { canEditAny } from '~/common';
 import { Redacted } from '../../../components/Redacted';
 import { PartnerDetailsFragment } from './PartnerDetail.graphql';

--- a/src/scenes/Partners/Detail/PartnerDetail.tsx
+++ b/src/scenes/Partners/Detail/PartnerDetail.tsx
@@ -11,7 +11,6 @@ import {
 import { Add, Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import { Many } from 'lodash';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { listOrPlaceholders, square } from '~/common';

--- a/src/scenes/Partners/Detail/PartnerPostList.tsx
+++ b/src/scenes/Partners/Detail/PartnerPostList.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useListQuery } from '../../../components/List';
 import { PostableIdFragment } from '../../../components/posts/PostableId.graphql';
 import { PostList } from '../../../components/posts/PostList';

--- a/src/scenes/Partners/Detail/PartnerTypesCard.tsx
+++ b/src/scenes/Partners/Detail/PartnerTypesCard.tsx
@@ -9,7 +9,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import {
   FinancialReportingTypeLabels,
   PartnerTypeLabels,

--- a/src/scenes/Partners/Edit/EditPartner.tsx
+++ b/src/scenes/Partners/Edit/EditPartner.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
-import React, { ComponentType, useMemo } from 'react';
+import { ComponentType, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
 import {
   FinancialReportingTypeLabels,

--- a/src/scenes/Partners/List/PartnerList.tsx
+++ b/src/scenes/Partners/List/PartnerList.tsx
@@ -12,7 +12,7 @@ import {
   TabContext,
   TabPanel,
 } from '@material-ui/lab';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { simpleSwitch } from '~/common';
 import { useNumberFormatter } from '../../../components/Formatters';

--- a/src/scenes/Partners/List/PartnerSortOptions.tsx
+++ b/src/scenes/Partners/List/PartnerSortOptions.tsx
@@ -1,5 +1,4 @@
 import { ComponentType } from 'react';
-import * as React from 'react';
 import { Partner } from '~/api/schema.graphql';
 import { SortOption, SortOptionProps } from '../../../components/Sort';
 

--- a/src/scenes/Partners/Partners.tsx
+++ b/src/scenes/Partners/Partners.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '../../components/Error';
 import { PartnerDetail } from './Detail';

--- a/src/scenes/Partnerships/Create/CreatePartnership.tsx
+++ b/src/scenes/Partnerships/Create/CreatePartnership.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreatePartnership as CreatePartnershipType } from '~/api/schema.graphql';

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { Decorator } from 'final-form';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { onUpdateInvalidateProps, removeItemFromList } from '~/api';
 import { PeriodType, UpdatePartnershipInput } from '~/api/schema.graphql';

--- a/src/scenes/Partnerships/List/PartnershipList.tsx
+++ b/src/scenes/Partnerships/List/PartnershipList.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Breadcrumb } from '../../../components/Breadcrumb';
 import { useDialog } from '../../../components/Dialog';

--- a/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
+++ b/src/scenes/Partnerships/PartnershipForm/PartnershipForm.tsx
@@ -1,6 +1,5 @@
 import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
-import React from 'react';
 import {
   FinancialReportingTypeLabels,
   PartnershipAgreementStatus,

--- a/src/scenes/Products/Create/CreateProduct.tsx
+++ b/src/scenes/Products/Create/CreateProduct.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@apollo/client';
 import { Breadcrumbs, makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 import { addItemToList, handleFormError } from '~/api';

--- a/src/scenes/Products/Detail/ProductDetail.tsx
+++ b/src/scenes/Products/Detail/ProductDetail.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@apollo/client';
 import { Grid, makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import {
   idForUrl,
   useChangesetAwareIdFromUrl,

--- a/src/scenes/Products/Detail/ProductDetailHeader.tsx
+++ b/src/scenes/Products/Detail/ProductDetailHeader.tsx
@@ -7,7 +7,6 @@ import {
 } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Breadcrumb } from '../../../components/Breadcrumb';
 import { EngagementBreadcrumb } from '../../../components/EngagementBreadcrumb';

--- a/src/scenes/Products/Detail/ProductInfo.tsx
+++ b/src/scenes/Products/Detail/ProductInfo.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { ProductMediumLabels, ProductStepLabels } from '~/api/schema.graphql';
 import { displayMethodologyWithLabel, mapFromList } from '~/common';
 import {

--- a/src/scenes/Products/Detail/Progress/ProgressIcon.tsx
+++ b/src/scenes/Products/Detail/Progress/ProgressIcon.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@material-ui/core';
 import { CheckCircle } from '@material-ui/icons';
-import React from 'react';
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
   done: {

--- a/src/scenes/Products/Detail/Progress/StepEditDialog.tsx
+++ b/src/scenes/Products/Detail/Progress/StepEditDialog.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { Alert } from '@material-ui/lab';
 import { isBoolean } from 'lodash';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { ProductStepLabels, ProgressMeasurement } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Products/Detail/Progress/StepList.tsx
+++ b/src/scenes/Products/Detail/Progress/StepList.tsx
@@ -1,5 +1,4 @@
 import { Grid, Typography } from '@material-ui/core';
-import React from 'react';
 import { ProgressMeasurement } from '~/api/schema.graphql';
 import { useDialog } from '../../../../components/Dialog';
 import {

--- a/src/scenes/Products/Detail/Progress/StepProgress.tsx
+++ b/src/scenes/Products/Detail/Progress/StepProgress.tsx
@@ -6,7 +6,6 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core';
-import React from 'react';
 import { ProductStepLabels, ProgressMeasurement } from '~/api/schema.graphql';
 import { StepProgressFragment } from './ProductProgress.graphql';
 import { ProgressIcon } from './ProgressIcon';

--- a/src/scenes/Products/Edit/EditProduct.tsx
+++ b/src/scenes/Products/Edit/EditProduct.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@apollo/client';
 import { Breadcrumbs, makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 import {

--- a/src/scenes/Products/List/ProductList.tsx
+++ b/src/scenes/Products/List/ProductList.tsx
@@ -1,5 +1,4 @@
 import { Card, makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import { getChangeset } from '~/api';
 import { IdFragment } from '~/common';
 import { List, useListQuery } from '../../../components/List';

--- a/src/scenes/Products/ProductForm/CompletionSection.tsx
+++ b/src/scenes/Products/ProductForm/CompletionSection.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, Typography } from '@material-ui/core';
-import React from 'react';
 import {
   AutocompleteField,
   AutocompleteFieldProps,

--- a/src/scenes/Products/ProductForm/DefaultAccordion.tsx
+++ b/src/scenes/Products/ProductForm/DefaultAccordion.tsx
@@ -10,7 +10,7 @@ import { ExpandMore } from '@material-ui/icons';
 import clsx from 'clsx';
 import { FormState } from 'final-form';
 import { get, startCase } from 'lodash';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Except } from 'type-fest';
 import { useFieldName } from '../../../components/form';
 import { ProductKey } from './ProductFormFields';

--- a/src/scenes/Products/ProductForm/GoalsSection.tsx
+++ b/src/scenes/Products/ProductForm/GoalsSection.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@material-ui/core';
 import { ToggleButton } from '@material-ui/lab';
-import React from 'react';
 import { displayProductTypes } from '~/common';
 import { EnumField } from '../../../components/form';
 import { productTypes } from './constants';

--- a/src/scenes/Products/ProductForm/MediumsSection.tsx
+++ b/src/scenes/Products/ProductForm/MediumsSection.tsx
@@ -1,5 +1,4 @@
 import { ToggleButton } from '@material-ui/lab';
-import React from 'react';
 import { ProductMediumLabels, ProductMediumList } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { EnumField } from '../../../components/form';

--- a/src/scenes/Products/ProductForm/MethodologySection.tsx
+++ b/src/scenes/Products/ProductForm/MethodologySection.tsx
@@ -1,6 +1,5 @@
 import { Typography } from '@material-ui/core';
 import { ToggleButton } from '@material-ui/lab';
-import React from 'react';
 import { ProductApproachLabels } from '~/api/schema.graphql';
 import {
   ApproachMethodologies,

--- a/src/scenes/Products/ProductForm/OtherProductSection.tsx
+++ b/src/scenes/Products/ProductForm/OtherProductSection.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { TextField } from '../../../components/form';
 import { DefaultAccordion } from './DefaultAccordion';
 import { SectionProps } from './ProductFormFields';

--- a/src/scenes/Products/ProductForm/PartnershipProducingMediumsSection.tsx
+++ b/src/scenes/Products/ProductForm/PartnershipProducingMediumsSection.tsx
@@ -1,5 +1,4 @@
 import { List, ListItem, Typography } from '@material-ui/core';
-import React from 'react';
 import { ProductMedium, ProductMediumLabels } from '~/api/schema.graphql';
 import { AutocompleteField } from '../../../components/form';
 import { PartnershipForLabelFragment } from '../Detail/ProductDetail.graphql';

--- a/src/scenes/Products/ProductForm/ProductForm.tsx
+++ b/src/scenes/Products/ProductForm/ProductForm.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/core';
 import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
-import React from 'react';
 import { Form, FormProps } from 'react-final-form';
 import { Except, Merge } from 'type-fest';
 import {

--- a/src/scenes/Products/ProductForm/ProductFormFields.tsx
+++ b/src/scenes/Products/ProductForm/ProductFormFields.tsx
@@ -1,5 +1,5 @@
 import { FormApi, FormState } from 'final-form';
-import React, { ComponentType, useState } from 'react';
+import { ComponentType, useState } from 'react';
 import { Except, Merge, UnionToIntersection } from 'type-fest';
 import { FieldGroup, SecuredEditableKeys } from '../../../components/form';
 import { CompletionSection } from './CompletionSection';

--- a/src/scenes/Products/ProductForm/ProductSection.tsx
+++ b/src/scenes/Products/ProductForm/ProductSection.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@material-ui/core';
-import React, { ComponentType, useEffect } from 'react';
+import { ComponentType, useEffect } from 'react';
 import { displayProductTypes } from '~/common';
 import { FieldConfig } from '../../../components/form';
 import {

--- a/src/scenes/Products/ProductForm/ProgressMeasurementSection.tsx
+++ b/src/scenes/Products/ProductForm/ProgressMeasurementSection.tsx
@@ -1,5 +1,4 @@
 import { ToggleButton } from '@material-ui/lab';
-import React from 'react';
 import {
   ProgressMeasurement,
   ProgressMeasurementLabels,

--- a/src/scenes/Products/ProductForm/ProgressTargetSection.tsx
+++ b/src/scenes/Products/ProductForm/ProgressTargetSection.tsx
@@ -1,5 +1,4 @@
 import { ToggleButton } from '@material-ui/lab';
-import React from 'react';
 import { NumberField } from '../../../components/form';
 import { SectionProps } from './ProductFormFields';
 import { SecuredAccordion } from './SecuredAccordion';

--- a/src/scenes/Products/ProductForm/ScriptureReferencesSection.tsx
+++ b/src/scenes/Products/ProductForm/ScriptureReferencesSection.tsx
@@ -1,5 +1,4 @@
 import { ToggleButton } from '@material-ui/lab';
-import React from 'react';
 import { UnspecifiedScripturePortion } from '~/api/schema.graphql';
 import {
   entries,

--- a/src/scenes/Products/ProductForm/SecuredAccordion.tsx
+++ b/src/scenes/Products/ProductForm/SecuredAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Merge } from 'type-fest';
 import {
   SecuredField,

--- a/src/scenes/Products/ProductForm/StepsSection.tsx
+++ b/src/scenes/Products/ProductForm/StepsSection.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { ToggleButton } from '@material-ui/lab';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { ProductStepLabels } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { EnumField } from '../../../components/form';

--- a/src/scenes/Products/ProductForm/VersesCountField.tsx
+++ b/src/scenes/Products/ProductForm/VersesCountField.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { getBookTotalVerses } from '../../../common/biblejs';
 import { NumberField, NumberFieldProps } from '../../../components/form';

--- a/src/scenes/Products/ProductLoadError.tsx
+++ b/src/scenes/Products/ProductLoadError.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Except } from 'type-fest';
 import { Error, ErrorProps } from '../../components/Error';
 

--- a/src/scenes/Products/Products.tsx
+++ b/src/scenes/Products/Products.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { ChangesetContext } from '../../components/Changeset';
 import { NotFoundRoute } from '../../components/Error';

--- a/src/scenes/ProgressReports/Detail/ProductTable.tsx
+++ b/src/scenes/ProgressReports/Detail/ProductTable.tsx
@@ -1,6 +1,6 @@
 import { sortBy, uniq } from 'lodash';
 import { Column } from 'material-table';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { ProductStep, ProductStepLabels } from '~/api/schema.graphql';
 import { bookIndexFromName } from '../../../common/biblejs';
 import { Link } from '../../../components/Routing';

--- a/src/scenes/ProgressReports/Detail/ProductTableList.tsx
+++ b/src/scenes/ProgressReports/Detail/ProductTableList.tsx
@@ -1,7 +1,6 @@
 import { Grid, GridProps, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { groupBy } from 'lodash';
-import React from 'react';
 import Table from '../../../components/Table/Table';
 import { ProductTable } from './ProductTable';
 import { ProgressOfProductForReportFragment } from './ProgressReportDetail.graphql';

--- a/src/scenes/ProgressReports/Detail/ProgressReportCard.tsx
+++ b/src/scenes/ProgressReports/Detail/ProgressReportCard.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from '@material-ui/core';
-import React from 'react';
 import {
   DefinedFileCard,
   DefinedFileCardProps,

--- a/src/scenes/ProgressReports/Detail/ProgressReportDetail.tsx
+++ b/src/scenes/ProgressReports/Detail/ProgressReportDetail.tsx
@@ -10,7 +10,6 @@ import {
 } from '@material-ui/core';
 import { Edit, SkipNextRounded as SkipIcon } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useWindowSize } from 'react-use';
 import { Breadcrumb } from '../../../components/Breadcrumb';

--- a/src/scenes/ProgressReports/Detail/ProgressSummaryCard.tsx
+++ b/src/scenes/ProgressReports/Detail/ProgressSummaryCard.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, Grid, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { ProgressSummaryFragment } from './ProgressReportDetail.graphql';
 
 interface ProgressSummaryCardProps {

--- a/src/scenes/ProgressReports/List/ProgressReportList.tsx
+++ b/src/scenes/ProgressReports/List/ProgressReportList.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client';
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   idForUrl,

--- a/src/scenes/ProgressReports/ProgressReports.tsx
+++ b/src/scenes/ProgressReports/ProgressReports.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { ChangesetContext } from '../../components/Changeset';
 import { NotFoundRoute } from '../../components/Error';

--- a/src/scenes/Projects/Budget/ProjectBudget.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudget.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/client';
 import { Breadcrumbs, Grid, makeStyles, Typography } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Breadcrumb } from '../../../components/Breadcrumb';
 import { DefinedFileCard } from '../../../components/DefinedFileCard';

--- a/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
+++ b/src/scenes/Projects/Budget/ProjectBudgetRecords.tsx
@@ -1,7 +1,7 @@
 import { useApolloClient, useMutation } from '@apollo/client';
 import { sortBy, sumBy } from 'lodash';
 import { Column, Components } from 'material-table';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { onUpdateChangeFragment, readFragment } from '~/api';
 import { RecalculateChangesetDiffFragmentDoc as RecalculateChangesetDiff } from '~/common/fragments';
 import {

--- a/src/scenes/Projects/ChangeRequest/Create/CreateProjectChangeRequest.tsx
+++ b/src/scenes/Projects/ChangeRequest/Create/CreateProjectChangeRequest.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import {

--- a/src/scenes/Projects/ChangeRequest/List/ProjectChangeRequestList.tsx
+++ b/src/scenes/Projects/ChangeRequest/List/ProjectChangeRequestList.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Breadcrumb } from '../../../../components/Breadcrumb';
 import { useDialog } from '../../../../components/Dialog';

--- a/src/scenes/Projects/ChangeRequest/Update/UpdateProjectChangeRequest.tsx
+++ b/src/scenes/Projects/ChangeRequest/Update/UpdateProjectChangeRequest.tsx
@@ -1,5 +1,4 @@
 import { useMutation } from '@apollo/client';
-import React from 'react';
 import { Except } from 'type-fest';
 import { removeItemFromList } from '~/api';
 import {

--- a/src/scenes/Projects/Create/CreateProject.tsx
+++ b/src/scenes/Projects/Create/CreateProject.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '../../../api';
 import { ButtonLink } from '../../../components/Routing';

--- a/src/scenes/Projects/Create/CreateProjectForm.stories.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.stories.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@material-ui/core';
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 import { useDialog } from '../../../components/Dialog';
 import { CreateProjectForm as Form } from './CreateProjectForm';
 

--- a/src/scenes/Projects/Create/CreateProjectForm.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CreateProjectInput, ProjectTypeList } from '~/api/schema.graphql';
 import {
   DialogForm,

--- a/src/scenes/Projects/Files/CreateProjectDirectory.tsx
+++ b/src/scenes/Projects/Files/CreateProjectDirectory.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreateDirectoryInput } from '~/api/schema.graphql';

--- a/src/scenes/Projects/Files/DirectoryBreadcrumb.tsx
+++ b/src/scenes/Projects/Files/DirectoryBreadcrumb.tsx
@@ -1,6 +1,5 @@
 import { fade, makeStyles } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { useDrop } from 'react-dnd';
 import { Breadcrumb, BreadcrumbProps } from '../../../components/Breadcrumb';
 import { DndFileNode, DropOnDirResult } from './util';

--- a/src/scenes/Projects/Files/FileRow.tsx
+++ b/src/scenes/Projects/Files/FileRow.tsx
@@ -3,7 +3,7 @@ import { makeStyles, useForkRef } from '@material-ui/core';
 import clsx from 'clsx';
 import { MTableBodyRow } from 'material-table';
 import { useSnackbar } from 'notistack';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import { addItemToList, removeItemFromList } from '~/api';

--- a/src/scenes/Projects/Files/Files.tsx
+++ b/src/scenes/Projects/Files/Files.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '../../../components/Error';
 import { ProjectFilesList } from './ProjectFilesList';

--- a/src/scenes/Projects/Files/NodeDragPreview.tsx
+++ b/src/scenes/Projects/Files/NodeDragPreview.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, Paper } from '@material-ui/core';
-import React from 'react';
 import { FileNodeInfoFragment } from '../../../components/files/files.graphql';
 import { fileIcon } from '../../../components/files/fileTypes';
 import { parseFileNameAndExtension } from '../../../components/Formatters';

--- a/src/scenes/Projects/Files/NodePreviewLayer.tsx
+++ b/src/scenes/Projects/Files/NodePreviewLayer.tsx
@@ -1,5 +1,4 @@
 import { makeStyles } from '@material-ui/core';
-import * as React from 'react';
 import { useDragLayer } from 'react-dnd';
 import { NodeDragPreview } from './NodeDragPreview';
 import { DndFileNode } from './util';

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@material-ui/core';
 import { CreateNewFolder, Publish } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';

--- a/src/scenes/Projects/List/ProjectFilterOptions.stories.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FilterButtonDialog } from '../../../components/Filter';
 import { ProjectFilterOptions } from './ProjectFilterOptions';
 

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from '@material-ui/core';
-import * as React from 'react';
 import {
   ProjectStatusLabels,
   ProjectStatusList,

--- a/src/scenes/Projects/List/ProjectList.tsx
+++ b/src/scenes/Projects/List/ProjectList.tsx
@@ -13,7 +13,7 @@ import {
   TabPanel,
 } from '@material-ui/lab';
 import { omit, pickBy } from 'lodash';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Project } from '~/api/schema.graphql';
 import { simpleSwitch } from '~/common';

--- a/src/scenes/Projects/List/ProjectSortOptions.stories.tsx
+++ b/src/scenes/Projects/List/ProjectSortOptions.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Project } from '../../../api';
 import { SortButtonDialog, SortValue } from '../../../components/Sort';
 import { ProjectSortOptions } from './ProjectSortOptions';

--- a/src/scenes/Projects/List/ProjectSortOptions.tsx
+++ b/src/scenes/Projects/List/ProjectSortOptions.tsx
@@ -1,5 +1,4 @@
 import { ComponentType } from 'react';
-import * as React from 'react';
 import { Project } from '~/api/schema.graphql';
 import { SortOption, SortOptionProps } from '../../../components/Sort';
 

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
 import { addItemToList } from '~/api';
 import {

--- a/src/scenes/Projects/Members/List/ProjectMembersList.tsx
+++ b/src/scenes/Projects/Members/List/ProjectMembersList.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
-import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Breadcrumb } from '../../../../components/Breadcrumb';
 import { useDialog } from '../../../../components/Dialog';

--- a/src/scenes/Projects/Members/Update/UpdateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Update/UpdateProjectMember.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery } from '@apollo/client';
 import { Container } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import React from 'react';
 import { Except } from 'type-fest';
 import { removeItemFromList } from '~/api';
 import {

--- a/src/scenes/Projects/Overview/PresetInventory/PresetInventoryButton.tsx
+++ b/src/scenes/Projects/Overview/PresetInventory/PresetInventoryButton.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { Typography } from '@material-ui/core';
-import React from 'react';
 import { readFragment } from '../../../../api';
 import { IconButton } from '../../../../components/IconButton';
 import {

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -3,7 +3,6 @@ import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Add, DateRange, Edit, Publish } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import clsx from 'clsx';
-import React from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Helmet } from 'react-helmet-async';
 import { ProjectStepLabels } from '~/api/schema.graphql';

--- a/src/scenes/Projects/Overview/ProjectPostList.tsx
+++ b/src/scenes/Projects/Overview/ProjectPostList.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useListQuery } from '../../../components/List';
 import { PostableIdFragment } from '../../../components/posts/PostableId.graphql';
 import { PostList } from '../../../components/posts/PostList';

--- a/src/scenes/Projects/Projects.tsx
+++ b/src/scenes/Projects/Projects.tsx
@@ -1,5 +1,4 @@
 import loadable from '@loadable/component';
-import React from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { splicePath } from '~/common';
 import { ChangesetContext } from '../../components/Changeset';

--- a/src/scenes/Projects/Reports/ProjectReports.tsx
+++ b/src/scenes/Projects/Reports/ProjectReports.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@apollo/client';
-import React from 'react';
 import { ReportType } from '~/api/schema.graphql';
 import { Error } from '../../../components/Error';
 import { PeriodicReportsList } from '../../../components/PeriodicReports/PeriodicReportsList';

--- a/src/scenes/Projects/Reports/SkipPeriodicReportDialog.tsx
+++ b/src/scenes/Projects/Reports/SkipPeriodicReportDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdatePeriodicReportInput } from '~/api/schema.graphql';
 import {

--- a/src/scenes/Projects/Reports/UpdatePeriodicReportDialog.tsx
+++ b/src/scenes/Projects/Reports/UpdatePeriodicReportDialog.tsx
@@ -1,5 +1,5 @@
 import { pick } from 'lodash';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { UpdatePeriodicReportInput } from '~/api/schema.graphql';
 import { ExtractStrict, many, Many } from '~/common';

--- a/src/scenes/Projects/Update/ProjectWorkflowDialog.tsx
+++ b/src/scenes/Projects/Update/ProjectWorkflowDialog.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
-import React from 'react';
 import { Except } from 'type-fest';
 import {
   ProjectStep,

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import { pick } from 'lodash';
-import React, { ComponentType, useMemo } from 'react';
+import { ComponentType, useMemo } from 'react';
 import { Except, Merge } from 'type-fest';
 import { invalidateProps } from '~/api';
 import { SensitivityList, UpdateProject } from '~/api/schema.graphql';

--- a/src/scenes/Root/AppMetadata.tsx
+++ b/src/scenes/Root/AppMetadata.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 export const AppMetadata = () => (

--- a/src/scenes/Root/Creates/CreateDialogProviders.tsx
+++ b/src/scenes/Root/Creates/CreateDialogProviders.tsx
@@ -1,5 +1,4 @@
 import { noop } from 'lodash';
-import * as React from 'react';
 import { createContext } from 'react';
 import { Power } from '~/api/schema.graphql';
 import { ChildrenProp } from '~/common';

--- a/src/scenes/Root/Creates/CreateMenu.tsx
+++ b/src/scenes/Root/Creates/CreateMenu.tsx
@@ -1,7 +1,6 @@
 import { ButtonProps, Menu, MenuItem, MenuProps } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 import { startCase } from 'lodash';
-import * as React from 'react';
 import { useContext, useState } from 'react';
 import { Power } from '~/api/schema.graphql';
 import { CreateButton } from '../../../components/CreateButton';

--- a/src/scenes/Root/CssBaseline.tsx
+++ b/src/scenes/Root/CssBaseline.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, CssBaseline as MuiCssBaseline } from '@material-ui/core';
-import * as React from 'react';
 
 const useStyles = makeStyles(() => ({
   // Use @global basically never

--- a/src/scenes/Root/Header/Header.tsx
+++ b/src/scenes/Root/Header/Header.tsx
@@ -1,5 +1,4 @@
 import { makeStyles } from '@material-ui/core';
-import * as React from 'react';
 import { HeaderSearch } from './HeaderSearch';
 import { ProfileToolbar } from './ProfileToolbar';
 

--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.stories.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { HeaderSearch as HS } from './HeaderSearch';
 
 export default { title: 'Scenes/Root/Header' };

--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
@@ -1,6 +1,5 @@
 import { InputAdornment, makeStyles } from '@material-ui/core';
 import { Search } from '@material-ui/icons';
-import * as React from 'react';
 import { Form } from 'react-final-form';
 import { useNavigate } from 'react-router-dom';
 import { TextField } from '../../../../components/form';

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.stories.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ProfileMenu as PM } from './ProfileMenu';
 
 export default { title: 'Scenes/Root/Header' };

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
@@ -7,7 +7,6 @@ import {
   Typography,
   useTheme,
 } from '@material-ui/core';
-import * as React from 'react';
 import { useDialog } from '../../../../components/Dialog';
 import { MenuItemLink } from '../../../../components/Routing';
 import { useSession } from '../../../../components/Session';

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.stories.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ProfileToolbar as PT } from './ProfileToolbar';
 
 export default { title: 'Scenes/Root/Header' };

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
@@ -7,7 +7,6 @@ import {
 } from '@material-ui/core';
 import { AccountCircle, MoreVert, NotificationsNone } from '@material-ui/icons';
 import { useState } from 'react';
-import * as React from 'react';
 import { useSession } from '../../../../components/Session';
 import { ProfileMenu } from '../ProfileMenu';
 import { UserActionsMenu } from '../UserActionsMenu';

--- a/src/scenes/Root/Header/UserActionsMenu/UserActionsMenu.stories.tsx
+++ b/src/scenes/Root/Header/UserActionsMenu/UserActionsMenu.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { UserActionsMenu as UAM } from './UserActionsMenu';
 
 export default { title: 'Scenes/Root/Header' };

--- a/src/scenes/Root/Header/UserActionsMenu/UserActionsMenu.tsx
+++ b/src/scenes/Root/Header/UserActionsMenu/UserActionsMenu.tsx
@@ -11,7 +11,6 @@ import {
   VisibilityOff as HideIcon,
   Visibility as ShowIcon,
 } from '@material-ui/icons';
-import React from 'react';
 import { useUpload, useUploadManager } from '../../../../components/Upload';
 
 const useStyles = makeStyles(({ spacing }) => ({

--- a/src/scenes/Root/MainLayout.tsx
+++ b/src/scenes/Root/MainLayout.tsx
@@ -1,5 +1,4 @@
 import { makeStyles } from '@material-ui/core';
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { useAuthRequired } from '../Authentication';
 import { CreateDialogProviders } from './Creates';

--- a/src/scenes/Root/Root.tsx
+++ b/src/scenes/Root/Root.tsx
@@ -1,5 +1,4 @@
 import loadable from '@loadable/component';
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '../../components/Error';
 import { useIdentifyInLogRocket, useSession } from '../../components/Session';

--- a/src/scenes/Root/Sidebar/Sidebar.stories.tsx
+++ b/src/scenes/Root/Sidebar/Sidebar.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Sidebar as SidebarComponent } from './Sidebar';
 
 export default { title: 'Scenes/Root' };

--- a/src/scenes/Root/Sidebar/Sidebar.tsx
+++ b/src/scenes/Root/Sidebar/Sidebar.tsx
@@ -10,7 +10,6 @@ import {
 } from '@material-ui/core';
 import { FolderOpen, Language, Person } from '@material-ui/icons';
 import { ComponentType } from 'react';
-import * as React from 'react';
 import { PeopleJoinedIcon } from '../../../components/Icons';
 import { ListItemLink, ListItemLinkProps } from '../../../components/Routing';
 import { CreateButtonMenu } from '../Creates';

--- a/src/scenes/Root/Sidebar/SidebarHeader.tsx
+++ b/src/scenes/Root/Sidebar/SidebarHeader.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, Typography } from '@material-ui/core';
-import * as React from 'react';
 import { CordIcon } from '../../../components/Icons';
 import { SwooshBackground } from './SwooshBackground';
 

--- a/src/scenes/Root/Sidebar/SwooshBackground.tsx
+++ b/src/scenes/Root/Sidebar/SwooshBackground.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, SvgIcon, SvgIconProps } from '@material-ui/core';
 import clsx from 'clsx';
-import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useUserAgent } from '../../../hooks';
 

--- a/src/scenes/Root/useNonProdWarning.tsx
+++ b/src/scenes/Root/useNonProdWarning.tsx
@@ -2,7 +2,6 @@
 import { IconButton, Link } from '@material-ui/core';
 import { Close } from '@material-ui/icons';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { useIsomorphicEffect } from '../../hooks';
 
 export const useNonProdWarning = () => {

--- a/src/scenes/Root/useOldChromeWarning.tsx
+++ b/src/scenes/Root/useOldChromeWarning.tsx
@@ -1,5 +1,4 @@
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { useIsomorphicEffect, useUserAgent } from '../../hooks';
 
 export const useOldChromeWarning = () => {

--- a/src/scenes/SearchResults/SearchResults.tsx
+++ b/src/scenes/SearchResults/SearchResults.tsx
@@ -2,7 +2,6 @@ import { useQuery } from '@apollo/client';
 import { Card, CardContent, makeStyles, Typography } from '@material-ui/core';
 import { startCase } from 'lodash';
 import { ReactElement } from 'react';
-import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Error } from '../../components/Error';
 import { LanguageListItemCard } from '../../components/LanguageListItemCard';

--- a/src/scenes/Users/Create/CreateUser.tsx
+++ b/src/scenes/Users/Create/CreateUser.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from '@apollo/client';
 import { useSnackbar } from 'notistack';
-import React from 'react';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { CreatePersonInput } from '~/api/schema.graphql';

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -3,7 +3,7 @@ import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { Edit } from '@material-ui/icons';
 import { Skeleton } from '@material-ui/lab';
 import { DateTime } from 'luxon';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { useInterval } from 'react-use';

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { Maybe, UpdateUserInput } from '~/api/schema.graphql';
 import { UserForm, UserFormProps } from '../UserForm';

--- a/src/scenes/Users/List/UserList.tsx
+++ b/src/scenes/Users/List/UserList.tsx
@@ -12,7 +12,7 @@ import {
   TabContext,
   TabPanel,
 } from '@material-ui/lab';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { User } from '~/api/schema.graphql';
 import { simpleSwitch } from '~/common';

--- a/src/scenes/Users/List/UserSortOptions.stories.tsx
+++ b/src/scenes/Users/List/UserSortOptions.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { User } from '../../../api';
 import { SortButtonDialog, SortValue } from '../../../components/Sort';
 import { UserSortOptions } from './UserSortOptions';

--- a/src/scenes/Users/List/UserSortOptions.tsx
+++ b/src/scenes/Users/List/UserSortOptions.tsx
@@ -1,5 +1,4 @@
 import { ComponentType } from 'react';
-import * as React from 'react';
 import { User } from '~/api/schema.graphql';
 import { SortOption, SortOptionProps } from '../../../components/Sort';
 

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -1,6 +1,5 @@
 import { Grid } from '@material-ui/core';
 import { memoize } from 'lodash';
-import React from 'react';
 import { RoleLabels, RoleList } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import {

--- a/src/scenes/Users/Users.tsx
+++ b/src/scenes/Users/Users.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '../../components/Error';
 import { UserDetail } from './Detail';

--- a/src/server/renderServerSideApp.tsx
+++ b/src/server/renderServerSideApp.tsx
@@ -7,9 +7,8 @@ import {
   Response as ExpressResponse,
 } from 'express';
 import { pickBy } from 'lodash';
-import React from 'react';
 import { resetServerContext } from 'react-beautiful-dnd';
-import ReactDOMServer from 'react-dom/server';
+import { renderToString } from 'react-dom/server';
 import { FilledContext, HelmetProvider } from 'react-helmet-async';
 import { StaticRouter } from 'react-router-dom/server';
 import { createClient } from '~/api/client/createClient';
@@ -47,7 +46,7 @@ export const renderServerSideApp = async (
     tree: <ServerApp req={req} apollo={apollo} helmetContext={helmetContext} />,
     renderFunction: (tree) => {
       resetServerContext();
-      return ReactDOMServer.renderToString(
+      return renderToString(
         location.wrap(sheets.collect(extractor.collectChunks(tree)))
       );
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "esnext",
     "lib": ["esnext", "dom", "dom.iterable"],
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "allowJs": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
The react library used to be required to be imported in every file in order to the JSX transforms to be able to reference React's createElement function.

With React 17 there's a new "JSX runtime" that allows the compiler to be configured with the correct import to use with the JSX transformation.
This means that we don't have to import react unless we need a specific function from the library.
