### PR TITLE
Fix CardGroup & ResponsiveDivider regression

### DIFF
--- a/src/common/styles.ts
+++ b/src/common/styles.ts
@@ -3,14 +3,16 @@ import { Breakpoint, Breakpoints } from '@mui/material';
 import { decomposeColor, recomposeColor } from '@mui/material/styles';
 import { clamp } from 'lodash';
 import { CSSObject as CSSProperties } from 'tss-react';
-import { lowerCase } from './case';
+import { LiteralUnion } from 'type-fest';
 
 export const square = (size: string | number) => ({
   width: size,
   height: size,
 });
 
-export type BreakpointAt = `${Breakpoint}${'Up' | 'Down'}` | boolean;
+export type BreakpointAt =
+  | LiteralUnion<`${Breakpoint}${'Up' | 'Down'}`, string>
+  | boolean;
 
 export const applyBreakpoint = (
   breakpoints: Breakpoints,
@@ -24,9 +26,15 @@ export const applyBreakpoint = (
     return {};
   }
   const [bp, dir] = bpProp.endsWith('Up')
-    ? ([bpProp.slice(0, -2) as Breakpoint, 'up'] as const)
-    : ([bpProp.slice(0, -4) as Breakpoint, 'down'] as const);
-  return { [breakpoints[dir](bp)]: css };
+    ? ([bpProp.slice(0, -2), 'up'] as const)
+    : bpProp.endsWith('Down')
+    ? ([bpProp.slice(0, -4), 'down'] as const)
+    : ([bpProp, 'up'] as const);
+  if (bp in breakpoints.values) {
+    return { [breakpoints[dir](bp as Breakpoint)]: css };
+  }
+  // Assume css query
+  return { [bpProp]: css };
 };
 
 /**

--- a/src/common/styles.ts
+++ b/src/common/styles.ts
@@ -16,16 +16,18 @@ export const applyBreakpoint = (
   breakpoints: Breakpoints,
   bpProp: BreakpointAt | undefined,
   css: CSSProperties
-) =>
-  bpProp === true
-    ? css
-    : !bpProp
-    ? {}
-    : {
-        [breakpoints[lowerCase(bpProp.slice(2) as 'Up' | 'Down')](
-          bpProp.slice(0, 2) as Breakpoint
-        )]: css,
-      };
+) => {
+  if (bpProp === true) {
+    return css;
+  }
+  if (!bpProp) {
+    return {};
+  }
+  const [bp, dir] = bpProp.endsWith('Up')
+    ? ([bpProp.slice(0, -2) as Breakpoint, 'up'] as const)
+    : ([bpProp.slice(0, -4) as Breakpoint, 'down'] as const);
+  return { [breakpoints[dir](bp)]: css };
+};
 
 /**
  * A helper to format the grid-template-areas CSS prop.

--- a/src/components/CardGroup/CardGroup.tsx
+++ b/src/components/CardGroup/CardGroup.tsx
@@ -1,37 +1,33 @@
 import { Card, CardProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
-import { Children, ComponentType, Fragment } from 'react';
-import { applyBreakpoint, BreakpointAt } from '~/common';
+import { Children, Fragment } from 'react';
+import { applyBreakpoint, BreakpointAt, extendSx } from '~/common';
 import { ResponsiveDivider } from '../ResponsiveDivider';
 
 export interface CardGroupProps extends CardProps {
   horizontal?: BreakpointAt;
 }
 
-const CardGroupRoot = styled(Card as ComponentType<CardGroupProps>)(
-  ({ horizontal, theme }) => ({
-    root: {
-      display: 'flex',
-      flexDirection: 'column',
-      ...applyBreakpoint(theme.breakpoints, horizontal, {
-        flexDirection: 'row',
+export const CardGroup = ({ horizontal, ...props }: CardGroupProps) => (
+  <Card
+    {...props}
+    sx={[
+      (theme) => ({
+        display: 'flex',
+        flexDirection: 'column',
+        ...applyBreakpoint(theme.breakpoints, horizontal, {
+          flexDirection: 'row',
+        }),
       }),
-    },
-  })
+      ...extendSx(props.sx),
+    ]}
+  >
+    {Children.map(props.children, (child, index) => (
+      <Fragment key={index}>
+        {index % 2 ? (
+          <ResponsiveDivider vertical={horizontal} spacing={2} />
+        ) : null}
+        {child}
+      </Fragment>
+    ))}
+  </Card>
 );
-
-export const CardGroup = (props: CardGroupProps) => {
-  const { children, ...rest } = props;
-  return (
-    <CardGroupRoot {...rest}>
-      {Children.map(children, (child, index) => (
-        <Fragment key={index}>
-          {index % 2 ? (
-            <ResponsiveDivider vertical={props.horizontal} spacing={2} />
-          ) : null}
-          {child}
-        </Fragment>
-      ))}
-    </CardGroupRoot>
-  );
-};

--- a/src/components/MemberListSummary/MemberListSummary.tsx
+++ b/src/components/MemberListSummary/MemberListSummary.tsx
@@ -1,8 +1,8 @@
 import {
   AvatarGroup,
   CardContent,
-  Grid,
   Skeleton,
+  Stack,
   Typography,
 } from '@mui/material';
 import { To } from 'history';
@@ -14,12 +14,6 @@ import { HugeIcon, HugeIconProps } from '../Icons';
 import { CardActionAreaLink } from '../Routing';
 
 const useStyles = makeStyles()(({ spacing }) => ({
-  grid: {
-    marginBottom: spacing(2),
-  },
-  seeAll: {
-    marginLeft: 'auto',
-  },
   bottomContent: {
     display: 'flex',
     alignItems: 'center',
@@ -62,20 +56,21 @@ export const MemberListSummary = ({
   return (
     <CardActionAreaLink to={to} disabled={!members}>
       <CardContent>
-        <Grid container spacing={4} className={classes.grid}>
-          <Grid item>
-            <HugeIcon icon={icon} />
-          </Grid>
-          <Grid item>
-            <Typography>{title}</Typography>
+        <Stack direction="row" spacing={4} mb={2}>
+          <HugeIcon icon={icon} />
+          <div>
+            <Typography sx={{ whiteSpace: 'nowrap' }}>{title}</Typography>
             <Typography variant="h1">
               {!members ? <Skeleton width="1ch" variant="text" /> : total}
             </Typography>
-          </Grid>
-          <Grid item className={classes.seeAll}>
-            <Typography color="primary">See All</Typography>
-          </Grid>
-        </Grid>
+          </div>
+          <Typography
+            color="primary"
+            sx={{ flex: 1, textAlign: 'right', whiteSpace: 'nowrap' }}
+          >
+            See All
+          </Typography>
+        </Stack>
         <div className={classes.bottomContent}>
           <AvatarGroup max={max} className={classes.avatarGroup}>
             {listOrPlaceholders(members, max).map((member, i) => (

--- a/src/components/PeriodicReports/OverviewCard/ReportInfoContainer.tsx
+++ b/src/components/PeriodicReports/OverviewCard/ReportInfoContainer.tsx
@@ -1,6 +1,6 @@
 import { Box, Stack } from '@mui/material';
 import { ChildrenProp, extendSx, StyleProps } from '~/common';
-import { ResponsiveDivider2 as ResponsiveDivider } from '../../ResponsiveDivider';
+import { ResponsiveDivider } from '../../ResponsiveDivider';
 
 export const ReportInfoContainer = ({
   spaceEvenlyAt,
@@ -13,7 +13,7 @@ export const ReportInfoContainer = ({
     <Stack
       divider={
         <ResponsiveDivider
-          verticalWhen={`@container (min-width: ${horizontalAt}px)`}
+          vertical={`@container (min-width: ${horizontalAt}px)`}
           className="divider"
         />
       }

--- a/src/components/ResponsiveDivider/ResponsiveDivider.tsx
+++ b/src/components/ResponsiveDivider/ResponsiveDivider.tsx
@@ -33,15 +33,19 @@ export const ResponsiveDivider = styled(
  */
 export const ResponsiveDivider2 = ({
   verticalWhen,
+  spacing,
   ...rest
 }: {
   verticalWhen: string;
+  spacing?: number;
 } & StyleProps) => (
   <Divider
     {...rest}
     sx={[
-      {
+      (theme) => ({
+        margin: theme.spacing(0, spacing ?? 0),
         [verticalWhen]: {
+          margin: theme.spacing(spacing ?? 0, 0),
           // Divider orientation=vertical
           borderBottomWidth: 0,
           borderRightWidth: 'thin',
@@ -49,7 +53,7 @@ export const ResponsiveDivider2 = ({
           height: 'auto',
           alignSelf: 'stretch',
         },
-      },
+      }),
       ...extendSx(rest.sx),
     ]}
   />

--- a/src/components/ResponsiveDivider/ResponsiveDivider.tsx
+++ b/src/components/ResponsiveDivider/ResponsiveDivider.tsx
@@ -1,42 +1,21 @@
-import { Divider, DividerProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
-import { ComponentType } from 'react';
+import { Divider } from '@mui/material';
 import { applyBreakpoint, BreakpointAt, extendSx, StyleProps } from '~/common';
 
-export interface ResponsiveDividerProps extends DividerProps {
-  vertical?: BreakpointAt;
-  spacing?: number;
-}
-
-export const ResponsiveDivider = styled(
-  Divider as ComponentType<ResponsiveDividerProps>
-)(({ spacing, vertical, theme }) => ({
-  root: {
-    width: `calc(100% - ${theme.spacing(spacing ?? 0)} * 2)`,
-    margin: theme.spacing(0, spacing ?? 0),
-    '.MuiGrid-container > &': {
-      marginRight: -1,
-    },
-    ...applyBreakpoint(theme.breakpoints, vertical, {
-      margin: theme.spacing(spacing ?? 0, 0),
-      borderLeftWidth: 'thin',
-      // Divider orientation=vertical & flexItem
-      width: 1,
-      height: 'auto',
-      alignSelf: 'stretch',
-    }),
-  },
-}));
-
 /**
- * Horizontal divider until `verticalWhen` css query is matched.
+ * Horizontal divider until `vertical`
  */
-export const ResponsiveDivider2 = ({
-  verticalWhen,
+export const ResponsiveDivider = ({
+  vertical,
   spacing,
   ...rest
 }: {
-  verticalWhen: string;
+  /**
+   * Can be:
+   * - true
+   * - a css media/container query
+   * - a theme breakpoint up/down i.e. "mdUp"
+   */
+  vertical?: BreakpointAt;
   spacing?: number;
 } & StyleProps) => (
   <Divider
@@ -44,7 +23,7 @@ export const ResponsiveDivider2 = ({
     sx={[
       (theme) => ({
         margin: theme.spacing(0, spacing ?? 0),
-        [verticalWhen]: {
+        ...applyBreakpoint(theme.breakpoints, vertical, {
           margin: theme.spacing(spacing ?? 0, 0),
           // Divider orientation=vertical
           borderBottomWidth: 0,
@@ -52,7 +31,7 @@ export const ResponsiveDivider2 = ({
           // Divider flexItem
           height: 'auto',
           alignSelf: 'stretch',
-        },
+        }),
       }),
       ...extendSx(rest.sx),
     ]}

--- a/src/components/ResponsiveDivider/ResponsiveDivider.tsx
+++ b/src/components/ResponsiveDivider/ResponsiveDivider.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, DividerProps } from '@mui/material';
+import { Divider, DividerProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { ComponentType } from 'react';
 import { applyBreakpoint, BreakpointAt, extendSx, StyleProps } from '~/common';
@@ -33,24 +33,24 @@ export const ResponsiveDivider = styled(
  */
 export const ResponsiveDivider2 = ({
   verticalWhen,
-  DividerProps,
   ...rest
-}: { verticalWhen: string; DividerProps?: DividerProps } & StyleProps) => (
-  <Box
+}: {
+  verticalWhen: string;
+} & StyleProps) => (
+  <Divider
     {...rest}
     sx={[
       {
-        hr: { display: 'none' },
-        'hr:nth-of-type(1)': { display: 'block' },
         [verticalWhen]: {
-          display: 'flex',
-          'hr:nth-of-type(2)': { display: 'initial' },
+          // Divider orientation=vertical
+          borderBottomWidth: 0,
+          borderRightWidth: 'thin',
+          // Divider flexItem
+          height: 'auto',
+          alignSelf: 'stretch',
         },
       },
       ...extendSx(rest.sx),
     ]}
-  >
-    <Divider {...DividerProps} />
-    <Divider {...DividerProps} orientation="vertical" flexItem />
-  </Box>
+  />
 );


### PR DESCRIPTION
8de22b710107212c2d1569ee78a5a1f908e7a60c did not work like I thought it did.
Already fixed `PaperTooltip`. 
This addresses `CardGroup` & `ResponsiveDivider`.
### Regressed (doesn't expand to same row)
<img src="https://github.com/SeedCompany/cord-field/assets/932566/0602ef6d-6008-40c8-80f8-306968b73a88" width="500" />

### Fixed
<img src="https://github.com/SeedCompany/cord-field/assets/932566/130d2e1d-6f14-46dc-b330-565e126117f7" width="500" />

----

Additionally I unified the two `ResponsiveDivider` components & changed implementation to only use one `<hr>` element.

---

Also fixed how the project details "Team Members" & "Partnerships" cards would smoosh weirdly.
### Before
<img src="https://github.com/SeedCompany/cord-field/assets/932566/8e7f9d63-83cf-4f43-882e-45b48a04711a" width="500" />

### After
<img src="https://github.com/SeedCompany/cord-field/assets/932566/8abf9cb6-77ab-403b-8912-10b97238fcc4" width="500" />

"See All" doesn't jump around now and looks good on all screen sizes.
The off center divider is accepted for this small width range.