### PR TITLE
Paratext Registry Id -> Paratext Id label

### DIFF
--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -153,7 +153,7 @@ const fieldMapping: Record<
     <CheckboxField {...props} label="Open to Investor Visitor" />
   ),
   paratextRegistryId: ({ props }) => (
-    <TextField {...props} label="Paratext Registry ID" />
+    <TextField {...props} label="Paratext ID" />
   ),
   usingAIAssistedTranslation: ({ props }) => (
     <EnumField

--- a/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
@@ -156,12 +156,11 @@ export const LanguageEngagementHeader = ({
           <DataButton
             onClick={() => show(['paratextRegistryId'])}
             secured={ptRegistryId}
-            redacted="You do not have permission to view Paratext Registry ID"
+            redacted="You do not have permission to view Paratext ID"
             children={
-              ptRegistryId.value &&
-              `Paratext Registry ID: ${ptRegistryId.value}`
+              ptRegistryId.value && `Paratext ID: ${ptRegistryId.value}`
             }
-            empty="Enter Paratext Registry ID"
+            empty="Enter Paratext ID"
           />
         </Grid>
         <Grid item>


### PR DESCRIPTION
Label change to correspond with the name of the actual ID we want to track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all user-visible labels and messages to use "Paratext ID" instead of "Paratext Registry ID" for enhanced clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->