### PR TITLE
Remove Growth Plan Card from Internship

### DIFF
--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagement.graphql
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagement.graphql
@@ -31,13 +31,6 @@ fragment InternshipEngagementDetail on InternshipEngagement {
     canRead
     canEdit
   }
-  growthPlan {
-    canRead
-    canEdit
-    value {
-      ...FileNodeInfo
-    }
-  }
   countryOfOrigin {
     canRead
     canEdit

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -9,11 +9,9 @@ import {
 } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { DataButton } from '../../../components/DataButton';
-import { DefinedFileCard } from '../../../components/DefinedFileCard';
 import { useDialog } from '../../../components/Dialog';
 import { EngagementBreadcrumb } from '../../../components/EngagementBreadcrumb';
 import { FieldOverviewCard } from '../../../components/FieldOverviewCard';
-import { FileActionsContextProvider } from '../../../components/files/FileActions';
 import {
   FormattedDate,
   FormattedDateRange,
@@ -33,7 +31,6 @@ import {
 } from '../EditEngagement/EditEngagementDialog';
 import { EngagementWorkflowDialog } from '../EditEngagement/EngagementWorkflowDialog';
 import { EngagementQuery } from '../Engagement.graphql';
-import { UploadInternshipEngagementGrowthPlanDocument } from '../Files';
 import { MentorCard } from './MentorCard';
 
 const useStyles = makeStyles()(({ spacing, breakpoints, palette }) => ({
@@ -207,21 +204,6 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                   <Grid item xs={6}>
                     <Typography variant="h4">Growth Plan</Typography>
                   </Grid>
-                </Grid>
-                <Grid item container spacing={3} alignItems="center">
-                  <FileActionsContextProvider>
-                    <Grid item xs={6}>
-                      <DefinedFileCard
-                        label="Growth Plan"
-                        parentId={engagement.id}
-                        uploadMutationDocument={
-                          UploadInternshipEngagementGrowthPlanDocument
-                        }
-                        resourceType="engagement"
-                        securedFile={engagement.growthPlan}
-                      />
-                    </Grid>
-                  </FileActionsContextProvider>
                 </Grid>
                 <Grid item xs={6}>
                   <MethodologiesCard


### PR DESCRIPTION
[Monday](https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/7828585765)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified the `InternshipEngagementDetail` component by removing the file upload functionality for the growth plan.
- **Bug Fixes**
	- Adjusted the layout to remove the grid item associated with the deleted file upload interface, ensuring a cleaner presentation of engagement details.
- **Data Structure Changes**
	- Removed the `growthPlan` field from the engagement details, streamlining the information displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->