### PR TITLE
Error handling Q2 2024

### DIFF
--- a/src/api/client/links/renderErrors.link.tsx
+++ b/src/api/client/links/renderErrors.link.tsx
@@ -31,8 +31,8 @@ const errorRenderer =
     }
 
     for (const gqlError of graphQLErrors || []) {
-      const codes = new Set(gqlError.extensions.codes as string[]);
-      const stacktrace = (gqlError.extensions.stacktrace ?? []) as string[];
+      const codes = new Set(gqlError.extensions.codes);
+      const stacktrace = gqlError.extensions.stacktrace ?? [];
 
       // don't show client errors unless they are API communication related
       if (codes.has('Client') && !codes.has('GraphQL')) {

--- a/src/api/client/links/session.link.ts
+++ b/src/api/client/links/session.link.ts
@@ -3,6 +3,12 @@ import { ErrorLink } from '@apollo/client/link/error';
 import { SessionDocument } from '~/components/Session/session.graphql';
 import { GQLOperations } from '../../operationsList';
 
+declare module '~/api/errorHandling/error.types' {
+  interface ErrorMap {
+    NoSession: unknown;
+  }
+}
+
 /**
  * Retry operations on session errors
  */
@@ -15,7 +21,7 @@ export class SessionLink extends ErrorLink {
 
         // Re-establish session if needed then retry the operation
         if (
-          ext.code === 'NoSession' &&
+          ext.codes[0] === 'NoSession' &&
           operation.operationName !== GQLOperations.Query.Session
         ) {
           if (!this.client) {

--- a/src/api/errorHandling/error.types.ts
+++ b/src/api/errorHandling/error.types.ts
@@ -88,11 +88,11 @@ export interface StepNotPlannedError extends InputError {
 }
 
 export const isErrorCode = <K extends keyof ErrorMap>(
-  errorInfo: ReturnType<typeof getErrorInfo>,
+  errorInfo: ErrorInfo,
   code: K
-): errorInfo is ErrorMap[K] => errorInfo.codes.includes(code);
+): errorInfo is ErrorInfo & ErrorMap[K] => errorInfo.codes.includes(code);
 
-export const getErrorInfo = (e: unknown) => {
+export const getErrorInfo = (e: unknown): ErrorInfo => {
   if (!(e instanceof ApolloError) || !e.graphQLErrors[0]) {
     // This is really to make TS happy. We should always have an ApolloError here.
     assert(e instanceof Error);
@@ -102,16 +102,10 @@ export const getErrorInfo = (e: unknown) => {
     };
   }
 
-  // For mutations we will assume they will only have one error
+  // For mutations, we will assume they will only have one error
   // since they should only be doing one operation.
-  const ext = e.graphQLErrors[0].extensions as {
-    codes?: Code[];
-    code?: Code;
-  };
-  const codes: Code[] = [
-    ...(ext.codes ?? (ext.code ? [ext.code] : [])),
-    'Default',
-  ];
+  const ext = e.graphQLErrors[0].extensions;
+  const codes = [...ext.codes, 'Default' as const];
   return {
     message: e.message,
     ...ext,

--- a/src/api/errorHandling/error.types.ts
+++ b/src/api/errorHandling/error.types.ts
@@ -2,6 +2,16 @@ import { ApolloError } from '@apollo/client';
 import { assert } from 'ts-essentials';
 import { ProductStep } from '../schema.graphql';
 
+interface CordErrorExtensions {
+  codes: readonly Code[];
+  stacktrace?: readonly string[];
+}
+
+declare module 'graphql/error/GraphQLError' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface GraphQLErrorExtensions extends CordErrorExtensions {}
+}
+
 /**
  * This is a mapping of error codes to their error object.
  * This mapping should be expanded upon as we add and handle
@@ -39,9 +49,8 @@ export type Code = keyof ErrorMap;
 /**
  * The basic error shape
  */
-interface ErrorInfo {
+interface ErrorInfo extends CordErrorExtensions {
   message: string;
-  codes: Code[];
 }
 
 /**

--- a/src/api/errorHandling/error.types.ts
+++ b/src/api/errorHandling/error.types.ts
@@ -37,6 +37,10 @@ export interface ErrorMap {
    */
   Server: ErrorInfo;
 
+  // Error in GraphQL schema.
+  // Could be a Client or Server error not fulfilling the schema.
+  GraphQL: unknown;
+
   /**
    * This is a special one that allows a default handler for any
    * un-handled error codes.

--- a/src/api/errorHandling/form-error-handling.test.ts
+++ b/src/api/errorHandling/form-error-handling.test.ts
@@ -2,6 +2,7 @@ import { ApolloError } from '@apollo/client';
 import { createForm, FORM_ERROR, FormApi } from 'final-form';
 import { GraphQLError } from 'graphql';
 import { noop } from 'lodash';
+import { Code } from './error.types';
 import { ErrorHandlers, handleFormError } from './form-error-handling';
 
 describe('handleFormError', () => {
@@ -11,7 +12,13 @@ describe('handleFormError', () => {
   beforeEach(() => {
     error = createError({
       message: 'Not found',
-      codes: ['VerySpecific', 'NotFound', 'SomethingElse', 'Input', 'Client'],
+      codes: [
+        'VerySpecific' as any,
+        'NotFound',
+        'SomethingElse',
+        'Input',
+        'Client',
+      ],
     });
     form = createForm({
       onSubmit: noop,
@@ -123,7 +130,7 @@ const createError = ({
   ...extensions
 }: {
   message: string;
-  codes: string[];
+  codes: Code[];
   [rest: string]: unknown;
 }) => {
   return new ApolloError({


### PR DESCRIPTION
Following up https://github.com/SeedCompany/cord-api-v3/pull/3181 with a few things here.

- Mostly type changes
- Stop normalizing `code` to `codes`, the latter should always exist.
- Fix SessionLink check for `NoSession` which was checking `code` instead of `codes`.
  This actually regressed around the Apollo Server v4 upgrade timeframe.