### PR TITLE
fix: remove aws-sdk npm prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "@typescript-eslint/types": "^5.62.0",
-    "aws-sdk": "npm:2.1372.0",
+    "aws-sdk": "2.1372.0",
     "babel-loader": "^8.3.0",
     "babel-plugin-transform-imports": "^2.0.0",
     "babel-plugin-transform-rename-import": "^2.3.0",


### PR DESCRIPTION
npm prefix on aws-sdk is breaking package installs. this removes the prefix