### PR TITLE
Remove Quarterly Report skip button

### DIFF
--- a/src/scenes/ProgressReports/Detail/ProgressReportDetail.tsx
+++ b/src/scenes/ProgressReports/Detail/ProgressReportDetail.tsx
@@ -20,7 +20,6 @@ import { Error } from '../../../components/Error';
 import { ReportLabel } from '../../../components/PeriodicReports/ReportLabel';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { ButtonLink, FabLink, Navigate } from '../../../components/Routing';
-import { SkipReportButton } from '../../Projects/Reports/SkipReportButton';
 import { ProgressReportDrawer } from '../EditForm';
 import {
   ProgressReportDetailDocument,
@@ -118,9 +117,6 @@ export const ProgressReportDetail = () => {
                 <Edit />
               </FabLink>
             </Tooltip>
-          </Grid>
-          <Grid item>
-            <SkipReportButton report={report} />
           </Grid>
         </Grid>
 


### PR DESCRIPTION
Fpm's should no longer be able to skip a quarterly report and be forced to address each one.

https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/5119154284