### PR TITLE
Convert empty email string to null instead of undefined

### DIFF
--- a/src/components/form/EmailField.tsx
+++ b/src/components/form/EmailField.tsx
@@ -31,6 +31,7 @@ export const EmailField = ({
     required={required}
     {...rest}
     inputMode="email"
+    parse={(v) => v || null}
     replace={(v) => (caseSensitive ? v : v.toLowerCase())}
   />
 );


### PR DESCRIPTION
final-form automatically converts "" -> undefined. Explicitly work around this to use null instead.

The API treats nulls as null values
and undefined as unchanged or omitted values