### PR TITLE
Temp limit Progress Reports to only Active/Completed Projects

### DIFF
--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
@@ -191,6 +191,11 @@ export const ProgressReportsGrid = ({
             end: {
               beforeInclusive: quarter.endOf('quarter'),
             },
+            engagement: {
+              project: {
+                status: ['Active', 'Completed'],
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
Until the logic to delete/not-create "useless" reports is applied in the API, we will filter them out here.

[Monday](https://seed-company-squad.monday.com/boards/3451697530/pulses/7602128788?doc_id=7602140219)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering for progress reports to include only 'Active' or 'Completed' projects. 

- **Bug Fixes**
  - Improved data retrieval logic for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->