### PR TITLE
Use current user's assignable roles when creating new users

### DIFF
--- a/src/components/Session/session.graphql
+++ b/src/components/Session/session.graphql
@@ -22,6 +22,7 @@ fragment LoggedInUser on User {
   }
   roles {
     value
+    assignableRoles
   }
   fullName
   realFirstName {

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material';
 import { memoize } from 'lodash';
-import { RoleLabels, RoleList } from '~/api/schema.graphql';
+import { RoleLabels } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import {
   DialogForm,
@@ -15,6 +15,7 @@ import {
   TextField,
 } from '../../../components/form';
 import { AutocompleteField } from '../../../components/form/AutocompleteField';
+import { useSession } from '../../../components/Session';
 import { UserFormFragment } from './UserForm.graphql';
 
 export type UserFormProps<T, R = void> = DialogFormProps<T, R> & {
@@ -34,6 +35,7 @@ export const UserForm = <T, R = void>({
   prefix,
   ...rest
 }: UserFormProps<T, R>) => {
+  const { session } = useSession();
   return (
     <DialogForm<T, R>
       DialogProps={{
@@ -135,13 +137,14 @@ export const UserForm = <T, R = void>({
           {(props) => (
             <AutocompleteField
               multiple
-              options={RoleList}
+              options={
+                user?.roles.assignableRoles ??
+                session?.roles.assignableRoles ??
+                []
+              }
               getOptionLabel={labelFrom(RoleLabels)}
               label="Roles"
               variant="outlined"
-              getOptionDisabled={(role) =>
-                user ? !user.roles.assignableRoles.includes(role) : true
-              }
               {...props}
             />
           )}


### PR DESCRIPTION
This fixes the UX where roles cannot be assigned while creating a new user.

We assume the assignable roles of the current user as the same as new users. I think this is safe although it's not the explicit API contract. The API can still do validation if there's an error here.

I also changed the list to just filter out un-assignable vs just disabling them. This seems like a better UX as the assignable could be short, and our roles are getting longer.