### PR TITLE
Adapt to TranslationProject Split & add type chips to UI

### DIFF
--- a/src/api/schema/typePolicies/lists/page-limit-pagination.ts
+++ b/src/api/schema/typePolicies/lists/page-limit-pagination.ts
@@ -230,7 +230,9 @@ const objectToKeyArgsRecurse = (obj: Record<string, any>): KeySpecifier =>
     (keyArgs: KeySpecifier, [key, val]) => [
       ...keyArgs,
       key,
-      ...(val && typeof val === 'object' ? [objectToKeyArgsRecurse(val)] : []),
+      ...(val && typeof val === 'object' && !Array.isArray(val)
+        ? [objectToKeyArgsRecurse(val)]
+        : []),
     ],
     []
   );
@@ -238,7 +240,7 @@ const objectToKeyArgsRecurse = (obj: Record<string, any>): KeySpecifier =>
 const cleanEmptyObjects = (obj: Record<string, any>): Record<string, any> => {
   const res: Record<string, any> = {};
   for (const [key, value] of Object.entries(obj)) {
-    if (!(value && typeof value === 'object')) {
+    if (!(value && typeof value === 'object' && !Array.isArray(value))) {
       res[key] = value;
       continue;
     }

--- a/src/common/fragments/index.ts
+++ b/src/common/fragments/index.ts
@@ -1,3 +1,8 @@
+import {
+  Id_InternshipProject_Fragment as InternshipProjectIdFragment,
+  Id_TranslationProject_Fragment as TranslationProjectIdFragment,
+} from './identity.graphql';
+
 export * from './common';
 export * from './identity.graphql';
 export * from './changeset.graphql';
@@ -5,3 +10,7 @@ export * from './lists.graphql';
 export * from './prompt.graphql';
 export * from './promptResponse.graphql';
 export * from './variant.graphql';
+
+export type ProjectIdFragment =
+  | TranslationProjectIdFragment
+  | InternshipProjectIdFragment;

--- a/src/common/fragments/index.ts
+++ b/src/common/fragments/index.ts
@@ -1,6 +1,7 @@
 import {
   Id_InternshipProject_Fragment as InternshipProjectIdFragment,
-  Id_TranslationProject_Fragment as TranslationProjectIdFragment,
+  Id_MomentumTranslationProject_Fragment as MomentumProjectIdFragment,
+  Id_MultiplicationTranslationProject_Fragment as MultiplicationProjectIdFragment,
 } from './identity.graphql';
 
 export * from './common';
@@ -12,5 +13,6 @@ export * from './promptResponse.graphql';
 export * from './variant.graphql';
 
 export type ProjectIdFragment =
-  | TranslationProjectIdFragment
+  | MomentumProjectIdFragment
+  | MultiplicationProjectIdFragment
   | InternshipProjectIdFragment;

--- a/src/components/ProjectListItemCard/ProjectListItem.graphql
+++ b/src/components/ProjectListItemCard/ProjectListItem.graphql
@@ -23,14 +23,7 @@ fragment ProjectListItem on Project {
   }
   modifiedAt
   ...TogglePin
-  ... on InternshipProject {
-    engagements {
-      total
-    }
-  }
-  ... on TranslationProject {
-    engagements {
-      total
-    }
+  engagements {
+    total
   }
 }

--- a/src/components/ProjectListItemCard/ProjectListItemCard.tsx
+++ b/src/components/ProjectListItemCard/ProjectListItemCard.tsx
@@ -1,7 +1,16 @@
-import { Card, CardContent, Grid, Skeleton, Typography } from '@mui/material';
+import {
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 import { PartialDeep } from 'type-fest';
-import { ProjectStatusLabels } from '~/api/schema.graphql';
+import { ProjectStatusLabels, ProjectTypeLabels } from '~/api/schema.graphql';
+import { labelFrom } from '~/common';
 import { ProjectListQueryVariables } from '../../scenes/Projects/List/projects.graphql';
 import { getProjectUrl } from '../../scenes/Projects/useProjectId';
 import { DisplaySimpleProperty } from '../DisplaySimpleProperty';
@@ -120,11 +129,17 @@ export const ProjectListItemCard = ({
               </Typography>
             </Grid>
             <Grid item>
-              <Sensitivity
-                value={project?.sensitivity}
-                loading={!project}
-                className={classes.sensitivity}
-              />
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Sensitivity
+                  value={project?.sensitivity}
+                  loading={!project}
+                  className={classes.sensitivity}
+                />
+                <Chip
+                  label={labelFrom(ProjectTypeLabels)(project?.type)}
+                  variant="outlined"
+                />
+              </Stack>
             </Grid>
             <Grid item>
               {!project ? (

--- a/src/components/form/Lookup/Project/ProjectLookup.graphql
+++ b/src/components/form/Lookup/Project/ProjectLookup.graphql
@@ -1,7 +1,5 @@
 query ProjectLookup($query: String!) {
-  search(
-    input: { query: $query, type: [TranslationProject, InternshipProject] }
-  ) {
+  search(input: { query: $query, type: [Project] }) {
     items {
       ... on Project {
         ...ProjectLookupItem
@@ -14,7 +12,7 @@ query TranslationProjectLookup($query: String!) {
   search(input: { query: $query, type: [TranslationProject] }) {
     items {
       ... on TranslationProject {
-        ...TranslationProjectLookupItem
+        ...ProjectLookupItem
       }
     }
   }
@@ -24,27 +22,13 @@ query InternshipProjectLookup($query: String!) {
   search(input: { query: $query, type: [InternshipProject] }) {
     items {
       ... on InternshipProject {
-        ...InternshipProjectLookupItem
+        ...ProjectLookupItem
       }
     }
   }
 }
 
 fragment ProjectLookupItem on Project {
-  id
-  name {
-    value
-  }
-}
-
-fragment TranslationProjectLookupItem on TranslationProject {
-  id
-  name {
-    value
-  }
-}
-
-fragment InternshipProjectLookupItem on InternshipProject {
   id
   name {
     value

--- a/src/scenes/Engagement/Delete/DeleteEngagement.tsx
+++ b/src/scenes/Engagement/Delete/DeleteEngagement.tsx
@@ -3,10 +3,7 @@ import { DeleteOutline } from '@mui/icons-material';
 import { Tooltip, Typography } from '@mui/material';
 import { removeItemFromList } from '~/api';
 import { callAll } from '~/common';
-import {
-  Id_InternshipProject_Fragment as InternshipProjectIdFragment,
-  Id_TranslationProject_Fragment as TranslationProjectIdFragment,
-} from '~/common/fragments';
+import { ProjectIdFragment } from '~/common/fragments';
 import { useDialog } from '../../../components/Dialog';
 import { DialogForm } from '../../../components/Dialog/DialogForm';
 import { SubmitError } from '../../../components/form';
@@ -17,10 +14,6 @@ import {
   DeleteEngagementDocument,
   EngagementToDeleteFragment,
 } from './DeleteEngagement.graphql';
-
-type ProjectIdFragment =
-  | TranslationProjectIdFragment
-  | InternshipProjectIdFragment;
 
 interface DeleteEngagementProps extends IconButtonProps {
   project: ProjectIdFragment;

--- a/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/Create/CreateInternshipEngagement.tsx
@@ -1,10 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
-import {
-  Id_InternshipProject_Fragment as InternshipProjectIdFragment,
-  Id_TranslationProject_Fragment as TranslationProjectIdFragment,
-} from '~/common/fragments';
+import { ProjectIdFragment } from '~/common/fragments';
 import {
   DialogForm,
   DialogFormProps,
@@ -18,10 +15,6 @@ interface CreateInternshipEngagementFormValues {
     internId: UserLookupItem;
   };
 }
-
-type ProjectIdFragment =
-  | TranslationProjectIdFragment
-  | InternshipProjectIdFragment;
 
 type CreateInternshipEngagementProps = Except<
   DialogFormProps<CreateInternshipEngagementFormValues>,

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.graphql
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.graphql
@@ -8,13 +8,11 @@ mutation createLanguageEngagement($input: CreateLanguageEngagementInput!) {
 
 fragment TranslationProjectSensitivity on TranslationProject {
   sensitivity
-  engagements {
+  engagements: languageEngagements {
     items {
-      ... on LanguageEngagement {
-        language {
-          value {
-            sensitivity
-          }
+      language {
+        value {
+          sensitivity
         }
       }
     }

--- a/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Create/CreateLanguageEngagement.tsx
@@ -2,10 +2,7 @@ import { useMutation } from '@apollo/client';
 import { Except } from 'type-fest';
 import { addItemToList } from '~/api';
 import { callAll } from '~/common';
-import {
-  Id_InternshipProject_Fragment as InternshipProjectIdFragment,
-  Id_TranslationProject_Fragment as TranslationProjectIdFragment,
-} from '~/common/fragments';
+import { ProjectIdFragment } from '~/common/fragments';
 import {
   DialogForm,
   DialogFormProps,
@@ -23,10 +20,6 @@ interface CreateLanguageEngagementFormValues {
     languageId: LanguageLookupItem;
   };
 }
-
-type ProjectIdFragment =
-  | TranslationProjectIdFragment
-  | InternshipProjectIdFragment;
 
 type CreateLanguageEngagementProps = Except<
   DialogFormProps<CreateLanguageEngagementFormValues>,

--- a/src/scenes/Engagement/LanguageEngagement/Create/recalculateSensitivity.ts
+++ b/src/scenes/Engagement/LanguageEngagement/Create/recalculateSensitivity.ts
@@ -7,7 +7,7 @@ export const recalculateSensitivity =
     projectRef: IdFragment
   ): MutationUpdaterFunction<Res, unknown, unknown, ApolloCache<unknown>> =>
   (cache) => {
-    if (projectRef.__typename !== 'TranslationProject') {
+    if (projectRef.__typename === 'InternshipProject') {
       return;
     }
 

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjectsTable.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjectsTable.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Chip } from '@mui/material';
 import {
   DataGrid,
   DataGridProps,
@@ -7,7 +7,7 @@ import {
 } from '@mui/x-data-grid';
 import { cmpBy, simpleSwitch } from '@seedcompany/common';
 import { useNavigate } from 'react-router-dom';
-import { ProjectStatusLabels } from '~/api/schema/enumLists';
+import { ProjectStatusLabels, ProjectTypeLabels } from '~/api/schema/enumLists';
 import { Sensitivity } from '~/api/schema/schema.graphql';
 import { extendSx, labelFrom } from '~/common';
 import { SensitivityIcon } from '~/components/Sensitivity';
@@ -46,15 +46,22 @@ export const PartnerDetailProjectsTable = (
       valueGetter: ({ value }) => labelFrom(ProjectStatusLabels)(value),
     },
     {
+      headerName: 'Type',
+      field: 'type',
+      flex: 0.75,
+      valueGetter: ({ value }) => labelFrom(ProjectTypeLabels)(value),
+      renderCell: ({ value }) => <Chip label={value} variant="outlined" />,
+    },
+    {
       headerName: 'Engagements',
       field: 'engagements',
-      flex: 1,
+      flex: 0.5,
       valueGetter: ({ value }) => value.total,
     },
     {
       headerName: 'Sensitivity',
       field: 'sensitivity',
-      flex: 1,
+      flex: 0.5,
       sortComparator: cmpBy<Sensitivity>((v) =>
         simpleSwitch(v, { Low: 0, Medium: 1, High: 2 })
       ),

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerProjects.graphql
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerProjects.graphql
@@ -14,6 +14,7 @@ query PartnerProjects($id: ID!, $input: ProjectListInput) {
 
 fragment PartnerDetailProjectsTableListItem on Project {
   id
+  type
   name {
     value
   }

--- a/src/scenes/Projects/ChangeRequest/Update/UpdateProjectChangeRequest.tsx
+++ b/src/scenes/Projects/ChangeRequest/Update/UpdateProjectChangeRequest.tsx
@@ -9,6 +9,7 @@ import {
   UpdateProjectChangeRequestInput,
 } from '~/api/schema.graphql';
 import { callAll, labelFrom } from '~/common';
+import { ProjectIdFragment } from '~/common/fragments';
 import {
   DialogForm,
   DialogFormProps,
@@ -28,10 +29,7 @@ import {
 } from './UpdateProjectChangeRequest.graphql';
 
 export interface UpdateProjectChangeRequestFormParams {
-  project: {
-    __typename?: 'TranslationProject' | 'InternshipProject';
-    id: string;
-  };
+  project: ProjectIdFragment;
   changeRequest: ChangeRequest;
 }
 

--- a/src/scenes/Projects/Create/CreateProjectForm.tsx
+++ b/src/scenes/Projects/Create/CreateProjectForm.tsx
@@ -1,4 +1,9 @@
-import { CreateProjectInput, ProjectTypeList } from '~/api/schema.graphql';
+import {
+  CreateProjectInput,
+  ProjectTypeLabels,
+  ProjectTypeList,
+} from '~/api/schema.graphql';
+import { labelFrom } from '~/common';
 import {
   DialogForm,
   DialogFormProps,
@@ -20,7 +25,8 @@ export const CreateProjectForm = (props: CreateProjectFormProps) => (
       name="project.type"
       label="Type"
       options={ProjectTypeList}
-      defaultValue="Translation"
+      getLabel={labelFrom(ProjectTypeLabels)}
+      defaultValue={ProjectTypeList[0]}
       required
       variant="toggle-grouped"
     />

--- a/src/scenes/Projects/List/ProjectFilterOptions.tsx
+++ b/src/scenes/Projects/List/ProjectFilterOptions.tsx
@@ -2,6 +2,7 @@ import { Tooltip } from '@mui/material';
 import {
   ProjectStatusLabels,
   ProjectStatusList,
+  ProjectTypeLabels,
   ProjectTypeList,
   SensitivityList,
 } from '~/api/schema.graphql';
@@ -19,7 +20,7 @@ import {
 export const useProjectFilters = makeQueryHandler({
   status: EnumListParam(ProjectStatusList, { InDevelopment: 'dev' }),
   sensitivity: EnumListParam(SensitivityList),
-  type: EnumParam(ProjectTypeList),
+  type: EnumListParam(ProjectTypeList),
   onlyMultipleEngagements: withKey(BooleanParam(), 'multi'),
   tab: withDefault(EnumParam(['mine', 'all', 'pinned']), 'mine'),
 });
@@ -47,7 +48,9 @@ export const ProjectFilterOptions = () => {
       <EnumField
         name="type"
         label="Type"
+        multiple
         options={ProjectTypeList}
+        getLabel={labelFrom(ProjectTypeLabels)}
         defaultOption="Show All"
         layout="two-column"
       />

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -10,13 +10,13 @@ import {
   Publish,
   Timeline as TimelineIcon,
 } from '@mui/icons-material';
-import { Grid, Skeleton, Tooltip, Typography } from '@mui/material';
+import { Chip, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
 import { Many } from '@seedcompany/common';
 import { useDropzone } from 'react-dropzone';
 import { Helmet } from 'react-helmet-async';
 import { makeStyles } from 'tss-react/mui';
 import { PartialDeep } from 'type-fest';
-import { ProjectStepLabels } from '~/api/schema.graphql';
+import { ProjectStepLabels, ProjectTypeLabels } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { BudgetOverviewCard } from '../../../components/BudgetOverviewCard';
 import { CardGroup } from '../../../components/CardGroup';
@@ -81,16 +81,17 @@ const useStyles = makeStyles()(({ spacing, breakpoints }) => ({
     flex: 1,
     display: 'flex',
     gap: spacing(1),
-  },
-  headerLoading: {
     alignItems: 'center',
   },
   name: {
     marginRight: spacing(2), // a little extra between text and buttons
-    lineHeight: 'inherit', // centers text with buttons better
+    // centers text with buttons better
+    lineHeight: 'inherit',
+    alignSelf: 'flex-start',
   },
   nameLoading: {
     width: '30%',
+    alignSelf: 'initial',
   },
   subheader: {
     display: 'flex',
@@ -197,12 +198,7 @@ export const ProjectOverview = () => {
       </Error>
       {!error && (
         <div className={classes.main}>
-          <header
-            className={cx(
-              classes.header,
-              project ? null : classes.headerLoading
-            )}
-          >
+          <header className={classes.header}>
             <Typography
               variant="h2"
               className={cx(classes.name, project ? null : classes.nameLoading)}
@@ -220,6 +216,12 @@ export const ProjectOverview = () => {
                 />
               )}
             </Typography>
+            {project && (
+              <Chip
+                label={labelFrom(ProjectTypeLabels)(project.type)}
+                variant="outlined"
+              />
+            )}
             {(!project || project.name.canEdit) && (
               <Tooltip title="Edit Project Name">
                 <IconButton

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -167,7 +167,7 @@ export const ProjectOverview = () => {
   });
 
   const isTranslation = project
-    ? project.__typename === 'TranslationProject'
+    ? project.__typename !== 'InternshipProject'
     : undefined;
 
   const engagementTypeLabel =

--- a/src/scenes/SearchResults/SearchResults.tsx
+++ b/src/scenes/SearchResults/SearchResults.tsx
@@ -90,8 +90,9 @@ const displayItem = (
 ): [exact: string | ReactElement, card: ReactElement] | ReactElement | null => {
   /* eslint-disable react/jsx-key -- type is tuple not array */
   switch (item.__typename) {
+    case 'MomentumTranslationProject':
+    case 'MultiplicationTranslationProject':
     case 'InternshipProject':
-    case 'TranslationProject':
       return [
         <Navigate replace to={`/projects/${item.id}`} />,
         <ProjectListItemCard key={item.id} project={item} />,


### PR DESCRIPTION
API PR: https://github.com/SeedCompany/cord-api-v3/pull/3160

<!--- replace the text in parentheses with Monday link for your task -->
## [Monday task](https://seed-company-squad.monday.com/boards/3451697530/pulses/6365817053)

<!--- or if you don't have a Monday task, you can remove the line above and give the reason here -->
<!--- 
## Reason for this PR
...

-->

## Description
<!--- Describe the changes in this pull request and include screenshots if needed -->
Added a chip displaying the project type on the Project Card, Project Overview Page and Partner table project tab. 

Project Card:
![Screenshot 2024-04-08 at 3 44 50 PM](https://github.com/SeedCompany/cord-field/assets/39035380/bb56cee9-1ea8-448b-b19f-cbd8cde72563)

Project Overview:
![Screenshot 2024-04-08 at 3 45 11 PM](https://github.com/SeedCompany/cord-field/assets/39035380/340d8a48-9b65-423a-8db1-26a7cdd3f8eb)


Partner Table Project tab:
![Screenshot 2024-04-09 at 11 19 29 AM](https://github.com/SeedCompany/cord-field/assets/39035380/6b849d38-74cc-4e85-89f9-9eed548ceb7b)



## Ready for review checklist
> Use `[N/A]` if the item is not applicable to this PR or remove the item
- [x] Change the task url above to the actual Monday task
- [ NA] Add/update tests if needed
- [x] Add reviewers to this PR
