### PR TITLE
Partner projects - Sort on client after all pages are fetched

### DIFF
--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerProjects.graphql
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerProjects.graphql
@@ -1,9 +1,8 @@
-query PartnerProjects($id: ID!, $input: ProjectListInput!) {
+query PartnerProjects($id: ID!, $input: ProjectListInput) {
   partner(id: $id) {
     id
     projects(input: $input) {
       canRead
-      canCreate
       hasMore
       total
       items {


### PR DESCRIPTION
Previously we sorted client side if there was only one page of items, and if there was more than one page we'd sort server side.

But say there were two pages, and you went to the next page, then you went to change the sort.
We'd go again to the server to do the sorting and first page, but we didn't need to. At that point, we would have all the items and could sort client side.

So that's what this does. After we have a complete list of items from all pages, we do client side sorting & pagination.

Here's what the cache entries look like:
<img width="686" alt="Screenshot 2024-01-22 at 9 08 37 PM" src="https://github.com/SeedCompany/cord-field/assets/932566/ab3cd124-a27a-4095-a5a4-d3a5e2401870">
It's worth noting that we keep the same merged list even if the sorting changes.
This allows a page of items from a different sorting to still contribute new items.
So it's possible to get the entire list by just changing the sorting without going through all the pages of each sorting config.
This does leave that merged list unsorted in cache, so it's expected to be sorted before being displayed.