### PR TITLE
Progress Report Grid - Expansion tweaks

### DIFF
--- a/src/components/Comments/CommentsContext.tsx
+++ b/src/components/Comments/CommentsContext.tsx
@@ -1,4 +1,4 @@
-import { useLocalStorageState, useSet } from 'ahooks';
+import { useLocalStorageState } from 'ahooks';
 import { noop } from 'lodash';
 import {
   createContext,
@@ -9,16 +9,12 @@ import {
   useState,
 } from 'react';
 import { ChildrenProp } from '~/common';
-
-type ExpandedThreads = ReturnType<typeof useSet<string>>[1] & {
-  has: (threadId: string) => boolean;
-  toggle: (threadId: string, next?: boolean) => void;
-};
+import { SetHook, useSet } from '~/hooks';
 
 const initialCommentsBarContext = {
   toggleCommentsBar: noop as (state?: boolean) => void,
   isCommentsBarOpen: false,
-  expandedThreads: {} as unknown as ExpandedThreads,
+  expandedThreads: {} as unknown as SetHook<string>,
   resourceId: undefined as string | undefined,
   setResourceId: noop as (resourceId: string | undefined) => void,
 };
@@ -31,18 +27,7 @@ export const CommentsProvider = ({ children }: ChildrenProp) => {
 
   const [resourceId, setResourceId] = useState<string | undefined>(undefined);
 
-  const [currentExpandedThreads, setExpandedThreads] = useSet<string>();
-  const expandedThreads = useMemo(
-    (): ExpandedThreads => ({
-      ...setExpandedThreads,
-      has: currentExpandedThreads.has.bind(currentExpandedThreads),
-      toggle: (threadId: string, next?: boolean) => {
-        next = next ?? !currentExpandedThreads.has(threadId);
-        setExpandedThreads[next ? 'add' : 'remove'](threadId);
-      },
-    }),
-    [currentExpandedThreads, setExpandedThreads]
-  );
+  const expandedThreads = useSet<string>();
 
   const toggleCommentsBar = useCallback(
     (state?: boolean) => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useFirstMountState';
+export * from './useSet';
 export * from './useUserAgent';
 export * from './useQueryParams';
 export * from './useIsomorphicEffect';

--- a/src/hooks/useSet.ts
+++ b/src/hooks/useSet.ts
@@ -1,0 +1,96 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useLatest } from 'ahooks';
+import { useMemo, useState } from 'react';
+import { Merge } from 'type-fest';
+
+export type SetHook<T> = Merge<Set<T>, SetModifiers<T>>;
+export interface SetModifiers<T> {
+  /**
+   * Add item to the set.
+   * No change if the item already exists, which the return value conveys.
+   */
+  readonly add: (item: T) => boolean &
+    // Not really, just so this can be typed as Set<T>
+    Set<T>;
+  /**
+   * Alias of {@link delete}.
+   */
+  readonly remove: (item: T) => boolean;
+  /**
+   * Remove an item from the set.
+   * No change if the item already exists, which the return value conveys.
+   */
+  readonly delete: (item: T) => boolean;
+  /**
+   * Toggle adding/removing an item from the set.
+   * Optionally, explicitly state if the value should be added/removed with the `next` arg.
+   * No change if the item already exists, which the return value conveys.
+   */
+  readonly toggle: (item: T, next?: boolean) => boolean;
+  /**
+   * Replace the entries with the ones given here.
+   * This always produces an identity change, even if the entry values are the same.
+   */
+  readonly set: (items: Iterable<T>) => void;
+  /**
+   * Remove all the entries.
+   * No change if the set is already empty.
+   */
+  readonly clear: () => void;
+  /**
+   * Reset the entries to the ones given in the hook creation.
+   * This always produces an identity change, even if the entry values are the same.
+   */
+  readonly reset: () => void;
+}
+
+/**
+ * Provides a Set in React state.
+ *
+ * Each change produces a new Set.
+ * However, the modifier functions (their identities) don't change
+ * and will always reference the current entries when needed.
+ *
+ * We do differ with `add()` return value, though.
+ * It returns whether an entry was added instead of returning `this`.
+ */
+export function useSet<T>(initialValue?: Iterable<T>): SetHook<T> {
+  const getInitValue = useLatest(() => new Set<T>(initialValue));
+  const [current, set] = useState(getInitValue.current);
+  const ref = useLatest(current);
+
+  const modifiers = useMemo((): SetModifiers<T> => {
+    const toggle = (item: T, next?: boolean) => {
+      // Keeping this found check independent of the setter scope below.
+      // React handles when it should be called and it could be not synchronous.
+      const found = ref.current.has(item);
+
+      set((prev) => {
+        // Check again here, because maybe prev has changed, and we don't want
+        // to change identity redundantly.
+        const currentlyIn = prev.has(item);
+        next = next ?? !currentlyIn;
+        if ((next && currentlyIn) || (!next && !currentlyIn)) {
+          return prev;
+        }
+
+        const temp = new Set(prev);
+        temp[next ? 'add' : 'delete'](item);
+        return temp;
+      });
+
+      return found;
+    };
+    return {
+      toggle,
+      add: (item) => toggle(item, true) as any,
+      remove: (item) => toggle(item, false),
+      delete: (item) => toggle(item, false),
+      set: (items) => set(new Set(items)),
+      reset: () => set(getInitValue.current),
+      clear: () => set((prev) => (prev.size === 0 ? prev : new Set())),
+    };
+  }, []);
+
+  return useMemo(() => Object.assign(current, modifiers), [current]);
+}

--- a/src/scenes/Dashboard/ProgressReportsWidget/ExpansionCell.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ExpansionCell.tsx
@@ -1,23 +1,15 @@
 import { Box } from '@mui/material';
-import {
-  GridState,
-  GridRenderCellParams as RenderCellParams,
-  useGridSelector,
-} from '@mui/x-data-grid';
+import { GridRenderCellParams as RenderCellParams } from '@mui/x-data-grid';
 import { ChildrenProp, extendSx, StyleProps } from '~/common';
+import { useExpanded } from './expansionState';
 
 export const ExpansionCell = ({
   id,
-  api,
   sx,
   className,
   children,
 }: Pick<RenderCellParams, 'id' | 'api'> & StyleProps & ChildrenProp) => {
-  const selectedRows = useGridSelector(
-    { current: api },
-    (state: GridState) => state.rowSelection
-  );
-  const isExpanded = selectedRows.includes(id);
+  const isExpanded = useExpanded().has(id);
 
   return (
     <Box

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
@@ -3,12 +3,12 @@ import {
   DataGridProProps as DataGridProps,
   GridColDef,
   GridRenderCellParams,
-  GridRowId,
   GridToolbarColumnsButton,
   GridToolbarFilterButton,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { entries } from '@seedcompany/common';
+import { useMemo } from 'react';
 import { extendSx } from '~/common';
 import {
   getInitialVisibility,
@@ -18,11 +18,11 @@ import {
   Toolbar,
   useFilterToggle,
 } from '~/components/Grid';
-import { useSet } from '~/hooks';
 import {
   CollapseAllButton,
   ExpandAllButton,
   ExpansionContext,
+  useExpandedSetup,
 } from './expansionState';
 import {
   ExpansionMarker,
@@ -114,7 +114,16 @@ export const ProgressReportsExpandedGrid = (
 ) => {
   const apiRef = useGridApiRef();
 
-  const expanded = useSet<GridRowId>();
+  const { expanded, onMouseDown, onRowClick } = useExpandedSetup();
+
+  const slotProps = useMemo(
+    (): DataGridProps['slotProps'] => ({
+      row: {
+        onMouseDown,
+      },
+    }),
+    [onMouseDown]
+  );
 
   return (
     <ExpansionContext.Provider value={expanded}>
@@ -125,7 +134,8 @@ export const ProgressReportsExpandedGrid = (
         apiRef={apiRef}
         columns={columns}
         initialState={initialState}
-        onRowClick={({ id }) => expanded.toggle(id)}
+        slotProps={slotProps}
+        onRowClick={onRowClick}
         getRowHeight={(params) =>
           expanded.has(params.id) ? 'auto' : COLLAPSED_ROW_HEIGHT
         }

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
@@ -9,7 +9,6 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { entries } from '@seedcompany/common';
-import { useMemo } from 'react';
 import { extendSx } from '~/common';
 import {
   getInitialVisibility,
@@ -20,6 +19,7 @@ import {
   useFilterToggle,
 } from '~/components/Grid';
 import { useSet } from '~/hooks';
+import { ExpansionContext } from './expansionState';
 import {
   ExpansionMarker,
   ProgressReportsColumnMap,
@@ -108,30 +108,31 @@ export const ProgressReportsExpandedGrid = (
 ) => {
   const apiRef = useGridApiRef();
 
-  const selected = useSet<GridRowId>();
+  const expanded = useSet<GridRowId>();
 
   return (
-    <ProgressReportsGrid
-      {...props}
-      density="standard"
-      slots={slots}
-      apiRef={apiRef}
-      columns={columns}
-      initialState={initialState}
-      onRowClick={({ id }) => selected.toggle(id)}
-      rowSelectionModel={useMemo(() => [...selected], [selected])}
-      getRowHeight={(params) =>
-        apiRef.current.isRowSelected(params.id) ? 'auto' : COLLAPSED_ROW_HEIGHT
-      }
-      sx={[
-        {
-          // Don't want 'auto' to shrink below this when the cell is empty
-          '.MuiDataGrid-cell': {
-            minHeight: COLLAPSED_ROW_HEIGHT,
+    <ExpansionContext.Provider value={expanded}>
+      <ProgressReportsGrid
+        {...props}
+        density="standard"
+        slots={slots}
+        apiRef={apiRef}
+        columns={columns}
+        initialState={initialState}
+        onRowClick={({ id }) => expanded.toggle(id)}
+        getRowHeight={(params) =>
+          expanded.has(params.id) ? 'auto' : COLLAPSED_ROW_HEIGHT
+        }
+        sx={[
+          {
+            // Don't want 'auto' to shrink below this when the cell is empty
+            '.MuiDataGrid-cell': {
+              minHeight: COLLAPSED_ROW_HEIGHT,
+            },
           },
-        },
-        ...extendSx(props.sx),
-      ]}
-    />
+          ...extendSx(props.sx),
+        ]}
+      />
+    </ExpansionContext.Provider>
   );
 };

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
@@ -9,7 +9,7 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { entries } from '@seedcompany/common';
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { extendSx } from '~/common';
 import {
   getInitialVisibility,
@@ -19,6 +19,7 @@ import {
   Toolbar,
   useFilterToggle,
 } from '~/components/Grid';
+import { useSet } from '~/hooks';
 import {
   ExpansionMarker,
   ProgressReportsColumnMap,
@@ -107,7 +108,7 @@ export const ProgressReportsExpandedGrid = (
 ) => {
   const apiRef = useGridApiRef();
 
-  const [selected, setSelected] = useState<GridRowId[]>([]);
+  const selected = useSet<GridRowId>();
 
   return (
     <ProgressReportsGrid
@@ -117,8 +118,8 @@ export const ProgressReportsExpandedGrid = (
       apiRef={apiRef}
       columns={columns}
       initialState={initialState}
-      onRowClick={({ id }) => setSelected(selected.length > 0 ? [] : [id])}
-      rowSelectionModel={selected}
+      onRowClick={({ id }) => selected.toggle(id)}
+      rowSelectionModel={useMemo(() => [...selected], [selected])}
       getRowHeight={(params) =>
         apiRef.current.isRowSelected(params.id) ? 'auto' : COLLAPSED_ROW_HEIGHT
       }

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsExpandedGrid.tsx
@@ -19,7 +19,11 @@ import {
   useFilterToggle,
 } from '~/components/Grid';
 import { useSet } from '~/hooks';
-import { ExpansionContext } from './expansionState';
+import {
+  CollapseAllButton,
+  ExpandAllButton,
+  ExpansionContext,
+} from './expansionState';
 import {
   ExpansionMarker,
   ProgressReportsColumnMap,
@@ -96,6 +100,8 @@ const ProgressReportsToolbar = () => (
         Pinned
       </QuickFilterButton>
     </QuickFilters>
+    <CollapseAllButton />
+    <ExpandAllButton />
   </Toolbar>
 );
 

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsWidget.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsWidget.tsx
@@ -40,6 +40,7 @@ export const ProgressReportsWidget = ({
           disablePortal
           options={quarter.available}
           getOptionLabel={(q) => `Q${q.fiscalQuarter} FY${q.fiscalYear}`}
+          isOptionEqualToValue={(a, b) => +a === +b}
           value={quarter.current}
           onChange={(_, q) => quarter.set(q)}
           disableClearable

--- a/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
@@ -1,4 +1,9 @@
-import { GridRowId } from '@mui/x-data-grid-pro';
+import {
+  UnfoldLess as CollapseIcon,
+  UnfoldMore as ExpandIcon,
+} from '@mui/icons-material';
+import { IconButton, Tooltip } from '@mui/material';
+import { GridRowId, useGridApiContext } from '@mui/x-data-grid-pro';
 import { createContext, useContext } from 'react';
 import { SetHook } from '~/hooks';
 
@@ -7,3 +12,29 @@ export const ExpansionContext = createContext<SetHook<GridRowId>>(
 );
 
 export const useExpanded = () => useContext(ExpansionContext);
+
+export const CollapseAllButton = () => {
+  const expanded = useExpanded();
+  return (
+    <Tooltip title="Collapse All Rows">
+      <IconButton color="primary" size="small" onClick={expanded.clear}>
+        <CollapseIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export const ExpandAllButton = () => {
+  const apiRef = useGridApiContext();
+  const expanded = useExpanded();
+  const expandAll = () => {
+    expanded.set(apiRef.current.state.rows.dataRowIds);
+  };
+  return (
+    <Tooltip title="Expand All Rows">
+      <IconButton color="primary" size="small" onClick={expandAll}>
+        <ExpandIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
@@ -1,0 +1,9 @@
+import { GridRowId } from '@mui/x-data-grid-pro';
+import { createContext, useContext } from 'react';
+import { SetHook } from '~/hooks';
+
+export const ExpansionContext = createContext<SetHook<GridRowId>>(
+  new Set() as any
+);
+
+export const useExpanded = () => useContext(ExpansionContext);

--- a/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
@@ -54,29 +54,80 @@ export const ExpandAllButton = () => {
 // i.e. to select the text within.
 const MOVEMENT_THRESHOLD = 10;
 
+interface Position {
+  x: number;
+  y: number;
+}
+const isPosClose = (a: Position, b: Position) =>
+  Math.abs(a.x - b.x) < MOVEMENT_THRESHOLD &&
+  Math.abs(a.y - b.y) < MOVEMENT_THRESHOLD;
+const eventPos = (e: MouseEvent) => ({ x: e.clientX, y: e.clientY });
+
 export const useExpandedSetup = () => {
   const expanded = useSet<GridRowId>();
 
-  const lastDownPos = useRef({ x: 0, y: 0 });
+  const { current: lastDownPositions } = useRef(new Set<Position>());
+  const { current: collapseTimers } = useRef(new Map<GridRowId, number>());
+
   const onMouseDown = useCallback((e: MouseEvent) => {
-    lastDownPos.current = { x: e.clientX, y: e.clientY };
+    if (!(e.target instanceof HTMLElement)) {
+      return;
+    }
+    const id = e.target.closest('[role="row"]')?.getAttribute('data-id');
+    if (!id) {
+      return;
+    }
+    const pos = eventPos(e);
+
+    const hasPrev = [...lastDownPositions].some((prev) =>
+      isPosClose(prev, pos)
+    );
+    if (hasPrev) {
+      const prevTimer = collapseTimers.get(id);
+      if (prevTimer) {
+        // console.log('cancelling collapse', id);
+        clearTimeout(prevTimer);
+        collapseTimers.delete(id);
+      }
+    }
+    // console.log('marking down pos');
+    lastDownPositions.add(pos);
+    setTimeout(() => {
+      // console.log('removing down pos');
+      lastDownPositions.delete(pos);
+    }, 500);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onRowClick = useCallback<GridProps['onRowClick'] & {}>(
     ({ id }, event) => {
-      const now = { x: event.clientX, y: event.clientY };
-      const prev = lastDownPos.current;
-      if (
-        Math.abs(now.x - prev.x) > MOVEMENT_THRESHOLD ||
-        Math.abs(now.y - prev.y) > MOVEMENT_THRESHOLD
-      ) {
+      const now = eventPos(event);
+      const prev = [...lastDownPositions].at(-1);
+      if (!prev || !isPosClose(prev, now)) {
+        // console.log('up, but dragging');
         // This click (up) event appears to be a drag, not a click.
         return;
       }
-      expanded.toggle(id);
+      if (event.detail > 1) {
+        // console.log('double click', event.detail);
+        const timer = collapseTimers.get(id);
+        clearTimeout(timer);
+        collapseTimers.delete(id);
+        return;
+      }
+      // console.log('single click');
+      if (!expanded.has(id)) {
+        expanded.add(id);
+      } else if (!collapseTimers.has(id)) {
+        const timer = window.setTimeout(() => {
+          collapseTimers.delete(id);
+          expanded.remove(id);
+        }, 500);
+        collapseTimers.set(id, timer);
+      }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [expanded]
   );
 
   return { expanded, onMouseDown, onRowClick };

--- a/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/expansionState.tsx
@@ -3,9 +3,19 @@ import {
   UnfoldMore as ExpandIcon,
 } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';
-import { GridRowId, useGridApiContext } from '@mui/x-data-grid-pro';
-import { createContext, useContext } from 'react';
-import { SetHook } from '~/hooks';
+import {
+  DataGridProProps as GridProps,
+  GridRowId,
+  useGridApiContext,
+} from '@mui/x-data-grid-pro';
+import {
+  createContext,
+  MouseEvent,
+  useCallback,
+  useContext,
+  useRef,
+} from 'react';
+import { SetHook, useSet } from '~/hooks';
 
 export const ExpansionContext = createContext<SetHook<GridRowId>>(
   new Set() as any
@@ -37,4 +47,37 @@ export const ExpandAllButton = () => {
       </IconButton>
     </Tooltip>
   );
+};
+
+// if moving more than this many pixels, will consider the click event
+// to be movement rather than a click.
+// i.e. to select the text within.
+const MOVEMENT_THRESHOLD = 10;
+
+export const useExpandedSetup = () => {
+  const expanded = useSet<GridRowId>();
+
+  const lastDownPos = useRef({ x: 0, y: 0 });
+  const onMouseDown = useCallback((e: MouseEvent) => {
+    lastDownPos.current = { x: e.clientX, y: e.clientY };
+  }, []);
+
+  const onRowClick = useCallback<GridProps['onRowClick'] & {}>(
+    ({ id }, event) => {
+      const now = { x: event.clientX, y: event.clientY };
+      const prev = lastDownPos.current;
+      if (
+        Math.abs(now.x - prev.x) > MOVEMENT_THRESHOLD ||
+        Math.abs(now.y - prev.y) > MOVEMENT_THRESHOLD
+      ) {
+        // This click (up) event appears to be a drag, not a click.
+        return;
+      }
+      expanded.toggle(id);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return { expanded, onMouseDown, onRowClick };
 };


### PR DESCRIPTION
- Create our own `useSet` hook
- Split expansion state to be independent of grid selected state
- Allow multiple rows to be expanded
- Add expand/collapse all buttons
- Avoid toggling expansion when the user intends to drag instead of click
- Avoid collapsing on double click (need to delay collapse)
- Fix Quarter Select comparison of current value to available options
