### PR TITLE
Abstract recent partner data grid work

### DIFF
--- a/src/components/EngagementDataGrid/EngagementColumns.tsx
+++ b/src/components/EngagementDataGrid/EngagementColumns.tsx
@@ -1,0 +1,157 @@
+import { Box } from '@mui/material';
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { cleanJoin } from '@seedcompany/common';
+import {
+  EngagementStatusLabels,
+  EngagementStatusList,
+  ProgressReportStatusLabels,
+  ProgressReportStatusList,
+  ProjectStepLabels,
+  ProjectStepList,
+  ProjectTypeLabels,
+  ProjectTypeList,
+  SensitivityLabels,
+  SensitivityList,
+} from '../../api/schema/enumLists';
+import { enumColumn, textColumn } from '../Grid';
+import { Link } from '../Routing';
+import { SensitivityIcon } from '../Sensitivity';
+import { EngagementDataGridRowFragment as Engagement } from './engagementDataGridRow.graphql';
+
+export const EngagementColumns: Array<GridColDef<Engagement>> = [
+  {
+    headerName: 'Name',
+    field: 'nameProjectFirst',
+    ...textColumn(),
+    minWidth: 200,
+    valueGetter: (_, row) =>
+      cleanJoin(' - ', [
+        row.project.name.value,
+        row.__typename === 'LanguageEngagement'
+          ? row.language.value?.name.value
+          : row.__typename === 'InternshipEngagement'
+          ? row.intern.value?.fullName
+          : null,
+      ]),
+    renderCell: ({ value, row }) => (
+      <Link to={`/projects/${row.project.id}`}>{value}</Link>
+    ),
+    serverFilter: ({ value }) => ({ name: value }),
+  },
+  {
+    headerName: 'Type',
+    field: 'project.type',
+    ...enumColumn(ProjectTypeList, ProjectTypeLabels),
+    width: 130,
+    valueGetter: (_, row) => row.project.type,
+  },
+  {
+    headerName: 'Project Step',
+    field: 'project.step',
+    width: 250,
+    valueGetter: (_, row) => row.project.step.value,
+    ...enumColumn(ProjectStepList, ProjectStepLabels, {
+      orderByIndex: true,
+    }),
+  },
+  {
+    headerName: 'Engagement Status',
+    field: 'status',
+    ...enumColumn(EngagementStatusList, EngagementStatusLabels, {
+      orderByIndex: true,
+    }),
+    width: 190,
+    valueGetter: (_, row) => row.status.value,
+  },
+  {
+    headerName: 'Country',
+    field: 'project.primaryLocation.name',
+    ...textColumn(),
+    valueGetter: (_, row) => row.project.primaryLocation.value?.name.value,
+    filterable: false,
+  },
+  {
+    headerName: 'ISO',
+    description: 'Ethnologue Code',
+    field: 'language.ethnologue.code',
+    ...textColumn(),
+    width: 95,
+    valueGetter: (_, row) =>
+      row.__typename === 'LanguageEngagement'
+        ? row.language.value?.ethnologue.code.value?.toUpperCase()
+        : '',
+  },
+  {
+    headerName: 'ROD',
+    description: 'Registry of Dialects',
+    field: 'language.registryOfDialectsCode',
+    ...textColumn(),
+    width: 95,
+    valueGetter: (_, row) =>
+      row.__typename === 'LanguageEngagement'
+        ? row.language.value?.registryOfDialectsCode.value
+        : '',
+  },
+  {
+    headerName: 'MOU Start',
+    field: 'startDate',
+    type: 'date',
+    valueGetter: (_, { startDate }) => startDate.value?.toJSDate(),
+    filterable: false,
+  },
+  {
+    headerName: 'MOU End',
+    field: 'endDate',
+    type: 'date',
+    valueGetter: (_, { endDate }) => endDate.value?.toJSDate(),
+    filterable: false,
+  },
+  {
+    headerName: 'QR Status',
+    description: 'Status of Quarterly Report Currently Due',
+    field: 'currentProgressReportDue.status',
+    ...enumColumn(ProgressReportStatusList, ProgressReportStatusLabels, {
+      orderByIndex: true,
+    }),
+    valueGetter: (_, row) =>
+      row.__typename === 'LanguageEngagement' &&
+      row.currentProgressReportDue.value
+        ? row.currentProgressReportDue.value.status.value
+        : null,
+    renderCell({ formattedValue: value, row }) {
+      const report =
+        row.__typename === 'LanguageEngagement'
+          ? row.currentProgressReportDue.value
+          : undefined;
+      if (!report) {
+        return null;
+      }
+      return <Link to={`/progress-reports/${report.id}`}>{value}</Link>;
+    },
+    filterable: false,
+  },
+  {
+    headerName: 'Sensitivity',
+    field: 'project.sensitivity',
+    width: 110,
+    ...enumColumn(SensitivityList, SensitivityLabels, {
+      orderByIndex: true,
+    }),
+    valueGetter: (_, row) => row.project.sensitivity,
+    renderCell: ({ value }) => (
+      <Box display="flex" alignItems="center" gap={1} textTransform="uppercase">
+        <SensitivityIcon value={value} disableTooltip />
+        {value}
+      </Box>
+    ),
+  },
+  {
+    headerName: 'Files',
+    field: 'files',
+    sortable: false,
+    filterable: false,
+    renderCell: ({ row }) => (
+      <Link to={`/projects/${row.project.id}/files`}>View Files</Link>
+    ),
+  },
+];

--- a/src/components/EngagementDataGrid/EngagementColumns.tsx
+++ b/src/components/EngagementDataGrid/EngagementColumns.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import { GridColDef } from '@mui/x-data-grid-pro';
 import { cleanJoin } from '@seedcompany/common';
 import {
@@ -10,12 +9,10 @@ import {
   ProjectStepList,
   ProjectTypeLabels,
   ProjectTypeList,
-  SensitivityLabels,
-  SensitivityList,
 } from '../../api/schema/enumLists';
 import { enumColumn, textColumn } from '../Grid';
+import { SensitivityColumn } from '../ProjectDataGrid';
 import { Link } from '../Routing';
-import { SensitivityIcon } from '../Sensitivity';
 import { EngagementDataGridRowFragment as Engagement } from './engagementDataGridRow.graphql';
 
 export const EngagementColumns: Array<GridColDef<Engagement>> = [
@@ -131,19 +128,9 @@ export const EngagementColumns: Array<GridColDef<Engagement>> = [
     filterable: false,
   },
   {
-    headerName: 'Sensitivity',
+    ...SensitivityColumn,
     field: 'project.sensitivity',
-    width: 110,
-    ...enumColumn(SensitivityList, SensitivityLabels, {
-      orderByIndex: true,
-    }),
     valueGetter: (_, row) => row.project.sensitivity,
-    renderCell: ({ value }) => (
-      <Box display="flex" alignItems="center" gap={1} textTransform="uppercase">
-        <SensitivityIcon value={value} disableTooltip />
-        {value}
-      </Box>
-    ),
   },
   {
     headerName: 'Files',

--- a/src/components/EngagementDataGrid/engagementDataGridRow.graphql
+++ b/src/components/EngagementDataGrid/engagementDataGridRow.graphql
@@ -1,0 +1,74 @@
+fragment engagementDataGridRow on Engagement {
+  id
+  status {
+    value
+  }
+  startDate {
+    value
+  }
+  endDate {
+    value
+  }
+
+  project {
+    id
+    type
+    name {
+      value
+    }
+    sensitivity
+    step {
+      value
+    }
+    primaryLocation {
+      value {
+        id
+        name {
+          value
+        }
+      }
+    }
+    mouStart {
+      value
+    }
+    mouEnd {
+      value
+    }
+  }
+
+  ... on LanguageEngagement {
+    currentProgressReportDue {
+      value {
+        id
+        status {
+          value
+        }
+      }
+    }
+    language {
+      value {
+        id
+        name {
+          value
+        }
+        ethnologue {
+          code {
+            value
+          }
+        }
+        registryOfDialectsCode {
+          value
+        }
+      }
+    }
+  }
+
+  ... on InternshipEngagement {
+    intern {
+      value {
+        id
+        fullName
+      }
+    }
+  }
+}

--- a/src/components/EngagementDataGrid/index.ts
+++ b/src/components/EngagementDataGrid/index.ts
@@ -1,0 +1,2 @@
+export * from './EngagementColumns';
+export * from './engagementDataGridRow.graphql';

--- a/src/components/Grid/enumColumn.tsx
+++ b/src/components/Grid/enumColumn.tsx
@@ -1,0 +1,20 @@
+import { getGridSingleSelectOperators, GridColDef } from '@mui/x-data-grid-pro';
+import { cmpBy } from '@seedcompany/common';
+import { EmptyEnumFilterValue } from './DefaultDataGridStyles';
+
+export const enumColumn = <T extends string>(
+  list: readonly T[],
+  labels: Record<T, string>,
+  { orderByIndex }: { orderByIndex?: boolean } = {}
+) =>
+  ({
+    type: 'singleSelect',
+    filterOperators: getGridSingleSelectOperators().filter(
+      (op) => op.value !== 'not'
+    ),
+    valueOptions: list.slice(),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    getOptionLabel: (v) => labels[v as T] ?? EmptyEnumFilterValue,
+    valueFormatter: (value: T) => labels[value],
+    ...(orderByIndex ? { sortComparator: cmpBy((v) => list.indexOf(v)) } : {}),
+  } satisfies Partial<GridColDef<any, T, string>>);

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -1,0 +1,4 @@
+export * from './DefaultDataGridStyles';
+export * from './EditNumberCell';
+export * from './useCurrencyColumn';
+export * from './enumColumn';

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -2,3 +2,4 @@ export * from './DefaultDataGridStyles';
 export * from './EditNumberCell';
 export * from './useCurrencyColumn';
 export * from './enumColumn';
+export * from './useDataGridSource';

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -2,4 +2,5 @@ export * from './DefaultDataGridStyles';
 export * from './EditNumberCell';
 export * from './useCurrencyColumn';
 export * from './enumColumn';
+export * from './textColumn';
 export * from './useDataGridSource';

--- a/src/components/Grid/textColumn.tsx
+++ b/src/components/Grid/textColumn.tsx
@@ -1,0 +1,20 @@
+import {
+  getGridStringOperators,
+  GridColDef,
+  GridFilterOperator,
+} from '@mui/x-data-grid-pro';
+
+export const containsOperator = {
+  ...(getGridStringOperators()[0]! as GridFilterOperator<
+    any,
+    string | null,
+    any
+  >),
+  label: 'search',
+  headerLabel: 'search',
+};
+
+export const textColumn = () =>
+  ({
+    filterOperators: [containsOperator],
+  } satisfies Partial<GridColDef<any, string | null, any>>);

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -53,7 +53,7 @@ const defaultInitialInput = {
 };
 const defaultKeyArgs = ['__typename', 'id'];
 
-export const useTable = <
+export const useDataGridSource = <
   Output extends Record<string, any>,
   Vars,
   Input extends Partial<ListInput>,

--- a/src/components/ProjectDataGrid/ProjectColumns.tsx
+++ b/src/components/ProjectDataGrid/ProjectColumns.tsx
@@ -1,0 +1,79 @@
+import { Box } from '@mui/material';
+import { GridColDef } from '@mui/x-data-grid-pro';
+import {
+  ProjectStatusLabels,
+  ProjectStatusList,
+  ProjectStepLabels,
+  ProjectStepList,
+  ProjectTypeLabels,
+  ProjectTypeList,
+  SensitivityLabels,
+  SensitivityList,
+} from '~/api/schema.graphql';
+import { enumColumn } from '../Grid';
+import { Link } from '../Routing';
+import { SensitivityIcon } from '../Sensitivity';
+import { ProjectDataGridRowFragment as Project } from './projectDataGridRow.graphql';
+
+export const SensitivityColumn = {
+  field: 'sensitivity',
+  ...enumColumn(SensitivityList, SensitivityLabels, {
+    orderByIndex: true,
+  }),
+  headerName: 'Sensitivity',
+  width: 110,
+  renderCell: ({ value }) => (
+    <Box display="flex" alignItems="center" gap={1} textTransform="uppercase">
+      <SensitivityIcon value={value} disableTooltip />
+      {value}
+    </Box>
+  ),
+} satisfies GridColDef;
+
+export const ProjectColumns: Array<GridColDef<Project>> = [
+  {
+    field: 'name',
+    valueGetter: (_, { name }) => name.value,
+    headerName: 'Name',
+    minWidth: 300,
+    renderCell: ({ value, row }) => (
+      <Link to={`/projects/${row.id}`}>{value}</Link>
+    ),
+  },
+  {
+    field: 'primaryLocation.name',
+    valueGetter: (_, { primaryLocation }) => primaryLocation.value?.name.value,
+    headerName: 'Country',
+    minWidth: 300,
+  },
+  {
+    field: 'project.step',
+    ...enumColumn(ProjectStepList, ProjectStepLabels, {
+      orderByIndex: true,
+    }),
+    valueGetter: (_, row) => row.step.value,
+    headerName: 'Step',
+    width: 250,
+  },
+  {
+    field: 'type',
+    ...enumColumn(ProjectTypeList, ProjectTypeLabels),
+    headerName: 'Type',
+    width: 130,
+  },
+  {
+    field: 'status',
+    ...enumColumn(ProjectStatusList, ProjectStatusLabels),
+    headerName: 'Status',
+    width: 160,
+  },
+  {
+    field: 'engagements',
+    type: 'number',
+    valueGetter: (_, { engagements }) => engagements.total,
+    filterable: false,
+    headerName: 'Engagements',
+    width: 130,
+  },
+  SensitivityColumn,
+];

--- a/src/components/ProjectDataGrid/index.ts
+++ b/src/components/ProjectDataGrid/index.ts
@@ -1,0 +1,2 @@
+export * from './ProjectColumns';
+export * from './projectDataGridRow.graphql';

--- a/src/components/ProjectDataGrid/projectDataGridRow.graphql
+++ b/src/components/ProjectDataGrid/projectDataGridRow.graphql
@@ -1,0 +1,23 @@
+fragment projectDataGridRow on Project {
+  id
+  type
+  name {
+    value
+  }
+  sensitivity
+  status
+  step {
+    value
+  }
+  engagements {
+    total
+  }
+  primaryLocation {
+    value {
+      id
+      name {
+        value
+      }
+    }
+  }
+}

--- a/src/components/Tabs/TabPanelContent.tsx
+++ b/src/components/Tabs/TabPanelContent.tsx
@@ -1,0 +1,20 @@
+import { Paper, PaperProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+type TabPanelContentProps = PaperProps;
+
+export const TabPanelContent = styled((props: TabPanelContentProps) => (
+  <Paper {...props} />
+))(({ theme }) => ({
+  padding: theme.spacing(2, 3),
+  maxWidth: `${theme.breakpoints.values.lg}px`,
+  // TODO I don't really like this. We should call out some other explicit way.
+  '&:has(> .MuiDataGrid-root)': {
+    flex: 1,
+    padding: 0,
+    maxWidth: '100cqw',
+    width: 'min-content',
+    // idk why -50, MUI pushes down past container
+    maxHeight: 'calc(100cqh - 50px)',
+  },
+}));

--- a/src/components/Tabs/TabsContainer.tsx
+++ b/src/components/Tabs/TabsContainer.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const TabsContainer = styled(Stack)(() => ({
+  flex: 1,
+  minHeight: 375,
+  containerType: 'size',
+  '& .MuiTabPanel-root': {
+    flex: 1,
+    padding: 0,
+    '&:not([hidden])': {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+  },
+}));

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,0 +1,2 @@
+export * from './TabsContainer';
+export * from './TabPanelContent';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,3 @@ export * from './useQueryParams';
 export * from './useIsomorphicEffect';
 export * from './useRequest';
 export * from './useScrolling';
-export * from './useTable';

--- a/src/scenes/Partners/Detail/PartnerDetail.tsx
+++ b/src/scenes/Partners/Detail/PartnerDetail.tsx
@@ -16,6 +16,7 @@ import { Error } from '~/components/Error';
 import { FormattedDate, FormattedDateTime } from '~/components/Formatters';
 import { IconButton } from '~/components/IconButton';
 import { InactiveStatusIcon } from '~/components/Icons/InactiveStatusIcon';
+import { TabsContainer } from '~/components/Tabs';
 import { TogglePinButton } from '~/components/TogglePinButton';
 import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { EditablePartnerField, EditPartner } from '../Edit';
@@ -199,21 +200,7 @@ const PartnerTabs = (props: PartnerViewEditProps) => {
   const [filters, setFilters] = usePartnerDetailsFilters();
 
   return (
-    <Stack
-      sx={{
-        flex: 1,
-        minHeight: 375,
-        container: 'main / size',
-        '& .MuiTabPanel-root': {
-          flex: 1,
-          p: 0,
-          '&:not([hidden])': {
-            display: 'flex',
-            flexDirection: 'column',
-          },
-        },
-      }}
-    >
+    <TabsContainer>
       <TabContext value={filters.tab}>
         <TabList
           onChange={(_e, tab) => setFilters({ ...filters, tab })}
@@ -246,6 +233,6 @@ const PartnerTabs = (props: PartnerViewEditProps) => {
           <PartnerDetailNotes {...props} />
         </TabPanel>
       </TabContext>
-    </Stack>
+    </TabsContainer>
   );
 };

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.graphql
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.graphql
@@ -5,88 +5,8 @@ query PartnerDetailEngagements($id: ID!, $input: EngagementListInput) {
       hasMore
       total
       items {
-        ...PartnerDetailEngagementsTableListItem
+        ...engagementDataGridRow
       }
     }
   }
-}
-
-fragment PartnerDetailEngagementsTableListItem on Engagement {
-  id
-  project {
-    ...PartnerDetailEngagementProjects
-  }
-  status {
-    value
-  }
-  startDate {
-    value
-  }
-  endDate {
-    value
-  }
-  ... on LanguageEngagement {
-    currentProgressReportDue {
-      value {
-        id
-        status {
-          value
-        }
-      }
-    }
-    language {
-      value {
-        ...PartnerDetailEngagementLanguage
-      }
-    }
-  }
-  ... on InternshipEngagement {
-    intern {
-      value {
-        id
-        fullName
-      }
-    }
-  }
-}
-
-fragment PartnerDetailEngagementLanguage on Language {
-  id
-  name {
-    value
-  }
-  ethnologue {
-    code {
-      value
-    }
-  }
-  registryOfDialectsCode {
-    value
-  }
-}
-
-fragment PartnerDetailEngagementProjects on Project {
-  id
-  name {
-    value
-  }
-  sensitivity
-  step {
-    value
-  }
-  primaryLocation {
-    value {
-      id
-      name {
-        value
-      }
-    }
-  }
-  mouStart {
-    value
-  }
-  mouEnd {
-    value
-  }
-  type
 }

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -32,7 +32,6 @@ export const PartnerDetailEngagements = () => {
     variables: { id: partnerId },
     listAt: 'partner.engagements',
     initialInput: {
-      count: 25,
       sort: 'nameProjectFirst',
     },
   });
@@ -51,7 +50,6 @@ export const PartnerDetailEngagements = () => {
         columns={EngagementColumns}
         initialState={initialState}
         headerFilters
-        disableRowSelectionOnClick
         sx={[flexLayout, noHeaderFilterButtons]}
       />
     </TabPanelContent>

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -20,9 +20,8 @@ import {
   SensitivityLabels,
   SensitivityList,
 } from '~/api/schema.graphql';
-import { enumColumn } from '~/components/Grid';
+import { enumColumn, useDataGridSource } from '~/components/Grid';
 import { SensitivityIcon } from '~/components/Sensitivity';
-import { useTable } from '~/hooks';
 import {
   DefaultDataGridStyles,
   flexLayout,
@@ -38,7 +37,7 @@ import {
 export const PartnerDetailEngagements = () => {
   const { partnerId = '' } = useParams();
 
-  const [props] = useTable({
+  const [props] = useDataGridSource({
     query: PartnerDetailEngagementsDocument,
     variables: { id: partnerId },
     listAt: 'partner.engagements',

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -1,4 +1,7 @@
-import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import {
+  DataGridPro as DataGrid,
+  DataGridProProps as DataGridProps,
+} from '@mui/x-data-grid-pro';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
@@ -19,7 +22,7 @@ const initialState = {
   pinnedColumns: {
     left: [EngagementColumns[0]!.field],
   },
-};
+} satisfies DataGridProps['initialState'];
 
 export const PartnerDetailEngagements = () => {
   const { partnerId = '' } = useParams();
@@ -46,9 +49,9 @@ export const PartnerDetailEngagements = () => {
         {...props}
         slotProps={slotProps}
         columns={EngagementColumns}
-        disableRowSelectionOnClick
-        headerFilters
         initialState={initialState}
+        headerFilters
+        disableRowSelectionOnClick
         sx={[flexLayout, noHeaderFilterButtons]}
       />
     </TabPanelContent>

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -1,38 +1,25 @@
-import { Box } from '@mui/material';
-import {
-  DataGridPro as DataGrid,
-  getGridStringOperators,
-  GridColDef,
-} from '@mui/x-data-grid-pro';
-import { cleanJoin } from '@seedcompany/common';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import {
-  EngagementStatusLabels,
-  EngagementStatusList,
-  ProgressReportStatusLabels,
-  ProgressReportStatusList,
-  ProjectStepLabels,
-  ProjectStepList,
-  ProjectTypeLabels,
-  ProjectTypeList,
-  SensitivityLabels,
-  SensitivityList,
-} from '~/api/schema.graphql';
-import { enumColumn, useDataGridSource } from '~/components/Grid';
-import { SensitivityIcon } from '~/components/Sensitivity';
+  EngagementDataGridRowFragment as Engagement,
+  EngagementColumns,
+} from '~/components/EngagementDataGrid';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noHeaderFilterButtons,
-} from '../../../../../components/Grid/DefaultDataGridStyles';
-import { Link } from '../../../../../components/Routing';
+  useDataGridSource,
+} from '~/components/Grid';
 import { PartnerTabContainer } from '../PartnerTabContainer';
-import {
-  PartnerDetailEngagementsTableListItemFragment as Engagement,
-  PartnerDetailEngagementsDocument,
-} from './PartnerDetailEngagements.graphql';
+import { PartnerDetailEngagementsDocument } from './PartnerDetailEngagements.graphql';
+
+const initialState = {
+  pinnedColumns: {
+    left: [EngagementColumns[0]!.field],
+  },
+};
 
 export const PartnerDetailEngagements = () => {
   const { partnerId = '' } = useParams();
@@ -67,164 +54,12 @@ export const PartnerDetailEngagements = () => {
         {...DefaultDataGridStyles}
         {...props}
         slotProps={slotProps}
-        columns={columns}
+        columns={EngagementColumns}
         disableRowSelectionOnClick
         headerFilters
-        initialState={{
-          pinnedColumns: {
-            left: ['nameProjectFirst'],
-          },
-        }}
+        initialState={initialState}
         sx={[flexLayout, noHeaderFilterButtons]}
       />
     </PartnerTabContainer>
   );
 };
-
-const containsOp = {
-  ...getGridStringOperators()[0]!,
-  label: 'search',
-  headerLabel: 'search',
-};
-const textColumn = {
-  filterOperators: [containsOp],
-  headerClassName: 'no-filter-button',
-};
-
-const columns: Array<GridColDef<Engagement>> = [
-  {
-    headerName: 'Name',
-    field: 'nameProjectFirst',
-    ...textColumn,
-    minWidth: 200,
-    valueGetter: (_, row) =>
-      cleanJoin(' - ', [
-        row.project.name.value,
-        row.__typename === 'LanguageEngagement'
-          ? row.language.value?.name.value
-          : row.__typename === 'InternshipEngagement'
-          ? row.intern.value?.fullName
-          : null,
-      ]),
-    renderCell: ({ value, row }) => (
-      <Link to={`/projects/${row.project.id}`}>{value}</Link>
-    ),
-    serverFilter: ({ value }) => ({ name: value }),
-  },
-  {
-    headerName: 'Type',
-    field: 'project.type',
-    ...enumColumn(ProjectTypeList, ProjectTypeLabels),
-    width: 130,
-    valueGetter: (_, row) => row.project.type,
-  },
-  {
-    headerName: 'Project Step',
-    field: 'project.step',
-    width: 250,
-    valueGetter: (_, row) => row.project.step.value,
-    ...enumColumn(ProjectStepList, ProjectStepLabels, {
-      orderByIndex: true,
-    }),
-  },
-  {
-    headerName: 'Engagement Status',
-    field: 'status',
-    ...enumColumn(EngagementStatusList, EngagementStatusLabels, {
-      orderByIndex: true,
-    }),
-    width: 190,
-    valueGetter: (_, row) => row.status.value,
-  },
-  {
-    headerName: 'Country',
-    field: 'project.primaryLocation.name',
-    ...textColumn,
-    valueGetter: (_, row) => row.project.primaryLocation.value?.name.value,
-    filterable: false,
-  },
-  {
-    headerName: 'ISO',
-    description: 'Ethnologue Code',
-    field: 'language.ethnologue.code',
-    ...textColumn,
-    width: 95,
-    valueGetter: (_, row) =>
-      row.__typename === 'LanguageEngagement'
-        ? row.language.value?.ethnologue.code.value?.toUpperCase()
-        : '',
-  },
-  {
-    headerName: 'ROD',
-    description: 'Registry of Dialects',
-    field: 'language.registryOfDialectsCode',
-    ...textColumn,
-    width: 95,
-    valueGetter: (_, row) =>
-      row.__typename === 'LanguageEngagement'
-        ? row.language.value?.registryOfDialectsCode.value
-        : '',
-  },
-  {
-    headerName: 'MOU Start',
-    field: 'startDate',
-    type: 'date',
-    valueGetter: (_, { startDate }) => startDate.value?.toJSDate(),
-    filterable: false,
-  },
-  {
-    headerName: 'MOU End',
-    field: 'endDate',
-    type: 'date',
-    valueGetter: (_, { endDate }) => endDate.value?.toJSDate(),
-    filterable: false,
-  },
-  {
-    headerName: 'QR Status',
-    description: 'Status of Quarterly Report Currently Due',
-    field: 'currentProgressReportDue.status',
-    ...enumColumn(ProgressReportStatusList, ProgressReportStatusLabels, {
-      orderByIndex: true,
-    }),
-    valueGetter: (_, row) =>
-      row.__typename === 'LanguageEngagement' &&
-      row.currentProgressReportDue.value
-        ? row.currentProgressReportDue.value.status.value
-        : null,
-    renderCell({ formattedValue: value, row }) {
-      const report =
-        row.__typename === 'LanguageEngagement'
-          ? row.currentProgressReportDue.value
-          : undefined;
-      if (!report) {
-        return null;
-      }
-      return <Link to={`/progress-reports/${report.id}`}>{value}</Link>;
-    },
-    filterable: false,
-  },
-  {
-    headerName: 'Sensitivity',
-    field: 'project.sensitivity',
-    width: 110,
-    ...enumColumn(SensitivityList, SensitivityLabels, {
-      orderByIndex: true,
-    }),
-    valueGetter: (_, row) => row.project.sensitivity,
-    renderCell: ({ value }) => (
-      <Box display="flex" alignItems="center" gap={1} textTransform="uppercase">
-        <SensitivityIcon value={value} disableTooltip />
-        {value}
-      </Box>
-    ),
-  },
-  {
-    headerName: 'Files',
-    field: 'files',
-    sortable: false,
-    filterable: false,
-    renderCell: ({ row }) => (
-      <Link to={`/projects/${row.project.id}/files`}>View Files</Link>
-    ),
-  },
-];

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -12,7 +12,7 @@ import {
   noHeaderFilterButtons,
   useDataGridSource,
 } from '~/components/Grid';
-import { PartnerTabContainer } from '../PartnerTabContainer';
+import { TabPanelContent } from '~/components/Tabs';
 import { PartnerDetailEngagementsDocument } from './PartnerDetailEngagements.graphql';
 
 const initialState = {
@@ -40,16 +40,7 @@ export const PartnerDetailEngagements = () => {
   );
 
   return (
-    <PartnerTabContainer
-      sx={{
-        flex: 1,
-        p: 0,
-        maxWidth: '100cqw',
-        width: 'min-content',
-        // idk why -50, MUI pushes down past container
-        maxHeight: 'calc(100cqh - 50px)',
-      }}
-    >
+    <TabPanelContent>
       <DataGrid<Engagement>
         {...DefaultDataGridStyles}
         {...props}
@@ -60,6 +51,6 @@ export const PartnerDetailEngagements = () => {
         initialState={initialState}
         sx={[flexLayout, noHeaderFilterButtons]}
       />
-    </PartnerTabContainer>
+    </TabPanelContent>
   );
 };

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -1,11 +1,10 @@
 import { Box } from '@mui/material';
 import {
   DataGridPro as DataGrid,
-  getGridSingleSelectOperators,
   getGridStringOperators,
   GridColDef,
 } from '@mui/x-data-grid-pro';
-import { cleanJoin, cmpBy } from '@seedcompany/common';
+import { cleanJoin } from '@seedcompany/common';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
@@ -21,11 +20,11 @@ import {
   SensitivityLabels,
   SensitivityList,
 } from '~/api/schema.graphql';
+import { enumColumn } from '~/components/Grid';
 import { SensitivityIcon } from '~/components/Sensitivity';
 import { useTable } from '~/hooks';
 import {
   DefaultDataGridStyles,
-  EmptyEnumFilterValue,
   flexLayout,
   noHeaderFilterButtons,
 } from '../../../../../components/Grid/DefaultDataGridStyles';
@@ -82,23 +81,6 @@ export const PartnerDetailEngagements = () => {
     </PartnerTabContainer>
   );
 };
-
-const enumColumn = <T extends string>(
-  list: readonly T[],
-  labels: Record<T, string>,
-  { orderByIndex }: { orderByIndex?: boolean } = {}
-) =>
-  ({
-    type: 'singleSelect',
-    filterOperators: getGridSingleSelectOperators().filter(
-      (op) => op.value !== 'not'
-    ),
-    valueOptions: list.slice(),
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    getOptionLabel: (v) => labels[v as T] ?? EmptyEnumFilterValue,
-    valueFormatter: (value: T) => labels[value],
-    ...(orderByIndex ? { sortComparator: cmpBy((v) => list.indexOf(v)) } : {}),
-  } satisfies Partial<GridColDef<any, T, string>>);
 
 const containsOp = {
   ...getGridStringOperators()[0]!,

--- a/src/scenes/Partners/Detail/Tabs/Finance/PartnerDetailFinance.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Finance/PartnerDetailFinance.tsx
@@ -1,7 +1,7 @@
 import { Many } from 'lodash';
+import { TabPanelContent } from '~/components/Tabs';
 import { EditablePartnerField } from '../../../Edit';
 import { PartnerDetailsFragment } from '../../PartnerDetail.graphql';
-import { PartnerTabContainer } from '../PartnerTabContainer';
 import { PartnerFinanceSectionHeading } from './PartnerFinanceSectionHeading';
 
 interface Props {
@@ -10,10 +10,10 @@ interface Props {
 }
 
 export const PartnerDetailFinance = ({ partner, editPartner: edit }: Props) => (
-  <PartnerTabContainer>
+  <TabPanelContent>
     <PartnerFinanceSectionHeading
       partner={partner}
       onEdit={() => edit('partner.pmcEntityCode')}
     />
-  </PartnerTabContainer>
+  </TabPanelContent>
 );

--- a/src/scenes/Partners/Detail/Tabs/Notes/PartnerDetailsNotes.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Notes/PartnerDetailsNotes.tsx
@@ -7,9 +7,9 @@ import { CreatePost } from '~/components/posts/CreatePost';
 import { PostableIdFragment } from '~/components/posts/PostableId.graphql';
 import { PostListItem } from '~/components/posts/PostListItemCard';
 import { ProgressButton } from '~/components/ProgressButton';
+import { TabPanelContent } from '~/components/Tabs';
 import { EditablePartnerField } from '../../../Edit';
 import { PartnerPostListDocument as PostListQuery } from '../../PartnerPostList.graphql';
-import { PartnerTabContainer } from '../PartnerTabContainer';
 
 interface Props {
   partner?: PostableIdFragment;
@@ -28,7 +28,7 @@ export const PartnerDetailNotes = ({ partner }: Props) => {
   });
 
   return (
-    <PartnerTabContainer>
+    <TabPanelContent>
       <ActionableSection
         loading={!partner}
         title="Notes"
@@ -59,6 +59,6 @@ export const PartnerDetailNotes = ({ partner }: Props) => {
 
         {partner && <CreatePost {...createPostState} parent={partner} />}
       </ActionableSection>
-    </PartnerTabContainer>
+    </TabPanelContent>
   );
 };

--- a/src/scenes/Partners/Detail/Tabs/PartnerTabContainer.tsx
+++ b/src/scenes/Partners/Detail/Tabs/PartnerTabContainer.tsx
@@ -1,7 +1,0 @@
-import { Paper } from '@mui/material';
-import { styled } from '@mui/material/styles';
-
-export const PartnerTabContainer = styled(Paper)(({ theme }) => ({
-  padding: theme.spacing(2, 3),
-  maxWidth: `${theme.breakpoints.values.lg}px`,
-}));

--- a/src/scenes/Partners/Detail/Tabs/People/PartnerDetailPeople.tsx
+++ b/src/scenes/Partners/Detail/Tabs/People/PartnerDetailPeople.tsx
@@ -10,9 +10,9 @@ import { Many } from 'lodash';
 import { makeStyles } from 'tss-react/mui';
 import { square } from '~/common';
 import { Avatar } from '~/components/Avatar';
+import { TabPanelContent } from '~/components/Tabs';
 import { UserListItemCardPortrait } from '~/components/UserListItemCard';
 import { EditablePartnerField } from '../../../Edit';
-import { PartnerTabContainer } from '../PartnerTabContainer';
 import { PartnerDetailPeopleFragment } from './PartnerDetailsPeople.graphql';
 
 interface Props {
@@ -37,7 +37,7 @@ export const PartnerDetailPeople = ({ partner, editPartner: edit }: Props) => {
   const { classes } = useStyles();
 
   return (
-    <PartnerTabContainer sx={{ pb: 4 }}>
+    <TabPanelContent sx={{ pb: 4 }}>
       <Typography variant="h3" gutterBottom>
         {partner ? 'Point of Contact' : <Skeleton width="120px" />}
       </Typography>
@@ -70,6 +70,6 @@ export const PartnerDetailPeople = ({ partner, editPartner: edit }: Props) => {
           </Button>
         }
       />
-    </PartnerTabContainer>
+    </TabPanelContent>
   );
 };

--- a/src/scenes/Partners/Detail/Tabs/Profile/PartnerDetailProfile.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Profile/PartnerDetailProfile.tsx
@@ -1,9 +1,9 @@
 import { Unstable_Grid2 as Grid } from '@mui/material';
 import { Many } from 'lodash';
 import { BooleanProperty } from '~/components/BooleanProperty';
+import { TabPanelContent } from '~/components/Tabs';
 import { EditablePartnerField } from '../../../Edit';
 import { PartnerDetailsFragment } from '../../PartnerDetail.graphql';
-import { PartnerTabContainer } from '../PartnerTabContainer';
 import { PartnerContactSection } from './PartnerContactSection';
 import { PartnerTypesSection } from './PartnerTypesSection';
 
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export const PartnerDetailProfile = ({ partner, editPartner: edit }: Props) => (
-  <PartnerTabContainer>
+  <TabPanelContent>
     <BooleanProperty
       label="Global Innovations Client"
       redacted="You do not have permission to view whether this is a Global Innovations Client"
@@ -36,5 +36,5 @@ export const PartnerDetailProfile = ({ partner, editPartner: edit }: Props) => (
         />
       </Grid>
     </Grid>
-  </PartnerTabContainer>
+  </TabPanelContent>
 );

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -5,7 +5,7 @@ import {
   ProjectDataGridRowFragment as Project,
   ProjectColumns,
 } from '~/components/ProjectDataGrid';
-import { PartnerTabContainer } from '../PartnerTabContainer';
+import { TabPanelContent } from '~/components/Tabs';
 import { PartnerProjectsDocument } from './PartnerProjects.graphql';
 
 export const PartnerDetailProjects = () => {
@@ -22,16 +22,7 @@ export const PartnerDetailProjects = () => {
   });
 
   return (
-    <PartnerTabContainer
-      sx={{
-        flex: 1,
-        p: 0,
-        maxWidth: '100cqw',
-        width: 'min-content',
-        // idk why -50, MUI pushes down past container
-        maxHeight: 'calc(100cqh - 50px)',
-      }}
-    >
+    <TabPanelContent>
       <DataGrid<Project>
         density="compact"
         disableColumnMenu
@@ -40,7 +31,7 @@ export const PartnerDetailProjects = () => {
         disableRowSelectionOnClick
         localeText={localeText}
       />
-    </PartnerTabContainer>
+    </TabPanelContent>
   );
 };
 

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -1,12 +1,28 @@
-import { DataGridPro as DataGrid, GridLocaleText } from '@mui/x-data-grid-pro';
+import {
+  DataGridPro as DataGrid,
+  DataGridProProps as DataGridProps,
+} from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { useDataGridSource } from '~/components/Grid';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noHeaderFilterButtons,
+  useDataGridSource,
+} from '~/components/Grid';
 import {
   ProjectDataGridRowFragment as Project,
   ProjectColumns,
 } from '~/components/ProjectDataGrid';
 import { TabPanelContent } from '~/components/Tabs';
 import { PartnerProjectsDocument } from './PartnerProjects.graphql';
+
+const initialState = {
+  pinnedColumns: {
+    left: [ProjectColumns[0]!.field],
+  },
+} satisfies DataGridProps['initialState'];
 
 export const PartnerDetailProjects = () => {
   const { partnerId = '' } = useParams();
@@ -21,20 +37,23 @@ export const PartnerDetailProjects = () => {
     },
   });
 
+  const slotProps = useMemo(
+    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
+    [props.slotProps]
+  );
+
   return (
     <TabPanelContent>
       <DataGrid<Project>
-        density="compact"
-        disableColumnMenu
+        {...DefaultDataGridStyles}
         {...props}
+        slotProps={slotProps}
         columns={ProjectColumns}
+        initialState={initialState}
+        headerFilters
         disableRowSelectionOnClick
-        localeText={localeText}
+        sx={[flexLayout, noHeaderFilterButtons]}
       />
     </TabPanelContent>
   );
-};
-
-const localeText: Partial<GridLocaleText> = {
-  noRowsLabel: 'This partner is not engaged in any projects',
 };

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -1,22 +1,12 @@
-import { Box } from '@mui/material';
-import {
-  DataGridPro as DataGrid,
-  GridColDef,
-  GridLocaleText,
-} from '@mui/x-data-grid-pro';
-import { cmpBy, simpleSwitch } from '@seedcompany/common';
+import { DataGridPro as DataGrid, GridLocaleText } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
-import { ProjectStatusLabels, ProjectTypeLabels } from '~/api/schema/enumLists';
-import { Sensitivity } from '~/api/schema/schema.graphql';
-import { labelFrom } from '~/common';
 import { useDataGridSource } from '~/components/Grid';
-import { SensitivityIcon } from '~/components/Sensitivity';
-import { Link } from '../../../../../components/Routing';
-import { PartnerTabContainer } from '../PartnerTabContainer';
 import {
-  PartnerProjectsDocument,
-  PartnerDetailProjectsTableListItemFragment as Project,
-} from './PartnerProjects.graphql';
+  ProjectDataGridRowFragment as Project,
+  ProjectColumns,
+} from '~/components/ProjectDataGrid';
+import { PartnerTabContainer } from '../PartnerTabContainer';
+import { PartnerProjectsDocument } from './PartnerProjects.graphql';
 
 export const PartnerDetailProjects = () => {
   const { partnerId = '' } = useParams();
@@ -46,7 +36,7 @@ export const PartnerDetailProjects = () => {
         density="compact"
         disableColumnMenu
         {...props}
-        columns={columns}
+        columns={ProjectColumns}
         disableRowSelectionOnClick
         localeText={localeText}
       />
@@ -57,47 +47,3 @@ export const PartnerDetailProjects = () => {
 const localeText: Partial<GridLocaleText> = {
   noRowsLabel: 'This partner is not engaged in any projects',
 };
-
-const columns: Array<GridColDef<Project>> = [
-  {
-    headerName: 'Project Name',
-    field: 'name',
-    minWidth: 300,
-    valueGetter: (_, { name }) => name.value,
-    renderCell: ({ value, row }) => (
-      <Link to={`/projects/${row.id}`}>{value}</Link>
-    ),
-  },
-  {
-    headerName: 'Type',
-    field: 'type',
-    width: 130,
-    valueGetter: labelFrom(ProjectTypeLabels),
-  },
-  {
-    headerName: 'Status',
-    field: 'status',
-    width: 160,
-    valueGetter: labelFrom(ProjectStatusLabels),
-  },
-  {
-    headerName: 'Engagements',
-    field: 'engagements',
-    width: 130,
-    valueGetter: (_, { engagements }) => engagements.total,
-  },
-  {
-    headerName: 'Sensitivity',
-    field: 'sensitivity',
-    width: 180,
-    sortComparator: cmpBy<Sensitivity>((v) =>
-      simpleSwitch(v, { Low: 0, Medium: 1, High: 2 })
-    ),
-    renderCell: ({ value }) => (
-      <Box display="flex" alignItems="center" gap={1} textTransform="uppercase">
-        <SensitivityIcon value={value} disableTooltip />
-        {value}
-      </Box>
-    ),
-  },
-];

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -9,8 +9,8 @@ import { useParams } from 'react-router-dom';
 import { ProjectStatusLabels, ProjectTypeLabels } from '~/api/schema/enumLists';
 import { Sensitivity } from '~/api/schema/schema.graphql';
 import { labelFrom } from '~/common';
+import { useDataGridSource } from '~/components/Grid';
 import { SensitivityIcon } from '~/components/Sensitivity';
-import { useTable } from '~/hooks';
 import { Link } from '../../../../../components/Routing';
 import { PartnerTabContainer } from '../PartnerTabContainer';
 import {
@@ -21,7 +21,7 @@ import {
 export const PartnerDetailProjects = () => {
   const { partnerId = '' } = useParams();
 
-  const [props] = useTable({
+  const [props] = useDataGridSource({
     query: PartnerProjectsDocument,
     variables: { id: partnerId },
     listAt: 'partner.projects',

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -33,7 +33,6 @@ export const PartnerDetailProjects = () => {
     listAt: 'partner.projects',
     initialInput: {
       sort: 'name',
-      count: 20,
     },
   });
 
@@ -51,7 +50,6 @@ export const PartnerDetailProjects = () => {
         columns={ProjectColumns}
         initialState={initialState}
         headerFilters
-        disableRowSelectionOnClick
         sx={[flexLayout, noHeaderFilterButtons]}
       />
     </TabPanelContent>

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerProjects.graphql
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerProjects.graphql
@@ -6,28 +6,8 @@ query PartnerProjects($id: ID!, $input: ProjectListInput) {
       hasMore
       total
       items {
-        ...PartnerDetailProjectsTableListItem
+        ...projectDataGridRow
       }
     }
   }
-}
-
-fragment PartnerDetailProjectsTableListItem on Project {
-  id
-  type
-  name {
-    value
-  }
-  status
-  ... on InternshipProject {
-    engagements {
-      total
-    }
-  }
-  ... on TranslationProject {
-    engagements {
-      total
-    }
-  }
-  sensitivity
 }


### PR DESCRIPTION
Abstracts partner tabs styles, and project & engagement columns to components/ for reuse.
Also synced the partner project's grid to have all the same settings as engagements.

Parts of this were pulled from #1551 and polished.