### PR TITLE
Comments Tweaks

### DIFF
--- a/src/api/schema/typePolicies/lists/page-limit-pagination.ts
+++ b/src/api/schema/typePolicies/lists/page-limit-pagination.ts
@@ -226,7 +226,7 @@ const reverse = <T>(list: readonly T[]): readonly T[] => list.slice().reverse();
 // left out of the key specifier
 const objectToKeyArgs = (obj: Record<string, any>): KeyArgs => {
   const keys = objectToKeyArgsRecurse(cleanEmptyObjects(obj));
-  return keys.length > 1 ? keys : false;
+  return keys.length > 0 ? keys : false;
 };
 const objectToKeyArgsRecurse = (obj: Record<string, any>): KeySpecifier =>
   Object.entries(obj).reduce(

--- a/src/components/Changeset/ChangesetBanner.tsx
+++ b/src/components/Changeset/ChangesetBanner.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles()(({ spacing, breakpoints }) => ({
 }));
 
 interface Props {
-  changesetId: string | null;
+  changesetId: string | undefined;
   onEdit?: () => void;
   onClose?: () => void;
 }

--- a/src/components/Changeset/useChangesetAwareIdFromUrl.ts
+++ b/src/components/Changeset/useChangesetAwareIdFromUrl.ts
@@ -9,10 +9,10 @@ export const useChangesetAwareIdFromUrl = (paramName: string) => {
   const navigate = useNavigate();
   let { [paramName]: objAndChangesetId = '' } = useParams();
   // eslint-disable-next-line prefer-const -- false positive
-  let [id = '', changesetId = null] = objAndChangesetId.split('~');
+  let [id = '', changesetId] = objAndChangesetId.split('~');
   if (!useBetaFeatures().has('projectChangeRequests')) {
     objAndChangesetId = id;
-    changesetId = null;
+    changesetId = undefined;
   }
   return {
     mergedId: objAndChangesetId,

--- a/src/components/Comments/CommentsContext.tsx
+++ b/src/components/Comments/CommentsContext.tsx
@@ -19,8 +19,6 @@ const initialCommentsBarContext = {
   toggleCommentsBar: noop as (state?: boolean) => void,
   isCommentsBarOpen: false,
   expandedThreads: {} as unknown as ExpandedThreads,
-  resourceCommentsTotal: 0,
-  setResourceCommentsTotal: noop,
   resourceId: undefined as string | undefined,
   setResourceId: noop as (resourceId: string | undefined) => void,
 };
@@ -32,8 +30,6 @@ export const CommentsProvider = ({ children }: ChildrenProp) => {
     useLocalStorageState<boolean>('show-comments', { defaultValue: false });
 
   const [resourceId, setResourceId] = useState<string | undefined>(undefined);
-
-  const [resourceCommentsTotal, setResourceCommentsTotal] = useState(0);
 
   const [currentExpandedThreads, setExpandedThreads] = useSet<string>();
   const expandedThreads = useMemo(
@@ -60,8 +56,6 @@ export const CommentsProvider = ({ children }: ChildrenProp) => {
       toggleCommentsBar,
       isCommentsBarOpen,
       expandedThreads,
-      resourceCommentsTotal,
-      setResourceCommentsTotal,
       resourceId,
       setResourceId,
     }),
@@ -69,7 +63,6 @@ export const CommentsProvider = ({ children }: ChildrenProp) => {
       toggleCommentsBar,
       isCommentsBarOpen,
       expandedThreads,
-      resourceCommentsTotal,
       resourceId,
       setResourceId,
     ]

--- a/src/components/Comments/CommentsThreadList.graphql
+++ b/src/components/Comments/CommentsThreadList.graphql
@@ -1,9 +1,12 @@
 query CommentThreadsList($resourceId: ID!, $input: CommentThreadListInput) {
-  commentThreads(resource: $resourceId, input: $input) {
-    canCreate
-    items {
-      ...commentThread
+  commentable(resource: $resourceId) {
+    id
+    commentThreads(input: $input) {
+      canCreate
+      items {
+        ...commentThread
+      }
+      ...Pagination
     }
-    ...Pagination
   }
 }

--- a/src/components/Comments/CommentsThreadList.tsx
+++ b/src/components/Comments/CommentsThreadList.tsx
@@ -5,13 +5,11 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { useEffect } from 'react';
 import { isNetworkRequestInFlight } from '../../api';
 import { renderError } from '../Error/error-handling';
 import { useListQuery } from '../List';
 import { ProgressButton } from '../ProgressButton';
 import { CreateComment } from './CommentForm/CreateComment';
-import { useCommentsContext } from './CommentsContext';
 import { CommentThreadsListDocument } from './CommentsThreadList.graphql';
 import { CommentThread } from './CommentThread';
 
@@ -20,8 +18,6 @@ interface CommentThreadListProps {
 }
 
 export const CommentsThreadList = ({ resourceId }: CommentThreadListProps) => {
-  const { setResourceCommentsTotal } = useCommentsContext();
-
   const list = useListQuery(CommentThreadsListDocument, {
     listAt: (data) => data.commentThreads,
     variables: {
@@ -32,10 +28,6 @@ export const CommentsThreadList = ({ resourceId }: CommentThreadListProps) => {
     },
   });
   const { data, error, loadMore, networkStatus } = list;
-
-  useEffect(() => {
-    setResourceCommentsTotal(data?.total ?? 0);
-  }, [data, setResourceCommentsTotal]);
 
   if (error) {
     const renderedError = renderError(error, {

--- a/src/components/Comments/CommentsThreadList.tsx
+++ b/src/components/Comments/CommentsThreadList.tsx
@@ -34,11 +34,7 @@ export const CommentsThreadList = ({ resourceId }: CommentThreadListProps) => {
   const { data, error, loadMore, networkStatus } = list;
 
   useEffect(() => {
-    const totalComments = (data?.items ?? [])
-      .flatMap((thread) => thread.comments.total)
-      .reduce((prev, total) => prev + total, 0);
-
-    setResourceCommentsTotal(totalComments);
+    setResourceCommentsTotal(data?.total ?? 0);
   }, [data, setResourceCommentsTotal]);
 
   if (error) {

--- a/src/components/Comments/CommentsThreadList.tsx
+++ b/src/components/Comments/CommentsThreadList.tsx
@@ -10,6 +10,7 @@ import { renderError } from '../Error/error-handling';
 import { useListQuery } from '../List';
 import { ProgressButton } from '../ProgressButton';
 import { CreateComment } from './CommentForm/CreateComment';
+import { useCommentsContext } from './CommentsContext';
 import { CommentThreadsListDocument } from './CommentsThreadList.graphql';
 import { CommentThread } from './CommentThread';
 
@@ -18,11 +19,14 @@ interface CommentThreadListProps {
 }
 
 export const CommentsThreadList = ({ resourceId }: CommentThreadListProps) => {
+  const { isCommentsBarOpen } = useCommentsContext();
+
   const list = useListQuery(CommentThreadsListDocument, {
     listAt: (data) => data.commentable.commentThreads,
     variables: {
       resourceId,
     },
+    skip: !isCommentsBarOpen,
   });
   const { data, error, loadMore, networkStatus } = list;
 

--- a/src/components/Comments/CommentsThreadList.tsx
+++ b/src/components/Comments/CommentsThreadList.tsx
@@ -22,9 +22,6 @@ export const CommentsThreadList = ({ resourceId }: CommentThreadListProps) => {
     listAt: (data) => data.commentThreads,
     variables: {
       resourceId,
-      input: {
-        order: 'ASC',
-      },
     },
   });
   const { data, error, loadMore, networkStatus } = list;

--- a/src/components/Comments/CommentsThreadList.tsx
+++ b/src/components/Comments/CommentsThreadList.tsx
@@ -19,7 +19,7 @@ interface CommentThreadListProps {
 
 export const CommentsThreadList = ({ resourceId }: CommentThreadListProps) => {
   const list = useListQuery(CommentThreadsListDocument, {
-    listAt: (data) => data.commentThreads,
+    listAt: (data) => data.commentable.commentThreads,
     variables: {
       resourceId,
     },

--- a/src/components/Comments/ThreadCount.graphql
+++ b/src/components/Comments/ThreadCount.graphql
@@ -1,0 +1,5 @@
+query ThreadCount($id: ID!) {
+  commentThreads(resource: $id) {
+    total
+  }
+}

--- a/src/components/Comments/ThreadCount.graphql
+++ b/src/components/Comments/ThreadCount.graphql
@@ -1,5 +1,8 @@
 query ThreadCount($id: ID!) {
-  commentThreads(resource: $id) {
-    total
+  commentable(resource: $id) {
+    id
+    commentThreads {
+      total
+    }
   }
 }

--- a/src/components/Comments/ToggleCommentButton.tsx
+++ b/src/components/Comments/ToggleCommentButton.tsx
@@ -1,21 +1,29 @@
+import { useQuery } from '@apollo/client';
 import { Comment } from '@mui/icons-material';
 import { Badge } from '@mui/material';
 import { Except } from 'type-fest';
 import { Feature } from '../Feature';
 import { IconButton, IconButtonProps } from '../IconButton';
 import { useCommentsContext } from './CommentsContext';
+import { ThreadCountDocument } from './ThreadCount.graphql';
 
 export type ToggleCommentsButtonProps = Except<IconButtonProps, 'children'>;
 
 export const ToggleCommentsButton = ({
   ...rest
 }: ToggleCommentsButtonProps) => {
-  const { toggleCommentsBar, resourceCommentsTotal } = useCommentsContext();
+  const { resourceId, toggleCommentsBar } = useCommentsContext();
+
+  const { data } = useQuery(ThreadCountDocument, {
+    variables: { id: resourceId! },
+    skip: !resourceId,
+  });
+  const total = data?.commentThreads.total ?? 0;
 
   return (
     <Feature flag="comments" match={true}>
       <IconButton onClick={() => toggleCommentsBar()} {...rest}>
-        <Badge badgeContent={resourceCommentsTotal} color="primary">
+        <Badge badgeContent={total} color="primary">
           <Comment />
         </Badge>
       </IconButton>

--- a/src/components/Comments/ToggleCommentButton.tsx
+++ b/src/components/Comments/ToggleCommentButton.tsx
@@ -15,7 +15,7 @@ export const ToggleCommentsButton = ({
   return (
     <Feature flag="comments" match={true}>
       <IconButton onClick={() => toggleCommentsBar()} {...rest}>
-        <Badge badgeContent={resourceCommentsTotal} color="error">
+        <Badge badgeContent={resourceCommentsTotal} color="primary">
           <Comment />
         </Badge>
       </IconButton>

--- a/src/components/Comments/ToggleCommentButton.tsx
+++ b/src/components/Comments/ToggleCommentButton.tsx
@@ -12,11 +12,13 @@ export type ToggleCommentsButtonProps = Except<IconButtonProps, 'children'>;
 export const ToggleCommentsButton = ({
   ...rest
 }: ToggleCommentsButtonProps) => {
-  const { resourceId, toggleCommentsBar } = useCommentsContext();
+  const { resourceId, isCommentsBarOpen, toggleCommentsBar } =
+    useCommentsContext();
 
   const { data } = useQuery(ThreadCountDocument, {
     variables: { id: resourceId! },
     skip: !resourceId,
+    fetchPolicy: isCommentsBarOpen ? 'cache-only' : 'cache-first',
   });
   const total = data?.commentable.commentThreads.total ?? 0;
 

--- a/src/components/Comments/ToggleCommentButton.tsx
+++ b/src/components/Comments/ToggleCommentButton.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Comment } from '@mui/icons-material';
-import { Badge } from '@mui/material';
+import { Badge, Tooltip } from '@mui/material';
 import { Except } from 'type-fest';
 import { Feature } from '../Feature';
 import { IconButton, IconButtonProps } from '../IconButton';
@@ -24,11 +24,13 @@ export const ToggleCommentsButton = ({
 
   return (
     <Feature flag="comments" match={true}>
-      <IconButton onClick={() => toggleCommentsBar()} {...rest}>
-        <Badge badgeContent={total} color="primary">
-          <Comment />
-        </Badge>
-      </IconButton>
+      <Tooltip title={`${isCommentsBarOpen ? 'Hide' : 'Show'} Comments`}>
+        <IconButton onClick={() => toggleCommentsBar()} {...rest}>
+          <Badge badgeContent={total} color="primary">
+            <Comment />
+          </Badge>
+        </IconButton>
+      </Tooltip>
     </Feature>
   );
 };

--- a/src/components/Comments/ToggleCommentButton.tsx
+++ b/src/components/Comments/ToggleCommentButton.tsx
@@ -18,7 +18,7 @@ export const ToggleCommentsButton = ({
     variables: { id: resourceId! },
     skip: !resourceId,
   });
-  const total = data?.commentThreads.total ?? 0;
+  const total = data?.commentable.commentThreads.total ?? 0;
 
   return (
     <Feature flag="comments" match={true}>


### PR DESCRIPTION
- Badge color is now primary
- Badge count is thread count, not all comments
- Threads are sorted DESC
- Threads are only loaded if the sidebar is open
- Thread count for badge is loaded separately if needed
- Some other minor cache tweaks

I moved to loading from `Commentable` this opens open the room for something like
```gql
query {
  language(id: "") {
    commentThreads { total }
  }
}
```
To load the badge count (or more info) without a separate network request.
This is only a half baked idea, so nothing like that changed here.
In general, I think it makes more sense from DX because we view the comments under a resource and now this & cache reflect that.
Performance wise before and after are the same. We always loaded the `Commentable` first anyways in the API.