### PR TITLE
feat: extend ms word formatting interceptor to take care of ordered l…

### DIFF
--- a/src/components/RichText/RichTextField.tsx
+++ b/src/components/RichText/RichTextField.tsx
@@ -36,7 +36,7 @@ import { getHelperText, showError } from '../form/util';
 import { FormattedNumber } from '../Formatters';
 import { EditorJsTheme } from './EditorJsTheme';
 import type { ToolKey } from './editorJsTools';
-import { handleMsUnorderedList } from './ms-word-helpers';
+import { handleMsPasteFormatting } from './ms-word-helpers';
 import { RichTextView } from './RichTextView';
 
 declare module '@editorjs/editorjs/types/data-formats/output-data' {
@@ -138,7 +138,7 @@ export function RichTextField({
     'paste',
     (event: ClipboardEvent) => {
       const formattedUl: RichTextData | undefined =
-        handleMsUnorderedList(event);
+        handleMsPasteFormatting(event);
       if (formattedUl) {
         event.preventDefault();
         input.onChange(formattedUl);


### PR DESCRIPTION
…ists and combined text

This should fix the issues related to both of these tickets:

https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/4888292883
https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/4877038624

These changes do the following:

- detect ms word ordered lists and unordered lists being pasted in. Potentially with other content
- If neither are detected nothing the normal paste is executed
- If either type of list is detected then all text is split by newline, paragraphs, ul, and ol are created as blocks and inserted in the right order
- This has been tested using the text dave thomas supplied (screenshot attached) as well as text with bullet points and ordered lists not from word, multiple list of the same and different types, and text with no lists

<img width="992" alt="Screenshot 2023-07-28 at 10 42 47 PM" src="https://github.com/SeedCompany/cord-field/assets/138262921/dd9fca53-0df1-4ecb-bf59-4b7c1842d837">
