### PR TITLE
Fix useDataGridSource transition to the cached list after loading last page

### DIFF
--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -265,8 +265,10 @@ export const useDataGridSource = <
           // maintain the previously loaded first page and sort client side.
           ...(!filteredListIsComplete ? { apiSortModel: sortModel } : {}),
         }));
+
+        apiRef.current.scrollToIndexes({ rowIndex: 0 });
       },
-      [filteredListIsComplete, initialSort, setView]
+      [apiRef, filteredListIsComplete, initialSort, setView]
     );
   const onFilterModelChange: DataGridProps['onFilterModelChange'] & {} =
     useCallback(
@@ -277,8 +279,10 @@ export const useDataGridSource = <
           // API should now use the current sorting state
           apiSortModel: prev.sortModel,
         }));
+
+        apiRef.current.scrollToIndexes({ rowIndex: 0 });
       },
-      [setView]
+      [apiRef, setView]
     );
 
   // DataGrid needs help when `rows` identity changes along with picking up


### PR DESCRIPTION
Now renders subsequent pages correctly even when loaded out of order.
DataGrid needs help when `rows` identity changes along with picking up sorting responsibility (`'client'`).
I believe this is mainly fixed by the effect asking it to sort (again?) when we transition to the different, fully cached, unsorted list.

While here I noticed that with a filter applied and all pages loaded, we continued to go to network when changing the sorting.
Now we handle this by sorting client side when the current filtered list is complete, even if the overall unfiltered list is incomplete.
Note: This still doesn't account for subsequent mounts, that have all the pages in Apollo cache, but not loaded in the DataGrid. Future work could check if these exist and load them instead of going to network.