### PR TITLE
Ignore current impersonation for sensitive operations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,12 @@ import { ThemeProvider } from '@mui/material/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import LogRocket from 'logrocket';
 import setupLogRocketReact from 'logrocket-react';
-import { ApolloProvider } from './api';
+import { ApolloProvider, GqlSensitiveOperations } from './api';
 import { LuxonCalenderDateUtils } from './common/LuxonCalenderDateUtils';
 import { ConfettiProvider } from './components/Confetti';
 import { Nest } from './components/Nest';
 import { SnackbarProvider } from './components/Snackbar';
 import { UploadProvider as FileUploadProvider } from './components/Upload';
-import { SensitiveOperations } from './scenes/Authentication';
 import { Root } from './scenes/Root';
 import { createTheme } from './theme';
 
@@ -19,7 +18,11 @@ if (logRocketAppId) {
     network: {
       requestSanitizer(request) {
         // Relies on operation name suffix which do in Apollo HttpLink config
-        if (SensitiveOperations.some((op) => request.url.endsWith('/' + op))) {
+        if (
+          [...GqlSensitiveOperations].some((op) =>
+            request.url.endsWith(`/${op}`)
+          )
+        ) {
           request.body = undefined;
         }
         return request;

--- a/src/api/client/links/impersonation.link.ts
+++ b/src/api/client/links/impersonation.link.ts
@@ -1,18 +1,26 @@
 import { setContext } from '@apollo/client/link/context';
 import { pickBy } from 'lodash';
 import { RefObject } from 'react';
+import { GqlSensitiveOperations } from '../../operationsList';
 import { Impersonation } from '../ImpersonationContext';
 
 export const createImpersonationLink = (
   ref?: RefObject<Impersonation | undefined>
 ) =>
-  setContext((req, prev) => ({
-    ...prev,
-    headers: {
-      ...prev.headers,
-      ...pickBy({
-        'x-cord-impersonate-user': ref?.current?.user,
-        'x-cord-impersonate-role': ref?.current?.roles?.join(','),
-      }),
-    },
-  }));
+  setContext((req, prev) => {
+    const isSensitiveOp = req.operationName
+      ? GqlSensitiveOperations.has(req.operationName)
+      : false;
+    const impersonation =
+      ref?.current && !isSensitiveOp ? ref.current : undefined;
+    return {
+      ...prev,
+      headers: {
+        ...prev.headers,
+        ...pickBy({
+          'x-cord-impersonate-user': impersonation?.user,
+          'x-cord-impersonate-role': impersonation?.roles?.join(','),
+        }),
+      },
+    };
+  });

--- a/src/api/operationsList/operations.codegen.ts
+++ b/src/api/operationsList/operations.codegen.ts
@@ -1,7 +1,49 @@
 import { plugin as basePlugin } from '@graphql-codegen/named-operations-object';
 import type { PluginFunction } from '@graphql-codegen/plugin-helpers';
+import { concatAST, FieldNode, visit } from 'graphql';
 
 export const plugin: PluginFunction = async (...args) => {
-  const result = await basePlugin(...args);
-  return result ? result + ' as const' : result;
+  let result = await basePlugin(...args);
+  result = result ? result + ' as const;' : result;
+
+  const [schema, documents] = args;
+
+  const queries = Object.values(schema.getQueryType()?.getFields() ?? {});
+  const mutations = Object.values(schema.getMutationType()?.getFields() ?? {});
+  const sensitiveQueries = new Set(
+    [...queries, ...mutations]
+      .filter(
+        (f) => f.description && /^\s*@sensitive-secrets$/m.test(f.description)
+      )
+      .map((f) => f.name)
+  );
+  const sensitiveOperationsNames = new Set();
+  const allAst = concatAST(documents.flatMap((v) => v.document ?? []));
+  visit(allAst, {
+    OperationDefinition: (node) => {
+      if (
+        !node.name ||
+        (node.operation !== 'query' && node.operation !== 'mutation')
+      ) {
+        return;
+      }
+      const fields = node.selectionSet.selections
+        .filter((s): s is FieldNode => s.kind === 'Field')
+        .map((s) => s.name.value);
+      for (const field of fields) {
+        if (sensitiveQueries.has(field)) {
+          sensitiveOperationsNames.add(node.name.value);
+        }
+      }
+    },
+  });
+
+  result += `
+
+export const GqlSensitiveOperations: ReadonlySet<string> = new Set([
+${[...sensitiveOperationsNames].map((n) => `  '${n}'`).join(',\n')}
+]);
+`;
+
+  return result;
 };

--- a/src/scenes/Authentication/index.ts
+++ b/src/scenes/Authentication/index.ts
@@ -1,5 +1,3 @@
-import { GQLOperations } from '../../api';
-
 export * from './AuthLayout';
 export * from './AuthWaiting';
 export * from './ChangePassword';
@@ -9,10 +7,3 @@ export * from './Logout';
 export * from './Register/Register';
 export * from './ResetPassword';
 export * from './useAuthRequired';
-
-export const SensitiveOperations = [
-  GQLOperations.Mutation.Login,
-  GQLOperations.Mutation.ResetPassword,
-  GQLOperations.Mutation.ChangePassword,
-  GQLOperations.Mutation.Register,
-];


### PR DESCRIPTION
Normal user flow doesn't allow this.
But there are edge cases where this could come up.