### PR TITLE
Only show assignable roles in project member form

### DIFF
--- a/src/common/array-helpers.ts
+++ b/src/common/array-helpers.ts
@@ -90,13 +90,3 @@ export const splice = <T>(
  */
 export const notNullish = <T>(item: T | null | undefined): item is T =>
   item != null;
-
-// simple utility function to move the available options for select list to the top of the list in the UI
-export const reorderListsByAvailable = (
-  activeList: readonly any[],
-  allList: readonly any[]
-) => {
-  return activeList.concat(
-    allList.filter((item) => !activeList.includes(item))
-  );
-};

--- a/src/common/array-helpers.ts
+++ b/src/common/array-helpers.ts
@@ -90,3 +90,13 @@ export const splice = <T>(
  */
 export const notNullish = <T>(item: T | null | undefined): item is T =>
   item != null;
+
+// simple utility function to move the available options for select list to the top of the list in the UI
+export const reorderListsByAvailable = (
+  activeList: readonly any[],
+  allList: readonly any[]
+) => {
+  return activeList.concat(
+    allList.filter((item) => !activeList.includes(item))
+  );
+};

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -7,9 +7,8 @@ import { addItemToList } from '~/api';
 import {
   CreateProjectMember as CreateProjectMemberInput,
   RoleLabels,
-  RoleList,
 } from '~/api/schema.graphql';
-import { labelFrom, reorderListsByAvailable } from '~/common';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -98,11 +97,8 @@ export const CreateProjectMember = ({
             <AutocompleteField
               disabled={!canRead || !userRoles}
               multiple
-              options={
-                userRoles
-                  ? reorderListsByAvailable(userRoles, RoleList)
-                  : RoleList
-              }
+              options={userRoles || []}
+              noOptionsText="No roles assignable to this person"
               getOptionLabel={labelFrom(RoleLabels)}
               name="roles"
               label="Roles"

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -9,7 +9,7 @@ import {
   RoleLabels,
   RoleList,
 } from '~/api/schema.graphql';
-import { labelFrom } from '~/common';
+import { labelFrom, reorderListsByAvailable } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -98,7 +98,11 @@ export const CreateProjectMember = ({
             <AutocompleteField
               disabled={!canRead || !userRoles}
               multiple
-              options={RoleList}
+              options={
+                userRoles
+                  ? reorderListsByAvailable(userRoles, RoleList)
+                  : RoleList
+              }
               getOptionLabel={labelFrom(RoleLabels)}
               name="roles"
               label="Roles"

--- a/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
+++ b/src/scenes/Projects/Members/Create/CreateProjectMember.tsx
@@ -109,9 +109,6 @@ export const CreateProjectMember = ({
                     : `You cannot read this person's roles`
                   : 'Select a person first'
               }
-              getOptionDisabled={(option) =>
-                !!userRoles && !userRoles.includes(option)
-              }
               variant="outlined"
             />
           </>


### PR DESCRIPTION
Quick PR to fix what I consider to be a UX annoyance. This adds a little utility function to put the available options for roles on top of the list instead of having them all be in the same order all the time
before:
<img width="487" alt="dropdown-before" src="https://github.com/SeedCompany/cord-field/assets/37881163/43943bc4-bfda-4cca-9fec-cc927c199842">
after:
<img width="557" alt="dropdown-after" src="https://github.com/SeedCompany/cord-field/assets/37881163/49b64aa6-6eb0-4aac-b55d-703e93276d75">

Edit: created a Monday ticket for tracking - https://seed-company-squad.monday.com/boards/3451697530/pulses/4926194488
