### PR TITLE
Don't keep create menu & dialogs mounted

### DIFF
--- a/src/scenes/Root/Creates/CreateDialogProviders.tsx
+++ b/src/scenes/Root/Creates/CreateDialogProviders.tsx
@@ -12,16 +12,12 @@ export const CreateItemContext = createContext<OpenCreateFn>(noop);
 export const CreateDialogProviders = (props: ChildrenProp) => {
   const [state, create, openedItem] = useDialog<Power>();
 
+  const Dialog = openedItem && creates.get(openedItem)?.[0];
+
   return (
     <CreateItemContext.Provider value={create}>
       {props.children}
-      {creates.map(([power, Dialog]) => (
-        <Dialog
-          {...state}
-          key={power}
-          open={state.open && openedItem === power}
-        />
-      ))}
+      {Dialog && <Dialog {...state} open={state.open} />}
     </CreateItemContext.Provider>
   );
 };

--- a/src/scenes/Root/Creates/CreateMenu.tsx
+++ b/src/scenes/Root/Creates/CreateMenu.tsx
@@ -1,7 +1,8 @@
 import { Add } from '@mui/icons-material';
 import { ButtonProps, Menu, MenuItem, MenuProps } from '@mui/material';
+import { entries } from '@seedcompany/common';
 import { startCase } from 'lodash';
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { Power } from '~/api/schema.graphql';
 import { CreateButton } from '../../../components/CreateButton';
 import { useSession } from '../../../components/Session';
@@ -26,9 +27,20 @@ export const CreateButtonMenu = (props: CreateButtonMenuProps) => {
     openDialog(power);
   };
 
-  const allowed = creates.filter(([power]) => powers?.includes(power));
+  const allowedCreates = useMemo(
+    () =>
+      entries(creates).flatMap(([power, [_, maybeLabel]]) =>
+        powers?.includes(power)
+          ? {
+              power,
+              label: maybeLabel ?? startCase(power.replace('Create', '')),
+            }
+          : []
+      ),
+    [powers]
+  );
 
-  if (allowed.length === 0) {
+  if (allowedCreates.length === 0) {
     return null;
   }
 
@@ -47,7 +59,6 @@ export const CreateButtonMenu = (props: CreateButtonMenuProps) => {
         id="create-menu"
         open={anchorEl !== null}
         anchorEl={anchorEl}
-        keepMounted
         onClose={closeAddMenu}
         anchorOrigin={{
           vertical: 'bottom',
@@ -59,9 +70,9 @@ export const CreateButtonMenu = (props: CreateButtonMenuProps) => {
         }}
         {...MenuProps}
       >
-        {allowed.map(([power, _, maybeLabel]) => (
+        {allowedCreates.map(({ power, label }) => (
           <MenuItem key={power} onClick={openCreate(power)}>
-            {maybeLabel ?? startCase(power.replace('Create', ''))}
+            {label}
           </MenuItem>
         ))}
       </Menu>

--- a/src/scenes/Root/Creates/Creates.tsx
+++ b/src/scenes/Root/Creates/Creates.tsx
@@ -1,3 +1,4 @@
+import { mapOf } from '@seedcompany/common';
 import { ComponentType } from 'react';
 import { Except } from 'type-fest';
 import { Power } from '~/api/schema.graphql';
@@ -9,15 +10,14 @@ import { CreateProject } from '../../Projects/Create';
 import { CreateUser } from '../../Users/Create';
 
 type Create = [
-  power: Power,
   dialog: ComponentType<Except<DialogFormProps<any, any>, 'onSubmit'>>,
   label?: string
 ];
 
-export const creates: Create[] = [
-  ['CreateProject', CreateProject],
-  ['CreateLanguage', CreateLanguage],
-  ['CreateUser', CreateUser, 'Person'],
-  ['CreatePartner', CreatePartner],
-  ['CreateLocation', CreateLocation],
-];
+export const creates = mapOf<Power, Create>([
+  ['CreateProject', [CreateProject]],
+  ['CreateLanguage', [CreateLanguage]],
+  ['CreateUser', [CreateUser, 'Person']],
+  ['CreatePartner', [CreatePartner]],
+  ['CreateLocation', [CreateLocation]],
+]);


### PR DESCRIPTION
Create menu can be mounted on click.
keepMounted is only recommended for mobile,
which is not the use case here.

Previously, we were keeping all the creation dialogs mounted too. Even though we only needed one, and only while it is open.

Also changed to a map & memo for small render performance.