### PR TITLE
Avoid the final report in the current progress reports grid

### DIFF
--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
@@ -187,6 +187,10 @@ export const ProgressReportsGrid = ({
           filter: {
             start: {
               afterInclusive: quarter.startOf('quarter'),
+              // Avoid final reports for projects that end at the end of the quarter.
+              // Their start date is the end date.
+              // So this ensures there is at least one day in between.
+              before: quarter.startOf('quarter').plus({ day: 1 }),
             },
             end: {
               beforeInclusive: quarter.endOf('quarter'),


### PR DESCRIPTION
Avoid final reports for projects that end at the end of the quarter.
Their start date is also their the end date. When that's also the end of the quarter they are also matched here.
So this ensures there is at least one day in between.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved filtering logic for progress reports, ensuring final reports for projects ending at the quarter's close are excluded.

- **Bug Fixes**
	- Enhanced clarity in the filtering criteria for progress reports displayed in the grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->