### PR TITLE
Show rich text view while loading editor

### DIFF
--- a/src/components/RichText/RichTextField.tsx
+++ b/src/components/RichText/RichTextField.tsx
@@ -16,6 +16,7 @@ import {
 import { EditorCore } from '@react-editor-js/core';
 import { identity, isEqual, pick } from 'lodash';
 import {
+  forwardRef,
   MouseEvent,
   ReactNode,
   RefObject,
@@ -30,6 +31,7 @@ import { FieldConfig, useField } from '../form';
 import { getHelperText, showError } from '../form/util';
 import { EditorJsTheme } from './EditorJsTheme';
 import type { ToolKey } from './editorJsTools';
+import { RichTextView } from './RichTextView';
 
 export type RichTextFieldProps = Pick<
   FieldConfig<RichTextData>,
@@ -122,7 +124,7 @@ export function RichTextField({
   ]);
 
   const loading = (
-    <Loading label={label} placeholder={placeholder} helperText={helperText} />
+    <Loading value={val} {...{ label, placeholder, helperText }} />
   );
   if (typeof window === 'undefined') {
     return loading;
@@ -248,18 +250,31 @@ export function RichTextField({
   );
 }
 
-const Loading = (
-  props: Pick<TextFieldProps, 'placeholder' | 'label' | 'helperText'>
-) => (
-  <TextField
-    variant="outlined"
-    {...props}
-    helperText={props.helperText ?? ' '}
-    multiline
-    disabled
-    minRows={2}
-  />
-);
+const Loading = ({
+  value,
+  ...props
+}: Pick<TextFieldProps, 'placeholder' | 'label' | 'helperText'> & {
+  value?: RichTextData;
+}) => {
+  // eslint-disable-next-line react/display-name
+  const Input = forwardRef((_, ref) => (
+    <div ref={ref as any}>
+      <RichTextView data={value} />
+    </div>
+  ));
+  return (
+    <TextField
+      variant="outlined"
+      {...props}
+      helperText={props.helperText ?? ' '}
+      InputProps={{ inputComponent: Input as any }}
+      multiline
+      disabled
+      minRows={2}
+      sx={{ opacity: 0.5 }}
+    />
+  );
+};
 
 // There's no API to determine if currently empty.
 // And the empty placeholder is rendered as a block.


### PR DESCRIPTION
Note the while flash in both cases is before data is received from API. Usually we have a loading state during this time, but the current progress report edit view does not.

# Before
https://user-images.githubusercontent.com/932566/201149778-7b82d2eb-3f42-4fc5-b4c1-e5fca19bff6e.mov

Here, the data is loaded but it looks like the field is empty for a little bit.
This left me thinking "where'd my data go?" (at least I can picture users thinking that).

# After
https://user-images.githubusercontent.com/932566/201149776-0b003f74-f153-4270-9266-ca4ddf60a36d.mov

Now as soon as we get the data it is presented. I gave it a transparency to help indicate that it's not ready to be clicked and edited yet.

I tried to reduce the jitter when transitioning from the loading view to the real one, but wasn't able to come up with anything within a few mins.