### PR TITLE
Update progress reports terminology

### DIFF
--- a/src/components/PeriodicReports/PeriodicReportsList.tsx
+++ b/src/components/PeriodicReports/PeriodicReportsList.tsx
@@ -26,7 +26,7 @@ export const PeriodicReportsList = ({
   onRowClick?: (report: PeriodicReportFragment) => void;
   TableCardProps?: CardProps;
 } & StyleProps) => {
-  const reportTypeName = `${type} Reports`;
+  const reportTypeName = `${type === 'Progress' ? 'Quarterly' : type} Reports`;
 
   return (
     <Box

--- a/src/components/ProgressReportsOverviewCard/ProgressReportsOverviewCard.tsx
+++ b/src/components/ProgressReportsOverviewCard/ProgressReportsOverviewCard.tsx
@@ -26,7 +26,7 @@ export const ProgressReportsOverviewCard = ({
   <Card {...rest} sx={{ width: 1 }}>
     <CardContent sx={{ width: 1 }}>
       <Typography variant="h4" paragraph>
-        Progress Reports
+        Quarterly Reports
       </Typography>
       <ReportInfoContainer horizontalAt={260} spaceEvenlyAt={430}>
         {dueCurrently?.value && (

--- a/src/scenes/ProgressReports/Detail/ProgressReportDetail.tsx
+++ b/src/scenes/ProgressReports/Detail/ProgressReportDetail.tsx
@@ -66,8 +66,8 @@ export const ProgressReportDetail = () => {
     return (
       <Error page error={error}>
         {{
-          NotFound: 'Could not find progress report',
-          Default: 'Error loading progress report',
+          NotFound: 'Could not find quarterly report',
+          Default: 'Error loading quarterly report',
         }}
       </Error>
     );
@@ -86,7 +86,7 @@ export const ProgressReportDetail = () => {
   return (
     <div className={classes.root}>
       <main className={classes.main}>
-        <Helmet title="Progress Report" />
+        <Helmet title="Quarterly Report" />
         <Breadcrumbs
           children={[
             <ProjectBreadcrumb key="project" data={engagement?.project} />,
@@ -99,7 +99,7 @@ export const ProgressReportDetail = () => {
                   : undefined
               }
             >
-              {!report ? <Skeleton width={200} /> : 'Progress Reports'}
+              {!report ? <Skeleton width={200} /> : 'Quarterly Reports'}
             </Breadcrumb>,
             <Breadcrumb key="report" to=".">
               {!report ? (
@@ -120,7 +120,7 @@ export const ProgressReportDetail = () => {
           <Grid item component={Typography} variant="h2">
             {data ? (
               <>
-                Progress Report - <ReportLabel report={report} />
+                Quarterly Report - <ReportLabel report={report} />
               </>
             ) : (
               <Skeleton width={442} />
@@ -194,7 +194,7 @@ export const ProgressReportDetail = () => {
               />
 
               <PromptResponseCard
-                title="Community Story"
+                title="Story"
                 showPrompt
                 promptResponse={report?.communityStories.items[0]}
                 loading={!report}

--- a/src/scenes/ProgressReports/EditForm/ProgressReportDrawerHeader.tsx
+++ b/src/scenes/ProgressReports/EditForm/ProgressReportDrawerHeader.tsx
@@ -94,7 +94,7 @@ export const ProgressReportDrawerHeader = ({ report }: ReportProp) => {
         sx={{ mt: 2, gap: 2, display: 'flex', alignItems: 'flex-end' }}
       >
         <span>
-          <ReportLabel report={report} /> &mdash; Field Report
+          Quarterly Report &mdash; <ReportLabel report={report} />
         </span>
         {report.status.value && (
           <Chip color="info" label={StatusLabels[report.status.value]!} />

--- a/src/scenes/ProgressReports/EditForm/Steps/index.ts
+++ b/src/scenes/ProgressReports/EditForm/Steps/index.ts
@@ -6,9 +6,9 @@ import { SubmitReportStep } from './SubmitReportStep';
 import { TeamNewsStep } from './TeamNews';
 
 export const Steps: GroupedStepMapShape = {
-  'Narrative Report': [
+  'Investor Connection': [
     ['Team News', TeamNewsStep],
-    ['Community Story', CommunityStoryStep],
+    ['Story', CommunityStoryStep],
   ],
   'Project Management': [
     ['Progress', ProgressStep],


### PR DESCRIPTION
[Monday.com Ticket: Update Terminology of Quarterly Reports UI](https://seed-company-squad.monday.com/boards/3451697530/pulses/3830415588)

Made all the requested changes

![Screenshot 2023-01-19 at 12 06 18 PM](https://user-images.githubusercontent.com/39035380/213548593-d5ac77e6-bd2c-4512-90a0-65890e800e41.png)

![Screenshot 2023-01-19 at 12 02 11 PM](https://user-images.githubusercontent.com/39035380/213547661-e57e7d8e-fd77-4945-a524-74c5a6b388d0.png)

![Screenshot 2023-01-19 at 12 03 16 PM](https://user-images.githubusercontent.com/39035380/213547944-1b372581-845a-4b8e-9cad-fcc4f658b6eb.png)

![Screenshot 2023-01-19 at 12 05 22 PM](https://user-images.githubusercontent.com/39035380/213548430-dde41c78-75fa-40ae-9078-bb4c319a1839.png)


