### PR TITLE
Workflow UI: Ungroup transition labels / MUI Controls / Reset Layout Control

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
     "tss-react": "^3.7.1",
     "validator": "^13.11.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz",
-    "xss": "^1.0.14"
+    "xss": "^1.0.14",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",

--- a/src/components/Workflow/Controls.tsx
+++ b/src/components/Workflow/Controls.tsx
@@ -6,14 +6,17 @@ import {
   Remove as ZoomOut,
 } from '@mui/icons-material';
 import { Button, ButtonGroup, Tooltip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { useToggle } from 'ahooks';
 import { useEffect } from 'react';
 import {
+  FitViewOptions,
   Panel,
   ReactFlowState,
   useReactFlow,
   useStore,
   useStoreApi,
+  ViewportHelperFunctionOptions,
 } from 'reactflow';
 import { shallow } from 'zustand/shallow';
 
@@ -24,6 +27,7 @@ const selector = (s: ReactFlowState) => ({
 });
 
 export const Controls = () => {
+  const theme = useTheme();
   const store = useStoreApi();
   const { isInteractive, minZoomReached, maxZoomReached } = useStore(
     selector,
@@ -40,6 +44,10 @@ export const Controls = () => {
   }
 
   const ToggleLock = isInteractive ? Unlock : Lock;
+
+  const zoomOptions = {
+    duration: theme.transitions.duration.complex,
+  } satisfies FitViewOptions & ViewportHelperFunctionOptions;
 
   return (
     <Panel position="bottom-left">
@@ -61,17 +69,20 @@ export const Controls = () => {
         })}
       >
         <Tooltip title="Zoom In" placement="right">
-          <Button onClick={() => zoomIn()} disabled={maxZoomReached}>
+          <Button onClick={() => zoomIn(zoomOptions)} disabled={maxZoomReached}>
             <ZoomIn />
           </Button>
         </Tooltip>
         <Tooltip title="Zoom Out" placement="right">
-          <Button onClick={() => zoomOut()} disabled={minZoomReached}>
+          <Button
+            onClick={() => zoomOut(zoomOptions)}
+            disabled={minZoomReached}
+          >
             <ZoomOut />
           </Button>
         </Tooltip>
         <Tooltip title="Fit View" placement="right">
-          <Button onClick={() => fitView()}>
+          <Button onClick={() => fitView(zoomOptions)}>
             <Fullscreen />
           </Button>
         </Tooltip>

--- a/src/components/Workflow/Controls.tsx
+++ b/src/components/Workflow/Controls.tsx
@@ -1,4 +1,5 @@
 import {
+  AutoGraph,
   Fullscreen,
   Lock,
   LockOpen as Unlock,
@@ -26,7 +27,11 @@ const selector = (s: ReactFlowState) => ({
   maxZoomReached: s.transform[2] >= s.maxZoom,
 });
 
-export const Controls = () => {
+export interface ControlsProps {
+  onResetLayout?: () => void;
+}
+
+export const Controls = (props: ControlsProps) => {
   const theme = useTheme();
   const store = useStoreApi();
   const { isInteractive, minZoomReached, maxZoomReached } = useStore(
@@ -101,6 +106,13 @@ export const Controls = () => {
             <ToggleLock />
           </Button>
         </Tooltip>
+        {props.onResetLayout && (
+          <Tooltip title="Reset Layout" placement="right">
+            <Button onClick={props.onResetLayout}>
+              <AutoGraph />
+            </Button>
+          </Tooltip>
+        )}
       </ButtonGroup>
     </Panel>
   );

--- a/src/components/Workflow/Controls.tsx
+++ b/src/components/Workflow/Controls.tsx
@@ -1,0 +1,96 @@
+import {
+  Fullscreen,
+  Lock,
+  LockOpen as Unlock,
+  Add as ZoomIn,
+  Remove as ZoomOut,
+} from '@mui/icons-material';
+import { Button, ButtonGroup, Tooltip } from '@mui/material';
+import { useToggle } from 'ahooks';
+import { useEffect } from 'react';
+import {
+  Panel,
+  ReactFlowState,
+  useReactFlow,
+  useStore,
+  useStoreApi,
+} from 'reactflow';
+import { shallow } from 'zustand/shallow';
+
+const selector = (s: ReactFlowState) => ({
+  isInteractive: s.nodesDraggable || s.elementsSelectable,
+  minZoomReached: s.transform[2] <= s.minZoom,
+  maxZoomReached: s.transform[2] >= s.maxZoom,
+});
+
+export const Controls = () => {
+  const store = useStoreApi();
+  const { isInteractive, minZoomReached, maxZoomReached } = useStore(
+    selector,
+    shallow
+  );
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+
+  // Don't show the panel until the bundle (with styles) is loaded
+  const [isVisible, setIsVisible] = useToggle();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(setIsVisible.setRight, []);
+  if (!isVisible) {
+    return null;
+  }
+
+  const ToggleLock = isInteractive ? Unlock : Lock;
+
+  return (
+    <Panel position="bottom-left">
+      <ButtonGroup
+        orientation="vertical"
+        color="secondary"
+        variant="text"
+        sx={(theme) => ({
+          x: theme.transitions.duration.complex,
+          backgroundColor: theme.palette.background.paper,
+          boxShadow: theme.shadows[4],
+          '.MuiButton-root': {
+            minWidth: 'initial',
+            p: '5px',
+          },
+          svg: {
+            fontSize: '1.5rem',
+          },
+        })}
+      >
+        <Tooltip title="Zoom In" placement="right">
+          <Button onClick={() => zoomIn()} disabled={maxZoomReached}>
+            <ZoomIn />
+          </Button>
+        </Tooltip>
+        <Tooltip title="Zoom Out" placement="right">
+          <Button onClick={() => zoomOut()} disabled={minZoomReached}>
+            <ZoomOut />
+          </Button>
+        </Tooltip>
+        <Tooltip title="Fit View" placement="right">
+          <Button onClick={() => fitView()}>
+            <Fullscreen />
+          </Button>
+        </Tooltip>
+        <Tooltip
+          title={isInteractive ? 'Lock Layout' : 'Unlock Layout'}
+          placement="right"
+        >
+          <Button
+            onClick={() => {
+              store.setState({
+                nodesDraggable: !isInteractive,
+                elementsSelectable: !isInteractive,
+              });
+            }}
+          >
+            <ToggleLock />
+          </Button>
+        </Tooltip>
+      </ButtonGroup>
+    </Panel>
+  );
+};

--- a/src/components/Workflow/Flowchart.tsx
+++ b/src/components/Workflow/Flowchart.tsx
@@ -55,7 +55,7 @@ const Flowchart = (props: Props) => {
 
   useQuery(props.doc, {
     onCompleted: ({ workflow }) => {
-      autoLayout.reset();
+      autoLayout.restart();
       const { nodes, edges } = parseWorkflow(workflow);
       const persistedPosNodes = nodes.map((node) =>
         storedPos?.[node.id] ? { ...node, position: storedPos[node.id]! } : node
@@ -96,7 +96,7 @@ const Flowchart = (props: Props) => {
         proOptions={{ hideAttribution: true }}
       >
         <Background />
-        <Controls />
+        <Controls onResetLayout={autoLayout.reset} />
       </ReactFlow>
     </FlowchartStyles>
   );

--- a/src/components/Workflow/Flowchart.tsx
+++ b/src/components/Workflow/Flowchart.tsx
@@ -93,6 +93,7 @@ const Flowchart = (props: Props) => {
         edgeTypes={edgeTypes}
         minZoom={0.1}
         nodesConnectable={false}
+        proOptions={{ hideAttribution: true }}
       >
         <Background />
         <Controls />

--- a/src/components/Workflow/Flowchart.tsx
+++ b/src/components/Workflow/Flowchart.tsx
@@ -6,7 +6,6 @@ import { ComponentType, useCallback, useMemo } from 'react';
 import ReactFlow, {
   applyNodeChanges,
   Background,
-  Controls,
   EdgeTypes,
   NodeProps,
   OnNodesChange,
@@ -15,6 +14,7 @@ import ReactFlow, {
   useNodesState,
   XYPosition,
 } from 'reactflow';
+import { Controls } from './Controls';
 import {
   Edge as EdgeComponent,
   FlowchartStyles,

--- a/src/components/Workflow/layout.ts
+++ b/src/components/Workflow/layout.ts
@@ -20,7 +20,8 @@ export const determinePositions = (nodes: Node[], edges: Edge[]) => {
 
   const nodeMap = mapKeys.fromList(nodes, (n) => n.id).asMap;
 
-  nodes.forEach((node) =>
+  // Reversing somehow produces a better layout
+  nodes.toReversed().forEach((node) =>
     g.setNode(node.id, {
       ...node,
       width: node.width!,

--- a/src/components/Workflow/nodes.tsx
+++ b/src/components/Workflow/nodes.tsx
@@ -26,7 +26,6 @@ import 'reactflow/dist/style.css';
 
 export const FlowchartStyles = styled(Box)(({ theme }) => ({
   height: '100%',
-  '.react-flow__attribution': { display: 'none' },
   '& .react-flow': {
     '.react-flow__edge-textbg': {
       fill: theme.palette.background.paper,

--- a/src/components/Workflow/parse-node-edges.tsx
+++ b/src/components/Workflow/parse-node-edges.tsx
@@ -22,24 +22,23 @@ export function parseWorkflow(workflow: Workflow) {
     })
   );
 
-  const transitionEnds = uniqBy(workflow.transitions, transitionEndId);
-  const transitionEndNodes = transitionEnds.map(
+  const transitions = workflow.transitions.map(
     (t): Node<Transition, NodeTypes> => ({
-      id: transitionEndId(t),
+      id: t.key,
       type: 'transition',
       data: t,
       position: { x: 0, y: 0 },
     })
   );
-  const nodes = [...states, ...transitionEndNodes].reverse();
+  const nodes = [...states, ...transitions].reverse();
 
   const edges = uniqBy(
     workflow.transitions
       .flatMap<Edge<Transition>>((t) => [
         ...t.from.map((from) => ({
-          id: `${from.value} -> ${transitionEndId(t)}`,
+          id: `${from.value} -> ${t.key}`,
           source: from.value,
-          target: transitionEndId(t),
+          target: t.key,
           targetHandle: 'forward',
           label: (
             <>
@@ -55,8 +54,8 @@ export function parseWorkflow(workflow: Workflow) {
         })),
         ...(isDynamic(t.to)
           ? t.to.relatedStates.map((state) => ({
-              id: `${transitionEndId(t)} -> ${state.value}`,
-              source: transitionEndId(t),
+              id: `${t.key} -> ${state.value}`,
+              source: t.key,
               target: state.value,
               targetHandle: isBack(t) ? 'back' : 'forward',
               label: isBack(t) ? 'Back' : undefined,
@@ -64,8 +63,8 @@ export function parseWorkflow(workflow: Workflow) {
             }))
           : [
               {
-                id: `${transitionEndId(t)} -> ${t.to.state.value}`,
-                source: transitionEndId(t),
+                id: `${t.key} -> ${t.to.state.value}`,
+                source: t.key,
                 target: t.to.state.value,
                 targetHandle: 'forward',
                 data: t,
@@ -85,13 +84,6 @@ export function parseWorkflow(workflow: Workflow) {
 export const isBack = (t: Transition) =>
   isDynamic(t.to) && t.to.label === 'Back';
 
-const transitionEndId = (t: Transition) => {
-  const endId =
-    t.to.__typename === 'WorkflowTransitionStaticTo'
-      ? t.to.state.value
-      : t.to.id;
-  return `${t.label} -> ${endId}`;
-};
 const isDynamic = isTypename<WorkflowTransitionDynamicTo>(
   'WorkflowTransitionDynamicTo'
 );

--- a/src/components/Workflow/parse-node-edges.tsx
+++ b/src/components/Workflow/parse-node-edges.tsx
@@ -30,7 +30,7 @@ export function parseWorkflow(workflow: Workflow) {
       position: { x: 0, y: 0 },
     })
   );
-  const nodes = [...states, ...transitions].reverse();
+  const nodes = [...states, ...transitions];
 
   const edges = uniqBy(
     workflow.transitions

--- a/src/components/Workflow/parse-node-edges.tsx
+++ b/src/components/Workflow/parse-node-edges.tsx
@@ -1,4 +1,3 @@
-import { cmpBy } from '@seedcompany/common';
 import { uniqBy } from 'lodash';
 import { Fragment } from 'react';
 import { Edge, Node } from 'reactflow';
@@ -23,18 +22,7 @@ export function parseWorkflow(workflow: Workflow) {
     })
   );
 
-  const transitionEnds = uniqBy(
-    workflow.transitions.toSorted(
-      cmpBy((t) => {
-        const endState =
-          t.to.__typename === 'WorkflowTransitionStaticTo'
-            ? t.to.state.value
-            : t.to.relatedStates[0]!.value;
-        return workflow.states.findIndex((e) => e.value === endState);
-      })
-    ),
-    transitionEndId
-  );
+  const transitionEnds = uniqBy(workflow.transitions, transitionEndId);
   const transitionEndNodes = transitionEnds.map(
     (t): Node<Transition, NodeTypes> => ({
       id: transitionEndId(t),

--- a/src/components/Workflow/useAutoLayout.ts
+++ b/src/components/Workflow/useAutoLayout.ts
@@ -16,7 +16,7 @@ export const useAutoLayout = (setNodes: Dispatch<Node[]>) => {
   const autoLayoutStage = useRef(0);
   const [show, setShow] = useToggle();
 
-  const reset = useCallback(() => {
+  const restart = useCallback(() => {
     autoLayoutStage.current = 0;
   }, []);
 
@@ -75,9 +75,22 @@ export const useAutoLayout = (setNodes: Dispatch<Node[]>) => {
     [store, api, autoLayoutStage, setShow, setNodes, highlightedState]
   );
 
+  const reset = useCallback(() => {
+    const positioned = determinePositions(
+      api.getNodes().map((node) => ({
+        ...node,
+        position: { x: 0, y: 0 },
+      })),
+      api.getEdges()
+    );
+    api.setNodes(positioned);
+    window.requestAnimationFrame(() => api.fitView());
+  }, [api]);
+
   return {
     show,
     showSx: !show ? showSx : undefined,
+    restart,
     reset,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7990,6 +7990,7 @@ __metadata:
     webpack-dynamic-public-path: "npm:^1.0.8"
     xlsx: "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
     xss: "npm:^1.0.14"
+    zustand: "npm:^4.5.2"
   dependenciesMeta:
     core-js-pure:
       built: false
@@ -21096,7 +21097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.4.1":
+"zustand@npm:^4.4.1, zustand@npm:^4.5.2":
   version: 4.5.2
   resolution: "zustand@npm:4.5.2"
   dependencies:


### PR DESCRIPTION
- Stop grouping transition nodes by label. 
  This was fine for mermaid rendering in API, but this UI now shows
notifications & permissions, which can be unique per transition.
  Previously pre-grouped transitions hid actual permissions/notifiers of other transitions with the same label & to state.
- Reimplement controls with MUI
  It looks nicer & more consistent
  ![MUI Controls](https://github.com/SeedCompany/cord-field/assets/932566/69b4c82e-4733-4b2f-8661-d935d6606f9a)
- Add control to reset persisted layout to auto generated one.
  If the workflow changes enough (like with bullet point # 1), users may want to start over.
  This gives the option without having to "clear everything for site data".


