### PR TITLE
Fix pin button tooltip changing position when toggling

### DIFF
--- a/src/components/TogglePinButton/TogglePinButton.tsx
+++ b/src/components/TogglePinButton/TogglePinButton.tsx
@@ -1,25 +1,12 @@
 import { useMutation } from '@apollo/client';
-import { Tooltip, TooltipProps } from '@mui/material';
-import { makeStyles } from 'tss-react/mui';
+import { SvgIcon, Tooltip, TooltipProps } from '@mui/material';
 import { Except } from 'type-fest';
 import { addItemToList, ListIdentifier, removeItemFromList } from '~/api';
 import { IconButton, IconButtonProps } from '../IconButton';
-import { PushPinIconFilled, PushPinIconOutlined } from '../Icons';
 import {
   TogglePinFragment,
   TogglePinnedDocument,
 } from './TogglePinButton.graphql';
-
-const useStyles = makeStyles<{ pinned: boolean }>()(
-  ({ transitions }, { pinned }) => ({
-    root: {
-      transition: transitions.create('transform', {
-        duration: transitions.duration.short,
-      }),
-      transform: pinned ? 'none' : 'rotate(45deg)',
-    },
-  })
-);
 
 export type TogglePinButtonProps = Except<IconButtonProps, 'children'> & {
   object?: TogglePinFragment;
@@ -40,8 +27,6 @@ export const TogglePinButton = ({
   TooltipProps,
   ...rest
 }: TogglePinButtonProps) => {
-  const { classes, cx } = useStyles({ pinned: object?.pinned ?? false });
-
   const [togglePinned] = useMutation(TogglePinnedDocument, {
     update: (cache, result, options) => {
       if (!result.data || !object) {
@@ -76,8 +61,6 @@ export const TogglePinButton = ({
     },
   });
 
-  const Icon = object?.pinned ? PushPinIconFilled : PushPinIconOutlined;
-
   const button = (
     <IconButton
       color={object?.pinned ? 'secondary' : undefined}
@@ -96,12 +79,25 @@ export const TogglePinButton = ({
       }}
       disabled={rest.disabled || !object}
       loading={rest.loading || !object}
-      classes={{
-        ...rest.classes,
-        root: cx(classes.root, rest.classes?.root),
-      }}
     >
-      <Icon fontSize={rest.size ? 'inherit' : undefined} />
+      <SvgIcon
+        viewBox="0 0 24 24"
+        fontSize={rest.size ? 'inherit' : undefined}
+        css={[
+          (theme) => ({
+            transition: theme.transitions.create('all', {
+              duration: theme.transitions.duration.short,
+            }),
+          }),
+          object?.pinned ? undefined : { transform: 'rotate(45deg)' },
+        ]}
+      >
+        {object?.pinned ? (
+          <path d="M16,9V4l1,0c0.55,0,1-0.45,1-1v0c0-0.55-0.45-1-1-1H7C6.45,2,6,2.45,6,3v0 c0,0.55,0.45,1,1,1l1,0v5c0,1.66-1.34,3-3,3h0v2h5.97v7l1,1l1-1v-7H19v-2h0C17.34,12,16,10.66,16,9z" />
+        ) : (
+          <path d="M14,4v5c0,1.12,0.37,2.16,1,3H9c0.65-0.86,1-1.9,1-3V4H14 M17,2H7C6.45,2,6,2.45,6,3c0,0.55,0.45,1,1,1c0,0,0,0,0,0l1,0v5 c0,1.66-1.34,3-3,3v2h5.97v7l1,1l1-1v-7H19v-2c0,0,0,0,0,0c-1.66,0-3-1.34-3-3V4l1,0c0,0,0,0,0,0c0.55,0,1-0.45,1-1 C18,2.45,17.55,2,17,2L17,2z" />
+        )}
+      </SvgIcon>
     </IconButton>
   );
 


### PR DESCRIPTION
### Before &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; After
<img src="https://github.com/SeedCompany/cord-field/assets/932566/9f216387-9986-4827-bbfc-08775606c7b3" width="200" alt="Before">
<img src="https://github.com/SeedCompany/cord-field/assets/932566/f6aae072-a077-4632-a210-203b2acd2485" width="200" alt="After">

The button has padding on it, and the bottom corner was rotating down. This isn't visually noticed normally because the button is a circle. But it affected the position of the tooltip,
the bottom point pushed it down.

Changing instead to animating the svg icon within the button.

Previously, the element was mounted/unmounted with the icon switch. The animation was on the parent button, so it was fine. Now that the animation is on the svg icon, it needs to stay mounted for the animation to appear.
Fixed this by swapping out the paths within the svg element.

Also took the opportunity to swap off the old styles.