### PR TITLE
Revert "Fix DataGrid resetting to first page on last page"

### DIFF
--- a/src/hooks/useTable.tsx
+++ b/src/hooks/useTable.tsx
@@ -152,7 +152,7 @@ export const useTable = <
 
   const dataGridProps = {
     rows: list?.items ?? [],
-    rowCount: isCacheComplete ? undefined : total,
+    rowCount: total,
     loading: isNetworkRequestInFlight(networkStatus),
     filterModel,
     paginationModel: { page: input.page - 1, pageSize: input.count },

--- a/src/hooks/useTable.tsx
+++ b/src/hooks/useTable.tsx
@@ -147,15 +147,12 @@ export const useTable = <
     ? (get(currentPage, listAt) as List)
     : undefined;
 
-  const indexOffset = (input.page - 1) * input.count;
-  const list = isCacheComplete
-    ? allPagesList.items.slice(indexOffset, indexOffset + input.count)
-    : currentPageList?.items;
+  const list = isCacheComplete ? allPagesList : currentPageList;
   const total = allPagesList?.total ?? currentPageList?.total ?? 0;
 
   const dataGridProps = {
-    rows: list ?? [],
-    rowCount: total,
+    rows: list?.items ?? [],
+    rowCount: isCacheComplete ? undefined : total,
     loading: isNetworkRequestInFlight(networkStatus),
     filterModel,
     paginationModel: { page: input.page - 1, pageSize: input.count },
@@ -196,7 +193,7 @@ export const useTable = <
     },
     pagination: total > input.count,
     pageSizeOptions: [input.count],
-    paginationMode: 'server',
+    paginationMode: isCacheComplete ? 'client' : 'server',
     sortingMode: isCacheComplete ? 'client' : 'server',
     filterMode: isCacheComplete ? 'client' : 'server',
     slotProps: apiSlotProps,


### PR DESCRIPTION
Revert and be happy with warning in console. Functionality is fine & no controlled -> uncontrolled side effects. Warning is annoying, but it is the least evil option.