### PR TITLE
Adjust ProgressReport rich text cell styling

### DIFF
--- a/src/components/RichText/RichTextView.tsx
+++ b/src/components/RichText/RichTextView.tsx
@@ -27,9 +27,15 @@ export const RichTextView = memo(function RichTextView({
   return <Blocks data={data1} renderers={renderers} />;
 });
 
-const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => {
+const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => (
+  <Typography paragraph>
+    <Text data={data} />
+  </Typography>
+);
+
+export const Text: RenderFn<{ text: string }> = ({ data }) => {
   const { text } = data ?? {};
-  return <Typography paragraph>{text && HTMLReactParser(text)}</Typography>;
+  return <>{text && HTMLReactParser(text)}</>;
 };
 
 const HeaderBlock: RenderFn<{ text: string; level: 1 | 2 | 3 | 4 | 5 | 6 }> = ({

--- a/src/components/RichText/RichTextView.tsx
+++ b/src/components/RichText/RichTextView.tsx
@@ -2,22 +2,30 @@ import type { OutputData as RichTextData } from '@editorjs/editorjs';
 import { Divider, Typography } from '@mui/material';
 import Blocks from 'editorjs-blocks-react-renderer';
 import HTMLReactParser from 'html-react-parser';
-import { memo } from 'react';
+import { memo, ReactElement, useMemo } from 'react';
 import { ToolKey } from './editorJsTools';
+
+export type RichTextRenderers = { [K in ToolKey]?: RenderFn<any> };
+
+export type RenderFn<T = undefined> = (_: { data?: T }) => ReactElement;
 
 export const RichTextView = memo(function RichTextView({
   data,
+  renderers: renderersInput,
 }: {
   data?: RichTextData | null;
+  renderers?: RichTextRenderers;
 }) {
+  const renderers = useMemo(
+    () => ({ ...defaultRenderers, ...renderersInput }),
+    [renderersInput]
+  );
   if (!data) {
     return null;
   }
   const data1 = { version: '0', time: 0, ...data };
   return <Blocks data={data1} renderers={renderers} />;
 });
-
-type RenderFn<T = undefined> = (_: { data?: T }) => JSX.Element;
 
 const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => {
   const { text } = data ?? {};
@@ -37,7 +45,7 @@ const HeaderBlock: RenderFn<{ text: string; level: 1 | 2 | 3 | 4 | 5 | 6 }> = ({
 
 const DelimiterBlock: RenderFn = () => <Divider sx={{ my: 2 }} />;
 
-const renderers: { [K in ToolKey]?: RenderFn<any> } = {
+const defaultRenderers: RichTextRenderers = {
   paragraph: ParagraphBlock,
   header: HeaderBlock,
   delimiter: DelimiterBlock,

--- a/src/components/RichText/RichTextView.tsx
+++ b/src/components/RichText/RichTextView.tsx
@@ -2,19 +2,24 @@ import type { OutputData as RichTextData } from '@editorjs/editorjs';
 import { Divider, Typography } from '@mui/material';
 import Blocks from 'editorjs-blocks-react-renderer';
 import HTMLReactParser from 'html-react-parser';
-import { memo, ReactElement, useMemo } from 'react';
-import { ToolKey } from './editorJsTools';
+import { ComponentType, memo, useMemo } from 'react';
+import { BlockDataMap, ToolKey } from './editorJsTools';
 
-export type RichTextRenderers = { [K in ToolKey]?: RenderFn<any> };
+export type Renderers = {
+  [K in ToolKey]?: ComponentType<BlockProps<K>>;
+};
 
-export type RenderFn<T = undefined> = (_: { data?: T }) => ReactElement;
+export interface BlockProps<K extends ToolKey> {
+  data?: K extends keyof BlockDataMap ? BlockDataMap[K] : never;
+  className?: string;
+}
 
 export const RichTextView = memo(function RichTextView({
   data,
   renderers: renderersInput,
 }: {
   data?: RichTextData | null;
-  renderers?: RichTextRenderers;
+  renderers?: Renderers;
 }) {
   const renderers = useMemo(
     () => ({ ...defaultRenderers, ...renderersInput }),
@@ -24,23 +29,27 @@ export const RichTextView = memo(function RichTextView({
     return null;
   }
   const data1 = { version: '0', time: 0, ...data };
-  return <Blocks data={data1} renderers={renderers} />;
+  return (
+    <Blocks
+      data={data1}
+      // @ts-expect-error our types are stricter
+      renderers={renderers}
+    />
+  );
 });
 
-const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => (
+const ParagraphBlock = ({ data }: BlockProps<'paragraph'>) => (
   <Typography paragraph>
     <Text data={data} />
   </Typography>
 );
 
-export const Text: RenderFn<{ text: string }> = ({ data }) => {
+export const Text = ({ data }: BlockProps<'paragraph'>) => {
   const { text } = data ?? {};
   return <>{text && HTMLReactParser(text)}</>;
 };
 
-const HeaderBlock: RenderFn<{ text: string; level: 1 | 2 | 3 | 4 | 5 | 6 }> = ({
-  data,
-}) => {
+const HeaderBlock = ({ data }: BlockProps<'header'>) => {
   const { text, level = 1 } = data ?? {};
   return (
     <Typography variant={`h${level}`} gutterBottom>
@@ -49,9 +58,9 @@ const HeaderBlock: RenderFn<{ text: string; level: 1 | 2 | 3 | 4 | 5 | 6 }> = ({
   );
 };
 
-const DelimiterBlock: RenderFn = () => <Divider sx={{ my: 2 }} />;
+const DelimiterBlock = () => <Divider sx={{ my: 2 }} />;
 
-const defaultRenderers: RichTextRenderers = {
+const defaultRenderers: Renderers = {
   paragraph: ParagraphBlock,
   header: HeaderBlock,
   delimiter: DelimiterBlock,

--- a/src/components/RichText/editorJsTools.ts
+++ b/src/components/RichText/editorJsTools.ts
@@ -47,3 +47,9 @@ export type ToolKey = keyof typeof EDITOR_JS_TOOLS;
 
 export const customTools = (toolsNames: ToolKey[]) =>
   pick(EDITOR_JS_TOOLS, toolsNames);
+
+export interface BlockDataMap {
+  paragraph: { text: string };
+  header: { text: string; level: 1 | 2 | 3 | 4 | 5 | 6 };
+  list: { style: 'unordered' | 'ordered'; items: string[] };
+}

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
@@ -1,5 +1,7 @@
+import { Box } from '@mui/material';
 import {
   DataGridProProps as DataGridProps,
+  GridRenderCellParams,
   GridRowId,
   GridToolbarColumnsButton,
   GridToolbarFilterButton,
@@ -24,9 +26,34 @@ import {
 
 const COLLAPSED_ROW_HEIGHT = 54;
 
+// Position cell text consistently regardless of expansion
+const NonExpansionCell = ({ formattedValue }: GridRenderCellParams) => (
+  <Box
+    sx={{
+      '--height': `${COLLAPSED_ROW_HEIGHT}px`,
+      // Causes row to grow by 1px on row height auto
+      // Shift the 1px to padding to prevent.
+      height: 'calc(var(--height) - 1px)',
+      pt: '1px',
+      // This is exactly what MUI does when not auto height
+      lineHeight: 'calc(var(--height) - 1px)',
+
+      display: 'flex',
+      alignItems: 'center',
+    }}
+  >
+    {formattedValue}
+  </Box>
+);
+
 const columns = entries(ProgressReportsColumnMap).map(([name, col]) => ({
   field: name,
   ...col,
+  ...(!(
+    'cellClassName' in col && col.cellClassName.includes(ExpansionMarker)
+  ) && {
+    renderCell: NonExpansionCell,
+  }),
 }));
 
 const initialState = {
@@ -93,11 +120,6 @@ export const ProgressReportsExpandedGrid = (props: Partial<DataGridProps>) => {
           '.MuiDataGrid-cell': {
             minHeight: COLLAPSED_ROW_HEIGHT,
           },
-          [`.MuiDataGrid-row--dynamicHeight .MuiDataGrid-cell:not(.${ExpansionMarker})`]:
-            {
-              // Magic number to keep text vertically unchanged when the row is expanded
-              pt: '17.5px',
-            },
         },
         ...extendSx(props.sx),
       ]}

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
@@ -22,12 +22,12 @@ import {
   textColumn,
   useDataGridSource,
 } from '~/components/Grid';
-import { RichTextView } from '~/components/RichText';
 import { Link } from '~/components/Routing';
 import {
   ProgressReportsDataGridRowFragment as ProgressReport,
   ProgressReportsDocument,
 } from './progressReportsDataGridRow.graphql';
+import { RichTextCell } from './RichTextCell';
 import { VariantResponseCell } from './VariantResponseCell';
 
 export type ProgressReportColumnMapShape = Record<
@@ -99,14 +99,14 @@ export const ProgressReportsColumnMap = {
   },
   'varianceExplanation.comments': {
     headerName: 'Variance Explanation',
-    width: 250,
+    width: 400,
     sortable: false,
     filterable: false,
     valueGetter: (_, { varianceExplanation }) =>
       varianceExplanation.comments.value,
-    renderCell: ({ value }) => (
-      <Box m={1} display="flex" alignItems="center" gap={1}>
-        <RichTextView data={value} />
+    renderCell: (props) => (
+      <Box my={1}>
+        <RichTextCell {...props} />
       </Box>
     ),
     cellClassName: ExpansionMarker,

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
@@ -35,7 +35,7 @@ export type ProgressReportColumnMapShape = Record<
   SetOptional<GridColDef<ProgressReport>, 'field'>
 >;
 
-export const ExpansionMarker = 'multiline';
+export const ExpansionMarker = 'expandable';
 
 export const ProgressReportsColumnMap = {
   project: {

--- a/src/scenes/Dashboard/ProgressReportsWidget/RichTextCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/RichTextCell.tsx
@@ -6,8 +6,8 @@ import {
 } from '@mui/x-data-grid';
 import { extendSx, RichTextJson, StyleProps } from '~/common';
 import {
-  RenderFn,
-  RichTextRenderers,
+  BlockProps,
+  Renderers,
   RichTextView,
   Text,
 } from '../../../components/RichText';
@@ -52,15 +52,13 @@ export const RichTextCell = ({
   );
 };
 
-const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => (
+const ParagraphBlock = ({ data }: BlockProps<'paragraph'>) => (
   <Typography variant="body2" paragraph>
     <Text data={data} />
   </Typography>
 );
 
-const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
-  data,
-}) => {
+const List = ({ data }: BlockProps<'list'>) => {
   // eslint-disable-next-line react/jsx-no-useless-fragment
   if (!data) return <></>;
   const { style, items } = data;
@@ -90,7 +88,7 @@ const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
   );
 };
 
-const renderers: RichTextRenderers = {
+const renderers: Renderers = {
   paragraph: ParagraphBlock,
   list: List,
 };

--- a/src/scenes/Dashboard/ProgressReportsWidget/RichTextCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/RichTextCell.tsx
@@ -1,0 +1,96 @@
+import { Box, Typography } from '@mui/material';
+import {
+  GridState,
+  GridRenderCellParams as RenderCellParams,
+  useGridSelector,
+} from '@mui/x-data-grid';
+import { extendSx, RichTextJson, StyleProps } from '~/common';
+import {
+  RenderFn,
+  RichTextRenderers,
+  RichTextView,
+  Text,
+} from '../../../components/RichText';
+import { ProgressReportsDataGridRowFragment as ProgressReport } from './progressReportsDataGridRow.graphql';
+
+type CellParams = RenderCellParams<ProgressReport, RichTextJson>;
+
+export const RichTextCell = ({
+  id,
+  value,
+  api,
+  sx,
+  className,
+}: Pick<CellParams, 'value' | 'id' | 'api'> & StyleProps) => {
+  const selectedRows = useGridSelector(
+    { current: api },
+    (state: GridState) => state.rowSelection
+  );
+  const isExpanded = selectedRows[0] === id;
+
+  if (!value) return null;
+
+  return (
+    <Box
+      sx={[
+        {
+          overflow: 'hidden',
+          textWrap: 'wrap',
+          display: isExpanded ? 'contents' : '-webkit-box',
+          WebkitLineClamp: '2',
+          WebkitBoxOrient: 'vertical',
+
+          // No trailing spacing on response
+          '& > *:last-child': { mb: 0 },
+        },
+        ...extendSx(sx),
+      ]}
+      className={className}
+    >
+      <RichTextView data={value} renderers={renderers} />
+    </Box>
+  );
+};
+
+const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => (
+  <Typography variant="body2" paragraph>
+    <Text data={data} />
+  </Typography>
+);
+
+const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
+  data,
+}) => {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  if (!data) return <></>;
+  const { style, items } = data;
+  return (
+    <Box
+      component={style === 'unordered' ? 'ul' : 'ol'}
+      sx={{ display: 'contents' }}
+    >
+      {items.map((text, index) => (
+        <Typography
+          key={index}
+          variant="body2"
+          component="li"
+          gutterBottom
+          sx={{
+            display: 'block',
+            '&::before': {
+              content: style === 'unordered' ? `"• "` : `"${index + 1}. "`,
+            },
+            '&:last-of-type': { mb: 0 },
+          }}
+        >
+          <Text data={{ text }} />
+        </Typography>
+      ))}
+    </Box>
+  );
+};
+
+const renderers: RichTextRenderers = {
+  paragraph: ParagraphBlock,
+  list: List,
+};

--- a/src/scenes/Dashboard/ProgressReportsWidget/RichTextCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/RichTextCell.tsx
@@ -26,7 +26,7 @@ export const RichTextCell = ({
     { current: api },
     (state: GridState) => state.rowSelection
   );
-  const isExpanded = selectedRows[0] === id;
+  const isExpanded = selectedRows.includes(id);
 
   if (!value) return null;
 

--- a/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
@@ -10,6 +10,7 @@ import {
   RenderFn,
   RichTextRenderers,
   RichTextView,
+  Text,
 } from '../../../components/RichText';
 import { RoleIcon as BaseRoleIcon } from '../../../components/RoleIcon';
 import { ProgressReportsDataGridRowFragment as ProgressReport } from './progressReportsDataGridRow.graphql';
@@ -51,6 +52,12 @@ export const VariantResponseCell = ({ value, ...props }: CellParams) => {
   );
 };
 
+const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => (
+  <Typography variant="body2" paragraph>
+    <Text data={data} />
+  </Typography>
+);
+
 const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
   data,
 }) => {
@@ -62,9 +69,10 @@ const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
       component={style === 'unordered' ? 'ul' : 'ol'}
       sx={{ display: 'contents' }}
     >
-      {items.map((item, index) => (
+      {items.map((text, index) => (
         <Typography
           key={index}
+          variant="body2"
           component="li"
           gutterBottom
           sx={{
@@ -75,13 +83,15 @@ const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
             '&:last-of-type': { mb: 0 },
           }}
         >
-          {item}
+          <Text data={{ text }} />
         </Typography>
       ))}
     </Box>
   );
 };
+
 const renderers: RichTextRenderers = {
+  paragraph: ParagraphBlock,
   list: List,
 };
 

--- a/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import {
   GridState,
@@ -6,7 +6,11 @@ import {
   useGridSelector,
 } from '@mui/x-data-grid';
 import { VariantResponseFragment as VariantResponse } from '~/common/fragments';
-import { RichTextView } from '../../../components/RichText';
+import {
+  RenderFn,
+  RichTextRenderers,
+  RichTextView,
+} from '../../../components/RichText';
 import { RoleIcon as BaseRoleIcon } from '../../../components/RoleIcon';
 import { ProgressReportsDataGridRowFragment as ProgressReport } from './progressReportsDataGridRow.graphql';
 
@@ -42,9 +46,43 @@ export const VariantResponseCell = ({ value, ...props }: CellParams) => {
         variantRole={variant.responsibleRole}
         sx={{ fontSize: 36, float: 'left', mr: 1 }}
       />
-      <RichTextView data={response} />
+      <RichTextView data={response} renderers={renderers} />
     </Box>
   );
+};
+
+const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
+  data,
+}) => {
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  if (!data) return <></>;
+  const { style, items } = data;
+  return (
+    <Box
+      component={style === 'unordered' ? 'ul' : 'ol'}
+      sx={{ display: 'contents' }}
+    >
+      {items.map((item, index) => (
+        <Typography
+          key={index}
+          component="li"
+          gutterBottom
+          sx={{
+            display: 'block',
+            '&::before': {
+              content: style === 'unordered' ? `"• "` : `"${index + 1}. "`,
+            },
+            '&:last-of-type': { mb: 0 },
+          }}
+        >
+          {item}
+        </Typography>
+      ))}
+    </Box>
+  );
+};
+const renderers: RichTextRenderers = {
+  list: List,
 };
 
 export const VariantResponseIconCell = ({ value }: CellParams) => {

--- a/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
@@ -1,29 +1,14 @@
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import {
-  GridState,
-  GridRenderCellParams as RenderCellParams,
-  useGridSelector,
-} from '@mui/x-data-grid';
+import { GridRenderCellParams as RenderCellParams } from '@mui/x-data-grid';
 import { VariantResponseFragment as VariantResponse } from '~/common/fragments';
-import {
-  RenderFn,
-  RichTextRenderers,
-  RichTextView,
-  Text,
-} from '../../../components/RichText';
 import { RoleIcon as BaseRoleIcon } from '../../../components/RoleIcon';
 import { ProgressReportsDataGridRowFragment as ProgressReport } from './progressReportsDataGridRow.graphql';
+import { RichTextCell } from './RichTextCell';
 
 type CellParams = RenderCellParams<ProgressReport, VariantResponse>;
 
 export const VariantResponseCell = ({ value, ...props }: CellParams) => {
-  const selectedRows = useGridSelector(
-    { current: props.api },
-    (state: GridState) => state.rowSelection
-  );
-  const isExpanded = selectedRows[0] === props.id;
-
   if (!value) return null;
 
   const { variant } = value;
@@ -34,65 +19,9 @@ export const VariantResponseCell = ({ value, ...props }: CellParams) => {
         variantRole={variant.responsibleRole}
         sx={{ fontSize: 36, float: 'left', mr: 1 }}
       />
-      <Box
-        sx={{
-          overflow: 'hidden',
-          textWrap: 'wrap',
-          display: isExpanded ? 'contents' : '-webkit-box',
-          WebkitLineClamp: '2',
-          WebkitBoxOrient: 'vertical',
-
-          // No trailing spacing on response
-          '& > *:last-child': { mb: 0 },
-        }}
-      >
-        <RichTextView data={response} renderers={renderers} />
-      </Box>
+      <RichTextCell value={response} {...props} />
     </Box>
   );
-};
-
-const ParagraphBlock: RenderFn<{ text: string }> = ({ data }) => (
-  <Typography variant="body2" paragraph>
-    <Text data={data} />
-  </Typography>
-);
-
-const List: RenderFn<{ style: 'unordered' | 'ordered'; items: string[] }> = ({
-  data,
-}) => {
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  if (!data) return <></>;
-  const { style, items } = data;
-  return (
-    <Box
-      component={style === 'unordered' ? 'ul' : 'ol'}
-      sx={{ display: 'contents' }}
-    >
-      {items.map((text, index) => (
-        <Typography
-          key={index}
-          variant="body2"
-          component="li"
-          gutterBottom
-          sx={{
-            display: 'block',
-            '&::before': {
-              content: style === 'unordered' ? `"• "` : `"${index + 1}. "`,
-            },
-            '&:last-of-type': { mb: 0 },
-          }}
-        >
-          <Text data={{ text }} />
-        </Typography>
-      ))}
-    </Box>
-  );
-};
-
-const renderers: RichTextRenderers = {
-  paragraph: ParagraphBlock,
-  list: List,
 };
 
 export const VariantResponseIconCell = ({ value }: CellParams) => {

--- a/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/VariantResponseCell.tsx
@@ -28,25 +28,25 @@ export const VariantResponseCell = ({ value, ...props }: CellParams) => {
   const { variant } = value;
   const response = value.response.value!;
   return (
-    <Box
-      sx={{
-        my: 1,
-
-        overflow: 'hidden',
-        textWrap: 'wrap',
-        display: isExpanded ? undefined : '-webkit-box',
-        WebkitLineClamp: '2',
-        WebkitBoxOrient: 'vertical',
-
-        // No trailing spacing on response
-        '& > *:last-child': { mb: 0 },
-      }}
-    >
+    <Box my={1}>
       <RoleIcon
         variantRole={variant.responsibleRole}
         sx={{ fontSize: 36, float: 'left', mr: 1 }}
       />
-      <RichTextView data={response} renderers={renderers} />
+      <Box
+        sx={{
+          overflow: 'hidden',
+          textWrap: 'wrap',
+          display: isExpanded ? 'contents' : '-webkit-box',
+          WebkitLineClamp: '2',
+          WebkitBoxOrient: 'vertical',
+
+          // No trailing spacing on response
+          '& > *:last-child': { mb: 0 },
+        }}
+      >
+        <RichTextView data={response} renderers={renderers} />
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
- More consistent font size
- lists render better & float around the variant icon
- Fixed line clamp in Safari
- Variance Explanation uses same wrapper now so it line clamps & expands like the other two.
- I increased its default width too

![Screenshot 2024-10-01 at 6 50 36 PM](https://github.com/user-attachments/assets/2f8a65b5-7d2a-44fa-af51-636912e752ef)
![Screenshot 2024-10-01 at 6 50 42 PM](https://github.com/user-attachments/assets/de5a6bcf-80f3-498d-9113-91ebf1f318c9)

Safari proof:
![Screenshot 2024-10-01 at 6 50 57 PM](https://github.com/user-attachments/assets/fe74cb00-8f86-4f06-b747-76418756d2d2)