### PR TITLE
Render Visual Media in Quarterly Reports

### DIFF
--- a/src/components/form/Dropzone.tsx
+++ b/src/components/form/Dropzone.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import { ReactNode } from 'react';
-import { useDropzone } from 'react-dropzone';
+import { Accept, useDropzone } from 'react-dropzone';
 import { makeStyles } from 'tss-react/mui';
 import { Except } from 'type-fest';
 import { extendSx, StyleProps } from '~/common';
@@ -45,6 +45,7 @@ export type DropzoneFieldProps = Except<FieldConfig<File, true>, 'multiple'> &
     label?: ReactNode;
     multiple?: boolean;
     disableFileList?: boolean;
+    accept?: Accept;
   };
 
 export function DropzoneField({
@@ -54,6 +55,7 @@ export function DropzoneField({
   className,
   sx,
   disableFileList,
+  accept,
 }: DropzoneFieldProps) {
   const { classes, cx } = useStyles();
 
@@ -89,6 +91,7 @@ export function DropzoneField({
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     multiple,
     onDrop,
+    accept: accept,
   });
 
   return (

--- a/src/scenes/ProgressReports/EditForm/Steps/Media/ImageField.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/Media/ImageField.tsx
@@ -6,24 +6,26 @@ import {
 } from '@mui/icons-material';
 import {
   Box,
+  Card,
   Fab,
   FabProps,
   ListItemIcon,
   Menu,
   MenuItem,
+  Typography,
 } from '@mui/material';
 import { useId, useState } from 'react';
 import { Sensitivity } from '~/api/schema.graphql';
 import { extendSx, square, StyleProps } from '~/common';
 import { DropzoneField, useSubmitButton } from '~/components/form';
 import { SensitivityIcon } from '../../../../../components/Sensitivity';
-import { ImageFragment } from './progressReportMedia.graphql';
+import { VisualMediaFragment as VisualMedia } from './progressReportMedia.graphql';
 
 export interface ImageFieldProps extends StyleProps {
   name: string;
   disabled?: boolean;
   sensitivity?: Sensitivity;
-  current?: ImageFragment;
+  current?: VisualMedia;
   canDelete: boolean;
   instructionMessage?: string;
 }
@@ -43,6 +45,7 @@ export const ImageField = ({
       disabled={disabled}
       disableFileList
       {...props}
+      accept={{ 'image/*': [] }}
       sx={[
         {
           m: 0,
@@ -88,15 +91,31 @@ export const ImageField = ({
         ...extendSx(props.sx),
       ]}
     >
-      <Box
-        component="img"
-        src={current.url}
-        crossOrigin="use-credentials"
-        sx={{
-          maxWidth: 1,
-          borderRadius: 1,
-        }}
-      />
+      {current.__typename === 'Image' ? (
+        <Box
+          component="img"
+          src={current.url}
+          crossOrigin="use-credentials"
+          sx={{
+            maxWidth: 1,
+            borderRadius: 1,
+          }}
+        />
+      ) : (
+        <Card
+          variant="outlined"
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            maxWidth: 1,
+            borderRadius: 1,
+            aspectRatio: current.dimensions.aspectRatio,
+          }}
+        >
+          <Typography variant="body1">Not an image</Typography>
+        </Card>
+      )}
       {sensitivity && (
         <SensitivityIcon
           value={sensitivity}

--- a/src/scenes/ProgressReports/EditForm/Steps/Media/MediaInfoForm.tsx
+++ b/src/scenes/ProgressReports/EditForm/Steps/Media/MediaInfoForm.tsx
@@ -47,8 +47,10 @@ export const MediaInfoForm = ({
   isFirstUpload,
   ...props
 }: MediaInfoFormProps) => {
-  const existingImage =
+  const existingFile =
     existingMedia?.media.__typename === 'Image'
+      ? existingMedia.media
+      : existingMedia?.media.__typename === 'Video'
       ? existingMedia.media
       : undefined;
 
@@ -57,7 +59,7 @@ export const MediaInfoForm = ({
       variant,
       id: existingMedia?.id,
       category: existingMedia?.category,
-      caption: existingImage?.caption,
+      caption: existingFile?.caption,
       variantGroup: existingMedia?.variantGroup,
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -83,7 +85,7 @@ export const MediaInfoForm = ({
               mb: 1,
             }}
           >
-            {!existingImage && !isFirstUpload && (
+            {!existingFile && !isFirstUpload && (
               <ImageField
                 name="newVersion"
                 sensitivity={sensitivity}
@@ -94,7 +96,7 @@ export const MediaInfoForm = ({
             )}
             <ImageField
               name="newFile"
-              current={existingImage}
+              current={existingFile}
               sensitivity={sensitivity}
               canDelete={existingMedia?.canDelete ?? false}
               sx={{ flex: 1, mt: 1, minWidth: 195 }}
@@ -104,7 +106,7 @@ export const MediaInfoForm = ({
                   : 'Click or drop to add a completely different image, because the previous is not suitable'
               }
             />
-            {existingImage && (
+            {existingFile && (
               <Stack gap="inherit" flex={2} minWidth={270}>
                 <SelectField
                   label="Photo Category"

--- a/src/scenes/ProgressReports/EditForm/Steps/Media/progressReportMedia.graphql
+++ b/src/scenes/ProgressReports/EditForm/Steps/Media/progressReportMedia.graphql
@@ -7,13 +7,13 @@ fragment progressReportMedia on ProgressReportMedia {
   category
   media {
     id
-    ...image
+    ...visualMedia
   }
   canEdit
   canDelete
 }
 
-fragment image on Image {
+fragment visualMedia on VisualMedia {
   id
   caption
   url


### PR DESCRIPTION
There was an issue where the user uploaded a video and because the UI rendered only Image files, the user or support team were not able to remove the file.

This change allows visual media files to be rendered and adds a filter for image uploads on Quarterly Reports.