### PR TITLE
Add PnP Extraction Result to Planning Sheet Card

### DIFF
--- a/src/scenes/Engagement/Files/UploadEngagementFiles.graphql
+++ b/src/scenes/Engagement/Files/UploadEngagementFiles.graphql
@@ -22,6 +22,9 @@ mutation UploadLanguageEngagementPnp(
       products {
         ...ProductList
       }
+      pnpExtractionResult {
+        ...pnpExtractionResult
+      }
     }
   }
 }

--- a/src/scenes/Engagement/LanguageEngagement/PlanningSpreadsheet/PlanningSpreadsheet.graphql
+++ b/src/scenes/Engagement/LanguageEngagement/PlanningSpreadsheet/PlanningSpreadsheet.graphql
@@ -7,4 +7,7 @@ fragment EngagementPlanningSpreadsheet on LanguageEngagement {
       ...FileNodeInfo
     }
   }
+  pnpExtractionResult {
+    ...pnpExtractionResult
+  }
 }

--- a/src/scenes/Engagement/LanguageEngagement/PlanningSpreadsheet/PlanningSpreadsheet.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/PlanningSpreadsheet/PlanningSpreadsheet.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import { Tooltip, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { entries } from '@seedcompany/common';
 import { pick } from 'lodash';
 import { makeStyles } from 'tss-react/mui';
@@ -20,6 +20,7 @@ import { HandleUploadCompletedFunction } from '../../../../components/files/hook
 import { EnumField, EnumOption } from '../../../../components/form';
 import { UploadLanguageEngagementPnpDocument as UploadPnp } from '../../Files';
 import { EngagementPlanningSpreadsheetFragment } from './PlanningSpreadsheet.graphql';
+import { PlanningSpreadsheetHeader } from './PlanningSpreadsheetHeader';
 
 const useStyles = makeStyles()(({ spacing, typography }) => ({
   section: {
@@ -45,21 +46,19 @@ export const PlanningSpreadsheet = ({ engagement, ...rest }: Props) => {
 
   return (
     <FileActionsContextProvider>
-      <Tooltip
-        title="This holds the planning info of PnP files"
-        placement="top"
-      >
-        <DefinedFileCard
-          {...rest}
-          label="Planning Spreadsheet"
-          uploadMutationDocument={UploadPnp}
-          parentId={engagement.id}
-          resourceType="engagement"
-          securedFile={engagement.pnp}
-          disableIcon
-          onUpload={setUploading}
-        />
-      </Tooltip>
+      {/* <Tooltip title="This holds the planning info of PnP files" placement="top"> */}
+      <DefinedFileCard
+        {...rest}
+        label="Planning Spreadsheet"
+        uploadMutationDocument={UploadPnp}
+        parentId={engagement.id}
+        resourceType="engagement"
+        securedFile={engagement.pnp}
+        disableIcon
+        disablePreview={true}
+        onUpload={setUploading}
+        header={<PlanningSpreadsheetHeader engagement={engagement} />}
+      />
       {upload && (
         <DialogForm<{ methodology?: Methodology }>
           {...dialogState}

--- a/src/scenes/Engagement/LanguageEngagement/PlanningSpreadsheet/PlanningSpreadsheetHeader.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/PlanningSpreadsheet/PlanningSpreadsheetHeader.tsx
@@ -1,0 +1,41 @@
+import { DialogContent, Stack, Typography } from '@mui/material';
+import { StyleProps } from '~/common';
+import { PreviewIconButton } from '~/components/files/FileActions/PreviewIconButton';
+import { PnPValidation } from '~/components/PnpValidation/PnpValidation';
+import { EngagementPlanningSpreadsheetFragment } from './PlanningSpreadsheet.graphql';
+
+interface PlanningSpreadsheetHeaderProps extends StyleProps {
+  engagement: EngagementPlanningSpreadsheetFragment;
+}
+
+export const PlanningSpreadsheetHeader = ({
+  engagement,
+}: PlanningSpreadsheetHeaderProps) => (
+  <Stack
+    sx={{
+      mt: -1,
+      flexDirection: 'row',
+      gap: 1,
+      alignItems: 'center',
+    }}
+  >
+    <Typography variant="h4">Planning Spreadsheet</Typography>
+    {engagement.pnp.value && (
+      <>
+        <PreviewIconButton file={engagement.pnp.value} />
+        {engagement.pnpExtractionResult && (
+          <PnPValidation
+            result={engagement.pnpExtractionResult}
+            slots={{
+              dialogContent: ({ children }) => (
+                <DialogContent dividers sx={{ p: 1 }}>
+                  {children}
+                </DialogContent>
+              ),
+            }}
+          />
+        )}
+      </>
+    )}
+  </Stack>
+);


### PR DESCRIPTION
[Monday](https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/7665475559?userId=37419707)

related: https://github.com/SeedCompany/cord-api-v3/pull/3334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `Preview` component for file previews, enhancing user interaction.
  - Added `pnpExtractionResult` field to provide detailed extraction data in the engagement planning spreadsheet.

- **Bug Fixes**
  - Removed the `Preview` component from the `ProgressReportCard`, streamlining the user interface.

- **Enhancements**
  - Updated `PlanningSpreadsheet` to improve the visual presentation and interaction with file cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->