### PR TITLE
Add ethnologue population display to language details page

### DIFF
--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -214,6 +214,11 @@ export const LanguageDetail = () => {
             loading={!language}
           />
           <DisplayProperty
+            label="Ethnologue Population"
+            value={formatNumber(ethnologue?.population.value)}
+            loading={!language}
+          />
+          <DisplayProperty
             label="Sponsor Start Date"
             value={<FormattedDate date={sponsorStartDate?.value} />}
             loading={!language}


### PR DESCRIPTION
PR for ticket: https://seed-company-squad.monday.com/boards/3451697530/views/78801639/pulses/4567125192

This will do the following:

- If ethnolougue population only is entered then on the language detail page both ethnolougue population and population will appear and they will be the same number
- If ethnolougue population and population are entered then they will both appear and they will be different numbers (as long as different numbers are entered)
- If niether population is entered then niether will appear
- Over-rides and list view will not be affected