### PR TITLE
Don't load LogRocket script unless enabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { ThemeProvider } from '@mui/material/styles';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { LicenseInfo as MuiXLicense } from '@mui/x-license';
-import LogRocket from 'logrocket';
-import setupLogRocketReact from 'logrocket-react';
 import { ApolloProvider, GqlSensitiveOperations } from './api';
 import { LuxonCalenderDateUtils } from './common/LuxonCalenderDateUtils';
 import { ConfettiProvider } from './components/Confetti';
@@ -14,25 +12,29 @@ import { createTheme } from './theme';
 
 const logRocketAppId = process.env.RAZZLE_LOG_ROCKET_APP_ID;
 if (logRocketAppId) {
-  LogRocket.init(logRocketAppId, {
-    shouldParseXHRBlob: true, // Parse API response bodies
-    network: {
-      requestSanitizer(request) {
-        // Relies on operation name suffix which do in Apollo HttpLink config
-        if (
-          [...GqlSensitiveOperations].some((op) =>
-            request.url.endsWith(`/${op}`)
-          )
-        ) {
-          request.body = undefined;
-        }
-        return request;
-      },
-    },
-  });
-  if (typeof window !== 'undefined') {
-    setupLogRocketReact(LogRocket);
-  }
+  void Promise.all([import('logrocket'), import('logrocket-react')]).then(
+    ([LogRocket, setupLogRocketReact]) => {
+      LogRocket.default.init(logRocketAppId, {
+        shouldParseXHRBlob: true, // Parse API response bodies
+        network: {
+          requestSanitizer(request) {
+            // Relies on operation name suffix which do in Apollo HttpLink config
+            if (
+              [...GqlSensitiveOperations].some((op) =>
+                request.url.endsWith(`/${op}`)
+              )
+            ) {
+              request.body = undefined;
+            }
+            return request;
+          },
+        },
+      });
+      if (typeof window !== 'undefined') {
+        setupLogRocketReact.default(LogRocket);
+      }
+    }
+  );
 }
 
 MuiXLicense.setLicenseKey(process.env.MUI_X_LICENSE_KEY!);

--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -1,7 +1,6 @@
 import { ApolloCache, useQuery } from '@apollo/client';
+import { useAsyncEffect } from 'ahooks';
 import { pickBy } from 'lodash';
-import LogRocket from 'logrocket';
-import { useEffect } from 'react';
 import { SessionOutput } from '~/api/schema.graphql';
 import { LoginMutation } from '../../scenes/Authentication/Login/Login.graphql';
 import { RegisterMutation } from '../../scenes/Authentication/Register/register.graphql';
@@ -57,10 +56,11 @@ export const useBetaFeatures = (): ReadonlySet<keyof BetaFeatures> =>
 export const useIdentifyInLogRocket = () => {
   const { session, impersonator } = useSession();
   const user = impersonator ?? session;
-  useEffect(() => {
+  useAsyncEffect(async () => {
     if (!user || !process.env.RAZZLE_LOG_ROCKET_APP_ID) {
       return;
     }
+    const LogRocket = await import('logrocket');
     LogRocket.identify(
       user.id,
       pickBy({


### PR DESCRIPTION
Tired of seeing the warning from adblock blocking it.
It's not even enabled locally, so if it's not enabled, don't import the module, which loads the script.