### PR TITLE
Implement a proper RelativeDateTime component

### DIFF
--- a/src/components/form/SavingStatus.tsx
+++ b/src/components/form/SavingStatus.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { ReactElement } from 'react';
 import { Nullable } from '../../common';
-import { FormattedDateTime } from '../Formatters';
+import { RelativeDateTime } from '../Formatters';
 
 export const SavingStatus = ({
   submitting,
@@ -14,6 +14,6 @@ export const SavingStatus = ({
     <>Saving...</>
   ) : savedAt ? (
     <>
-      Saved <FormattedDateTime date={savedAt} relative />
+      Saved <RelativeDateTime date={savedAt} />
     </>
   ) : null;


### PR DESCRIPTION
This one updates as needed to display an accurate relative time.
This is opinionated:
- `>= 1 day` is formatted as absolute time.
- `< 1 min` is formatted with a few different strings in order to not draw attention to it by changing the text every second.
   i.e. "Just now" -> "A few seconds ago" -> "1 minute ago" -> etc.


I did consider other libraries providing this functionality. I decided that:
- `luxon` and `ahooks` provided enough hard work to just connect them together myself
- It allows us our formatting to be opinionated easily
- Doesn't increase bundle size