### PR TITLE
Exp. of progress copy & use API thresholds shown in tooltips

### DIFF
--- a/src/components/form/EnumField.tsx
+++ b/src/components/form/EnumField.tsx
@@ -17,6 +17,8 @@ import { sortBy } from 'lodash';
 import {
   createContext,
   FocusEvent,
+  ForwardedRef,
+  forwardRef,
   MouseEvent,
   ReactElement,
   ReactNode,
@@ -321,7 +323,10 @@ export type EnumOptionsProps<T extends string> = {
   color?: ToggleButtonProps['color'];
 } & MergeExclusive<{ value: T }, { default: true }>;
 
-export const EnumOption = <T extends string>(props: EnumOptionsProps<T>) => {
+const EnumOptionInner = <T extends string>(
+  props: EnumOptionsProps<T>,
+  ref: ForwardedRef<HTMLElement>
+) => {
   const { variant, isChecked, onChange, ...ctx } = useEnumContext<T>();
   const { disabled = ctx.disabled, value: name, default: _, ...rest } = props;
 
@@ -329,6 +334,7 @@ export const EnumOption = <T extends string>(props: EnumOptionsProps<T>) => {
     return (
       <FormControlLabel
         {...rest}
+        ref={ref}
         name={name ?? 'default'}
         checked={isChecked(name)}
         onChange={(_, checked) => onChange(name, checked)}
@@ -355,6 +361,7 @@ export const EnumOption = <T extends string>(props: EnumOptionsProps<T>) => {
     return (
       <ToggleButton
         {...rest}
+        ref={ref as ForwardedRef<HTMLButtonElement>}
         value={name ?? 'default'}
         selected={selected}
         onChange={(_) => onChange(name, !selected)}
@@ -367,6 +374,11 @@ export const EnumOption = <T extends string>(props: EnumOptionsProps<T>) => {
 
   return null;
 };
+EnumOptionInner.displayName = 'EnumOption';
+
+export const EnumOption = forwardRef(EnumOptionInner) as <T extends string>(
+  props: EnumOptionsProps<T> & { ref?: ForwardedRef<HTMLElement> }
+) => ReactElement | null;
 
 interface EnumContextValue<Opt extends string> {
   fieldName: string;

--- a/src/scenes/ProgressReports/EditForm/Steps/ExplanationOfProgress/ExplanationOfProgress.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/ExplanationOfProgress/ExplanationOfProgress.tsx
@@ -122,8 +122,8 @@ export const ExplanationOfProgress: StepComponent = ({ report }) => {
         Explanation of Progress
       </Typography>
       <Typography paragraph>
-        Please provide an explanation of the state of progress for this
-        reporting period.
+        Select the appropriate state of Language Engagement Goal/Translation
+        Progress.
       </Typography>
 
       <Form<FormShape>

--- a/src/scenes/ProgressReports/EditForm/Steps/ExplanationOfProgress/ExplanationOfProgress.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/ExplanationOfProgress/ExplanationOfProgress.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client';
 import type { OutputData as RichTextData } from '@editorjs/editorjs';
-import { Card, CardContent, Typography } from '@mui/material';
+import { Card, CardContent, Tooltip, Typography } from '@mui/material';
 import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
 import { DateTime } from 'luxon';
@@ -149,21 +149,29 @@ export const ExplanationOfProgress: StepComponent = ({ report }) => {
               disabled={!explanation.reasons.canEdit}
               required
             >
-              <EnumOption<OptionGroup>
-                value="behind"
-                label="Behind / Delayed"
-                color="error"
-              />
-              <EnumOption<OptionGroup>
-                value="onTime"
-                label="On Time"
-                color="info"
-              />
-              <EnumOption<OptionGroup>
-                value="ahead"
-                label="Ahead"
-                color="success"
-              />
+              {/* Source or truth for thresholds:
+                  https://github.com/SeedCompany/cord-api-v3/blob/master/src/components/progress-summary/dto/schedule-status.enum.ts#L13-L17 */}
+              <Tooltip title="> -10%" placement="top">
+                <EnumOption<OptionGroup>
+                  value="behind"
+                  label="Behind / Delayed"
+                  color="error"
+                />
+              </Tooltip>
+              <Tooltip title="-10% to 30%" placement="top">
+                <EnumOption<OptionGroup>
+                  value="onTime"
+                  label="On Time"
+                  color="info"
+                />
+              </Tooltip>
+              <Tooltip title="> 30%" placement="top">
+                <EnumOption<OptionGroup>
+                  value="ahead"
+                  label="Ahead"
+                  color="success"
+                />
+              </Tooltip>
             </EnumField>
 
             {optionsByGroup[group].length > 0 && (

--- a/src/scenes/ProgressReports/EditForm/Steps/ExplanationOfProgress/ExplanationOfProgress.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/ExplanationOfProgress/ExplanationOfProgress.tsx
@@ -3,6 +3,7 @@ import type { OutputData as RichTextData } from '@editorjs/editorjs';
 import { Card, CardContent, Tooltip, Typography } from '@mui/material';
 import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
+import { camelCase } from 'lodash';
 import { DateTime } from 'luxon';
 import { useMemo, useState } from 'react';
 import { Form, FormProps } from 'react-final-form';
@@ -64,14 +65,9 @@ export const ExplanationOfProgress: StepComponent = ({ report }) => {
       : undefined;
 
     if (!group) {
-      const variance = report.cumulativeSummary?.variance;
-      group = !variance
-        ? 'onTime'
-        : variance >= 0.1
-        ? 'ahead'
-        : variance >= -0.1
-        ? 'behind'
-        : 'onTime';
+      group = camelCase(
+        report.varianceExplanation.scheduleStatus ?? 'OnTime'
+      ) as OptionGroup;
     }
 
     return {


### PR DESCRIPTION
[Monday.com ticket](https://seed-company-squad.monday.com/boards/3451697530/views/87873996/pulses/3873143878)

### Edited text under Title "Explanation of Progress" to: 
- Select the appropriate state of Language Engagement Goal/Translation Progress


### Added Tooltip for toggle buttons:
- Behind/Delayed = >-10%
- On Time = 30% to -10%
- Ahead = >30%