### PR TITLE
Theme Refresh

### DIFF
--- a/src/components/Changeset/PropertyDiff.tsx
+++ b/src/components/Changeset/PropertyDiff.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles()(({ palette, shape, spacing }) => ({
   },
   current: {
     color: palette.primary.dark,
-    background: fade(palette.primary.light, 0.5),
+    background: fade(palette.primary.main, 0.5),
   },
 }));
 

--- a/src/components/Widgets/Widget.tsx
+++ b/src/components/Widgets/Widget.tsx
@@ -10,8 +10,6 @@ export interface WidgetProps extends ChildrenProp {
 export const Widget = ({ colSpan, rowSpan, sx, ...props }: WidgetProps) => (
   <Card
     component={Stack}
-    elevation={0}
-    variant="outlined"
     sx={[
       {
         gridColumn: `span ${colSpan}`,

--- a/src/scenes/ProgressReports/EditForm/ProgressReportStepper.tsx
+++ b/src/scenes/ProgressReports/EditForm/ProgressReportStepper.tsx
@@ -67,12 +67,7 @@ export const ProgressReportStepper = () => {
     useProgressReportContext();
 
   return (
-    <Paper
-      elevation={4}
-      sx={{ p: 2 }}
-      component="nav"
-      aria-label="Quarterly Report Steps"
-    >
+    <Paper sx={{ p: 2 }} component="nav" aria-label="Quarterly Report Steps">
       <Typography component="h3" paragraph aria-hidden>
         Steps:
       </Typography>

--- a/src/scenes/ProgressReports/EditForm/Steps/SubmitReportStep/ConfirmIncompleteSubmissionDialog.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/SubmitReportStep/ConfirmIncompleteSubmissionDialog.tsx
@@ -66,7 +66,6 @@ const IncompleteSteps = () => {
             {steps.map(({ label: stepName, severity }) => (
               <Typography component="li" key={stepName}>
                 <Link
-                  underline="always"
                   // Carson doesn't love this logic being duplicated here,
                   // but values semantic markup more
                   to={{ search: `?step=${kebabCase(stepName)}` }}

--- a/src/scenes/ProgressReports/EditForm/Steps/VariantAccordion.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/VariantAccordion.tsx
@@ -18,7 +18,7 @@ export const VariantAccordion = ({
   const [expanded, { toggle }] = useToggle(expandedInput ?? false);
 
   return (
-    <Accordion expanded={expanded} elevation={2} square>
+    <Accordion expanded={expanded} square>
       <AccordionSummary
         aria-controls={`${variant.key}-content`}
         expandIcon={<ExpandMore />}

--- a/src/scenes/ProgressReports/List/ProgressReportsTable.tsx
+++ b/src/scenes/ProgressReports/List/ProgressReportsTable.tsx
@@ -102,6 +102,7 @@ export const RowLink = (props: GridRowProps) => {
       component={Link}
       variant="body2"
       to={`/progress-reports/${idForUrl(report)}`}
+      color="inherit"
       sx={{ textDecoration: 'none' }}
     >
       <GridRow {...props} />

--- a/src/scenes/ProgressReports/PnpValidation/PnPExtractionProblems.tsx
+++ b/src/scenes/ProgressReports/PnpValidation/PnPExtractionProblems.tsx
@@ -47,11 +47,7 @@ export const PnPExtractionProblems = memo(function PnPExtractionProblems({
             <Alert severity="info" sx={{ mb: 1 }}>
               Once these problems are fixed, the updated file needs to be
               uploaded on the{' '}
-              <Link
-                to={`/engagements/${engagement.id}`}
-                color="inherit"
-                underline="always"
-              >
+              <Link to={`/engagements/${engagement.id}`} color="inherit">
                 Planning Spreadsheet
               </Link>{' '}
               to synchronize the changes for the planned goals.

--- a/src/scenes/Root/Header/Header.tsx
+++ b/src/scenes/Root/Header/Header.tsx
@@ -3,7 +3,7 @@ import { HeaderSearch } from './HeaderSearch';
 import { ProfileToolbar } from './ProfileToolbar';
 
 export const Header = () => (
-  <AppBar position="static" color="inherit" elevation={1} sx={{ zIndex: 1 }}>
+  <AppBar position="static" color="inherit" sx={{ zIndex: 1 }}>
     <Toolbar sx={{ gap: 3, justifyContent: 'space-between' }}>
       <HeaderSearch sx={{ flex: 1, maxWidth: 500 }} />
       <ProfileToolbar />

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -15,6 +15,11 @@ export const appComponents = ({
     ? palette.primary.light
     : palette.primary.main;
   return {
+    MuiAppBar: {
+      defaultProps: {
+        elevation: 2,
+      },
+    },
     MuiCssBaseline: {
       styleOverrides: {
         '#root': {

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -51,11 +51,6 @@ export const appComponents = ({
         size: 'small',
       },
     },
-    MuiIconButton: {
-      defaultProps: {
-        size: 'large', // MUI v4 default. Consider removing.
-      },
-    },
     MuiCard: {
       defaultProps: {
         elevation: 8,

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -50,11 +50,6 @@ export const appComponents = ({
       defaultProps: {
         size: 'small',
       },
-      styleOverrides: {
-        root: {
-          textTransform: 'none',
-        },
-      },
     },
     MuiIconButton: {
       defaultProps: {
@@ -70,8 +65,6 @@ export const appComponents = ({
       styleOverrides: {
         root: {
           // Add divider between card content & actions
-          // Implementation is following <Divider /> from MUI v5
-          // https://github.com/mui-org/material-ui/pull/18965
           borderTop: `thin solid ${palette.divider}`,
         },
       },
@@ -82,11 +75,12 @@ export const appComponents = ({
       },
       styleOverrides: {
         root: {
-          textTransform: 'uppercase',
-          fontWeight: typography.weight.medium,
           '&.Mui-focused': {
             color: primaryColorForText,
           },
+        },
+        shrink: {
+          fontWeight: typography.weight.medium,
         },
       },
     },
@@ -94,11 +88,6 @@ export const appComponents = ({
       defaultProps: {
         // because we always shrink label we always want notch applied
         notched: true,
-      },
-      styleOverrides: {
-        notchedOutline: {
-          textTransform: 'uppercase',
-        },
       },
     },
     MuiFormControl: {

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -140,7 +140,7 @@ export const appComponents = ({
     },
     MuiLink: {
       defaultProps: {
-        underline: 'hover',
+        underline: 'always',
         color: 'primary.main',
       },
     },

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -11,9 +11,6 @@ export const appComponents = ({
   shape,
 }: Theme): Components<Theme> => {
   const dark = palette.mode === 'dark';
-  const primaryColorForText = dark
-    ? palette.primary.light
-    : palette.primary.main;
   return {
     MuiAppBar: {
       defaultProps: {
@@ -81,7 +78,7 @@ export const appComponents = ({
       styleOverrides: {
         root: {
           '&.Mui-focused': {
-            color: primaryColorForText,
+            color: palette.primary.main,
           },
         },
         shrink: {
@@ -144,7 +141,7 @@ export const appComponents = ({
     MuiLink: {
       defaultProps: {
         underline: 'hover',
-        color: dark ? 'primary.light' : 'primary.main',
+        color: 'primary.main',
       },
     },
     MuiToggleButtonGroup: {

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -51,9 +51,14 @@ export const appComponents = ({
         size: 'small',
       },
     },
+    MuiPaper: {
+      defaultProps: {
+        elevation: 2,
+      },
+    },
     MuiCard: {
       defaultProps: {
-        elevation: 8,
+        elevation: 2,
       },
     },
     MuiCardActions: {

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -32,7 +32,8 @@ export const createPalette = ({ dark }: { dark?: boolean }) => {
       main: '#f2994a',
     },
     text: {
-      primary: dark ? '#f3f4f6' : '#3c444e',
+      // Close to #3c444e while still using alpha
+      ...(!dark ? { primary: 'rgba(0, 0, 0, 0.75)' } : {}),
       secondary: '#8f928b',
     },
 

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -34,7 +34,9 @@ export const createPalette = ({ dark }: { dark?: boolean }) => {
     text: {
       // Close to #3c444e while still using alpha
       ...(!dark ? { primary: 'rgba(0, 0, 0, 0.75)' } : {}),
-      secondary: '#8f928b',
+      // Close to #8f928b while still using alpha
+      // Still it looks so contrast-less for form labels
+      // secondary: 'rgba(0, 0, 0, 0.45)',
     },
 
     // TODO theme.palette.augmentColor()

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,10 +1,10 @@
 import { PaletteColor, PaletteColorOptions } from '@mui/material';
 import { grey } from '@mui/material/colors';
-import { lighten, PaletteOptions } from '@mui/material/styles';
+import { PaletteOptions } from '@mui/material/styles';
 import { Role } from '~/api/schema/schema.graphql';
 
 export const createPalette = ({ dark }: { dark?: boolean }) => {
-  const mainGreen = '#467f3b';
+  const mainGreen = '#1EA973';
   const roleLuminance = dark ? 32 : 84;
   const palette: PaletteOptions = {
     mode: dark ? 'dark' : 'light',
@@ -14,8 +14,6 @@ export const createPalette = ({ dark }: { dark?: boolean }) => {
     primary: {
       main: mainGreen,
       contrastText: '#ffffff',
-      // default is lighten main color by 0.2
-      light: lighten(mainGreen, 0.4),
     },
     secondary: {
       main: dark ? grey[50] : '#3c444e',

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,9 +1,8 @@
-import type { Palette } from '@mui/material';
 import type { TypographyOptions } from '@mui/material/styles/createTypography';
 import { pickBy } from 'lodash';
 import type { CSSProperties } from 'react';
 
-export const typography = (palette: Palette): TypographyOptions => {
+export const typography = (): TypographyOptions => {
   const weight: FontWeights = {
     light: 300, // default
     regular: 400, // default
@@ -21,7 +20,6 @@ export const typography = (palette: Palette): TypographyOptions => {
 
     allVariants: {
       fontWeight: weight.medium,
-      color: palette.text.primary,
     },
 
     // Header 1


### PR DESCRIPTION
Mostly trying to get back to MUI defaults in a lot of places.
Driven by filters in tables which I bring up half way down.

## Stop coupling color to typography
  MUI components will inherit typography variants, but use a different action color.
  For example, `<FormLabel>` defaults to `secondary` text color and `body1` typography.
  So we probably want to respect that color.

## Primary text color `#3c444e` -> 75% black
Using opacity for gray renders better than solid colors, esp on colored backgrounds.
For context, MUI defaults is 87%.
75% matches close to what we had before.

Before
![Screenshot 2024-06-25 at 5 02 08 PM](https://github.com/SeedCompany/cord-field/assets/932566/1a6fb5be-a1f2-4741-801c-573ea6b86e15)
After
![Screenshot 2024-06-25 at 5 01 50 PM](https://github.com/SeedCompany/cord-field/assets/932566/4a73f266-cdfc-4c35-8cfc-b427cd6a38b9)


## Secondary text color `#8f928b` -> 60% black (MUI default) 

Following suit of primary.
Opacity has to drop all the way to **45%** to be close to what we had before.
For context, the `disabled` text color is only slightly lower than that at 38%.

The contrast just wasn't enough at 45% esp on labels of `filled` inputs, which have a gray background.

Before
![Screenshot 2024-06-25 at 5 05 13 PM](https://github.com/SeedCompany/cord-field/assets/932566/5f7518a5-47b7-4e5b-b10b-f311a023a6ab)
After
![Screenshot 2024-06-25 at 5 04 44 PM](https://github.com/SeedCompany/cord-field/assets/932566/ec52f386-6e9a-4b60-8449-a3207e5c93ed)

## ~~Re-allow input labels to act as placeholders that shrink~~ & remove all caps
~~Placeholders seem to still be desired by design, and MUI's default of the label acting as the placeholder and then shrinking to the label looks nice IMO. Better than having both a label & a placeholder.
I kept the slightly bolder weight when label is shrunk, but I would be down to remove that too.~~
I reverted this - can reconsider separately.

Before
![Screenshot 2024-06-25 at 5 08 04 PM](https://github.com/SeedCompany/cord-field/assets/932566/dc7c7063-b28c-453a-bf95-9f82a9a19776)
![Screenshot 2024-06-25 at 5 08 27 PM](https://github.com/SeedCompany/cord-field/assets/932566/c1e99221-790a-4e03-9b37-371356226637)
After
![Screenshot 2024-06-25 at 5 08 50 PM](https://github.com/SeedCompany/cord-field/assets/932566/2dcf6bed-8e33-4ceb-a971-0ab35a8948e1)
![Screenshot 2024-06-25 at 5 09 00 PM](https://github.com/SeedCompany/cord-field/assets/932566/f6ede2ee-f338-4fe4-b577-439495e8a730)

### Header filters in Tables

Those screenshots seem like subtle changes.
All of the changes so far (other than primary color) are to make the table header filters look better.

Before
![Screenshot 2024-06-25 at 5 15 43 PM](https://github.com/SeedCompany/cord-field/assets/932566/1e3f60d4-401b-4686-a886-2188902b08a0)
After
![Screenshot 2024-06-25 at 5 16 10 PM](https://github.com/SeedCompany/cord-field/assets/932566/03f5ecde-1f28-4809-81df-84fa5cc200c3)

The less opaque & non caps help the text to be so in your face. Esp comparing to the column title, which is smaller.

## `IconButton` default size `large` -> `medium` (MUI/MD default)

48px -> 40px. Seems fine to me, and it sounds like in general we want to shrink our UI elements more.

Before
![Screenshot 2024-06-25 at 5 22 45 PM](https://github.com/SeedCompany/cord-field/assets/932566/b18ba81c-739f-4766-a219-4fd64efd0e54)
After
![Screenshot 2024-06-25 at 5 23 08 PM](https://github.com/SeedCompany/cord-field/assets/932566/96df7f84-bb36-461c-8d51-e65992553d0b)


## ~~Background color `#fafafa` -> `#ffffff`~~ (MUI/MD default)

I reverted this per design request.

## `Card` elevation 8 -> 2 / `Paper` 1 -> 2 
1 is default for MUI.
To me, there is just not enough shadow on 1, to make the surface distinct from the background.
Paper is basically the same thing, so bumping to be consistent with Cards.

Before
![Screenshot 2024-06-25 at 5 26 28 PM](https://github.com/SeedCompany/cord-field/assets/932566/90172ee3-bea1-4b90-badb-06cc98652cf4)
After
![Screenshot 2024-06-25 at 5 26 04 PM](https://github.com/SeedCompany/cord-field/assets/932566/02386208-1e7f-432c-a09b-10ad5c016085)

- `AppBar` elevation 1 -> 2 
It is weird to have that floating surface lower than surfaces on page.

Before
![Screenshot 2024-06-25 at 5 29 58 PM](https://github.com/SeedCompany/cord-field/assets/932566/90dddac5-3092-450e-a5da-52c51522eb5a)
After
![Screenshot 2024-06-25 at 5 30 26 PM](https://github.com/SeedCompany/cord-field/assets/932566/cd922167-fb56-42cd-9f3a-f20c7997678e)

https://seed-company-squad.monday.com/boards/3451697530/pulses/7550535438