### PR TITLE
Hide Notice severity level

### DIFF
--- a/src/scenes/ProgressReports/PnpValidation/PnPExtractionProblems.tsx
+++ b/src/scenes/ProgressReports/PnpValidation/PnPExtractionProblems.tsx
@@ -24,8 +24,13 @@ export const PnPExtractionProblems = memo(function PnPExtractionProblems({
   result: Result;
   engagement: { id: string };
 }) {
+  // Temporarily filter out problems with "Notice" severity
+  const filteredProblems = result.problems.filter(
+    (problem) => problem.severity !== 'Notice'
+  );
+
   const bySheet = groupToMapBy(
-    result.problems.toSorted(
+    filteredProblems.toSorted(
       cmpBy((problem) => priority.indexOf(problem.severity))
     ),
     (p) => p.groups[0]!


### PR DESCRIPTION
Hiding problems with severity level of Notice temporarily per request from Sheri

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a filtering mechanism to display only relevant problems based on severity in the `PnPExtractionProblems` component.
	- Problems with a severity of "Notice" are now excluded from the displayed list.

- **Bug Fixes**
	- Enhanced problem grouping and rendering by ensuring only significant issues are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->