### PR TITLE
Engagement Grid Cell Editing for Milestone and AI Assist columns

### DIFF
--- a/src/components/EngagementDataGrid/EngagementColumns.tsx
+++ b/src/components/EngagementDataGrid/EngagementColumns.tsx
@@ -1,5 +1,9 @@
-import { Link as LinkIcon } from '@mui/icons-material';
-import { IconButton, Tooltip } from '@mui/material';
+import {
+  Check as CheckIcon,
+  Close as CloseIcon,
+  Link as LinkIcon,
+} from '@mui/icons-material';
+import { IconButton, MenuItem, Select, Tooltip } from '@mui/material';
 import {
   DataGridProProps as DataGridProps,
   GridColDef,
@@ -102,7 +106,53 @@ export const EngagementColumns: Array<GridColDef<Engagement>> = [
       row.__typename === 'LanguageEngagement'
         ? row.milestoneReached.value
         : null,
+    valueSetter: (value, row) => {
+      if (row.__typename !== 'LanguageEngagement') {
+        return row;
+      }
+      return {
+        ...row,
+        milestoneReached: {
+          ...row.milestoneReached,
+          value,
+        },
+      };
+    },
     filterable: false,
+    editable: true,
+    renderEditCell: (params) => {
+      const { value, api, row } = params;
+      if (row.__typename !== 'LanguageEngagement') {
+        api.stopCellEditMode({ id: row.id, field: 'milestoneReached' });
+        return null;
+      }
+      return (
+        <Select
+          onChange={(param) => {
+            void api.setEditCellValue({
+              id: row.id,
+              field: 'milestoneReached',
+              value: param.target.value,
+            });
+          }}
+          onClose={() => {
+            api.stopCellEditMode({
+              id: row.id,
+              field: 'milestoneReached',
+            });
+          }}
+          value={value ?? null}
+          fullWidth
+          open
+        >
+          {LanguageMilestoneList.map((milestone) => (
+            <MenuItem key={milestone} value={milestone}>
+              {LanguageMilestoneLabels[milestone]}
+            </MenuItem>
+          ))}
+        </Select>
+      );
+    },
   },
   {
     headerName: 'AI Assist',
@@ -114,6 +164,59 @@ export const EngagementColumns: Array<GridColDef<Engagement>> = [
         ? row.usingAIAssistedTranslation.value
         : null,
     filterable: false,
+    editable: true,
+    valueSetter: (value, row) =>
+      row.__typename === 'LanguageEngagement'
+        ? {
+            ...row,
+            usingAIAssistedTranslation: {
+              ...row.usingAIAssistedTranslation,
+              value,
+            },
+          }
+        : row,
+    renderEditCell: ({ value, api, row }) => {
+      if (row.__typename !== 'LanguageEngagement') {
+        api.stopCellEditMode({
+          id: row.id,
+          field: 'usingAIAssistedTranslation',
+        });
+        return null;
+      }
+      return (
+        <Select
+          onChange={(param) =>
+            void api.setEditCellValue({
+              id: row.id,
+              field: 'usingAIAssistedTranslation',
+              value: param.target.value,
+            })
+          }
+          onClose={() =>
+            api.stopCellEditMode({
+              id: row.id,
+              field: 'usingAIAssistedTranslation',
+            })
+          }
+          SelectDisplayProps={{
+            style: {
+              padding: '4px 0 0 0',
+            },
+          }}
+          value={value ?? null}
+          fullWidth
+          open
+        >
+          <MenuItem value={null as any}>Unknown</MenuItem>
+          <MenuItem value={true as any}>
+            <CheckIcon color="success" />
+          </MenuItem>
+          <MenuItem value={false as any}>
+            <CloseIcon color="error" />
+          </MenuItem>
+        </Select>
+      );
+    },
   },
   {
     headerName: 'Type',

--- a/src/scenes/Projects/List/EngagementsPanel.tsx
+++ b/src/scenes/Projects/List/EngagementsPanel.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@apollo/client';
 import {
   DataGridPro as DataGrid,
   DataGridProProps as DataGridProps,
@@ -17,9 +18,14 @@ import {
   noHeaderFilterButtons,
   useDataGridSource,
 } from '~/components/Grid';
+import { UpdateLanguageEngagementDocument } from '../../Engagement/EditEngagement/EditEngagementDialog.graphql';
 import { EngagementListDocument } from './EngagementList.graphql';
 
 export const EngagementsPanel = () => {
+  const [updateLanguageEngagement] = useMutation(
+    UpdateLanguageEngagementDocument
+  );
+
   const [dataGridProps] = useDataGridSource({
     query: EngagementListDocument,
     variables: {},
@@ -52,6 +58,39 @@ export const EngagementsPanel = () => {
       initialState={EngagementInitialState}
       headerFilters
       hideFooter
+      processRowUpdate={async (updatedRow) => {
+        if (updatedRow.__typename === 'LanguageEngagement') {
+          const updatedEngagement = {
+            id: updatedRow.id,
+            milestoneReached: updatedRow.milestoneReached.value,
+            usingAIAssistedTranslation:
+              updatedRow.usingAIAssistedTranslation.value,
+          };
+          try {
+            await updateLanguageEngagement({
+              variables: { input: { engagement: updatedEngagement } },
+            });
+          } catch (error) {
+            const milestoneCellMode = dataGridProps.apiRef.current.getCellMode(
+              updatedRow.id,
+              'milestoneReached'
+            );
+            dataGridProps.apiRef.current.stopCellEditMode({
+              id: updatedRow.id,
+              field:
+                milestoneCellMode === 'edit'
+                  ? 'milestoneReached'
+                  : 'usingAIAssistedTranslation',
+            });
+            return updatedRow;
+          }
+        }
+
+        return updatedRow;
+      }}
+      onProcessRowUpdateError={(error) => {
+        return error;
+      }}
       sx={[flexLayout, noHeaderFilterButtons, noFooter]}
     />
   );


### PR DESCRIPTION
This is the first grid that we are introducing cell editing functionality.  The `Engagement` grid will now allow a user to edit value's directly in cell for `Milestone` and `AI Assist` columns.