### PR TITLE
Stop implicitly parsing ISO date strings

### DIFF
--- a/codegen.schema.yml
+++ b/codegen.schema.yml
@@ -42,12 +42,15 @@ generates:
       - add:
           placement: prepend
           content: |
-            import { DateTime } from 'luxon';
-            import { CalendarDate, RichTextJson, MarkdownString, InlineMarkdownString } from '~/common';
+            import { RichTextJson, MarkdownString, InlineMarkdownString } from '~/common';
     config:
       scalars:
-        Date: CalendarDate
-        DateTime: DateTime
+        Date:
+          input: ~/common#CalendarDateOrISO
+          output: ~/common#ISOString
+        DateTime:
+          input: ~/common#DateTimeOrISO
+          output: ~/common#ISOString
         JSONObject: Record<string, any>
         URL: string
         RichText: RichTextJson

--- a/src/api/schema/typePolicies/scalars/scalars.parser.ts
+++ b/src/api/schema/typePolicies/scalars/scalars.parser.ts
@@ -1,36 +1,10 @@
-import { DateTime } from 'luxon';
-import { CalendarDate } from '~/common';
 import { Scalars } from '../../schema.graphql';
 
 export const Parsers: {
   [K in keyof Scalars]?: (val: any) => Scalars[K]['output'];
-} = {
-  Date: (val) => {
-    if (DateTime.isDateTime(val)) {
-      warnOfCacheIrregularity();
-      return val;
-    }
-    return CalendarDate.fromISO(val);
-  },
-  DateTime: (val) => {
-    if (DateTime.isDateTime(val)) {
-      warnOfCacheIrregularity();
-      return val;
-    }
-    return DateTime.fromISO(val);
-  },
-};
+} = {};
 
 export const optional =
   <T, R>(parser?: (val: T) => R) =>
   (val: T | null | undefined): R | null =>
     val != null ? parser?.(val) ?? (val as unknown as R) : null;
-
-function warnOfCacheIrregularity() {
-  console.warn(
-    `Date value in cache was already transformed.
-The thought as of this writing is that this should be avoided to maintain a consistent cache state.
-This has happened because the value was written back to the cache directly. aka. writeQuery()/writeFragment()
-`
-  );
-}

--- a/src/common/CalenderDate.ts
+++ b/src/common/CalenderDate.ts
@@ -19,15 +19,11 @@ export type ISOString = Tagged<string, 'ISOString'>;
 export type CalendarDateOrISO = CalendarDate | ISOString;
 export type DateTimeOrISO = DateTime | ISOString;
 
-export const asDateTime = <T extends DateTimeOrISO | Nil>(
-  date: T
-): DateTime | (T extends Nil ? null : never) =>
-  asLuxonInstance(date, DateTime) as any;
+export const asDateTime = <T extends DateTimeOrISO | Nil>(date: T) =>
+  asLuxonInstance(date, DateTime) as T extends Nil ? null : DateTime;
 
-export const asDate = <T extends CalendarDateOrISO | Nil>(
-  date: T
-): CalendarDate | (T extends Nil ? null : never) =>
-  asLuxonInstance(date, CalendarDate) as any;
+export const asDate = <T extends CalendarDateOrISO | Nil>(date: T) =>
+  asLuxonInstance(date, CalendarDate) as T extends Nil ? null : CalendarDate;
 
 function asLuxonInstance(
   date: ISOString | DateTime | null | undefined,

--- a/src/common/CalenderDate.ts
+++ b/src/common/CalenderDate.ts
@@ -1,3 +1,4 @@
+import { Nil } from '@seedcompany/common';
 import {
   DateObjectUnits,
   DateTime,
@@ -11,6 +12,29 @@ import {
   ZoneOptions,
 } from 'luxon';
 import { DefaultValidity, Invalid, Valid } from 'luxon/src/_util';
+import { Tagged } from 'type-fest';
+
+export type ISOString = Tagged<string, 'ISOString'>;
+
+export type CalendarDateOrISO = CalendarDate | ISOString;
+export type DateTimeOrISO = DateTime | ISOString;
+
+export const asDateTime = <T extends DateTimeOrISO | Nil>(
+  date: T
+): DateTime | (T extends Nil ? null : never) =>
+  asLuxonInstance(date, DateTime) as any;
+
+export const asDate = <T extends CalendarDateOrISO | Nil>(
+  date: T
+): CalendarDate | (T extends Nil ? null : never) =>
+  asLuxonInstance(date, CalendarDate) as any;
+
+function asLuxonInstance(
+  date: ISOString | DateTime | null | undefined,
+  cls: typeof DateTime
+) {
+  return !date ? null : cls.isDateTime(date) ? date : cls.fromISO(date);
+}
 
 declare module 'luxon/src/datetime' {
   interface DateTime {

--- a/src/common/LuxonCalenderDateUtils.ts
+++ b/src/common/LuxonCalenderDateUtils.ts
@@ -14,6 +14,9 @@ export class LuxonCalenderDateUtils extends LuxonUtils {
   }
 
   date = (value?: any) => {
+    if (typeof value === 'string') {
+      return CalendarDate.fromISO(value);
+    }
     const d = this.inner.date(value);
     return d ? CalendarDate.fromDateTime(d) : null;
   };

--- a/src/components/EngagementDataGrid/EngagementColumns.tsx
+++ b/src/components/EngagementDataGrid/EngagementColumns.tsx
@@ -23,6 +23,7 @@ import {
 } from '~/api/schema.graphql';
 import {
   booleanColumn,
+  dateColumn,
   enumColumn,
   getInitialVisibility,
   QuickFilterButton,
@@ -181,15 +182,15 @@ export const EngagementColumns: Array<GridColDef<Engagement>> = [
   {
     headerName: 'MOU Start',
     field: 'startDate',
-    type: 'date',
-    valueGetter: (_, { startDate }) => startDate.value?.toJSDate(),
+    ...dateColumn(),
+    valueGetter: dateColumn.valueGetter((_, { startDate }) => startDate.value),
     filterable: false,
   },
   {
     headerName: 'MOU End',
     field: 'endDate',
-    type: 'date',
-    valueGetter: (_, { endDate }) => endDate.value?.toJSDate(),
+    ...dateColumn(),
+    valueGetter: dateColumn.valueGetter((_, { endDate }) => endDate.value),
     filterable: false,
   },
   {

--- a/src/components/FieldOverviewCard/FieldOverviewCard.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.tsx
@@ -10,9 +10,9 @@ import {
   Typography,
 } from '@mui/material';
 import { To } from 'history';
-import { DateTime } from 'luxon';
 import { ReactNode } from 'react';
 import { makeStyles } from 'tss-react/mui';
+import { DateTimeOrISO } from '~/common';
 import { FormattedDateTime } from '../Formatters';
 import { HugeIcon, HugeIconProps } from '../Icons';
 import { ButtonLink, CardActionAreaLink } from '../Routing';
@@ -50,7 +50,7 @@ const useStyles = makeStyles()(({ spacing, palette }) => ({
 
 interface FieldOverviewCardData {
   value?: ReactNode;
-  updatedAt?: DateTime;
+  updatedAt?: DateTimeOrISO;
   to?: To;
 }
 

--- a/src/components/Grid/ColumnTypes/dateColumn.tsx
+++ b/src/components/Grid/ColumnTypes/dateColumn.tsx
@@ -8,11 +8,11 @@ import {
 import { Nil } from '@seedcompany/common';
 import { DateTime } from 'luxon';
 import { DateFilter } from '~/api/schema.graphql';
-import { CalendarDate } from '~/common';
+import { CalendarDate, ISOString } from '~/common';
 import { GridHeaderAddFilterButton } from '../GridHeaderAddFilterButton';
 import { column, RowLike } from './definition.types';
 
-type DateInput = Date | CalendarDate | Nil;
+type DateInput = Date | CalendarDate | ISOString | Nil;
 type DateValue = Date | null;
 
 type DateColDef<R extends RowModel = any> = ColDef<R, DateValue, string>;

--- a/src/components/PeriodicReports/OverviewCard/ReportInfo.tsx
+++ b/src/components/PeriodicReports/OverviewCard/ReportInfo.tsx
@@ -3,7 +3,7 @@ import { Box, Grid, Skeleton, Typography } from '@mui/material';
 import { omit } from 'lodash';
 import { DateTime } from 'luxon';
 import { ReactNode } from 'react';
-import { CalendarDate, StyleProps } from '~/common';
+import { asDate, CalendarDateOrISO, StyleProps } from '~/common';
 import { FormattedDate, FormattedDateTime } from '../../Formatters';
 import { PaperTooltip } from '../../PaperTooltip';
 import { Redacted } from '../../Redacted';
@@ -86,13 +86,13 @@ export const SkippedText = () => (
   </Grid>
 );
 
-export const Due = ({ date }: { date: CalendarDate }) => (
+export const Due = ({ date }: { date: CalendarDateOrISO }) => (
   <>
     Due{' '}
     <FormattedDate
       date={date}
       displayOptions={
-        date.diffNow('years').years < 1 // same year
+        asDate(date).diffNow('years').years < 1 // same year
           ? DATE_SHORT_NO_YEAR
           : undefined
       }

--- a/src/components/PeriodicReports/ReportLabel.tsx
+++ b/src/components/PeriodicReports/ReportLabel.tsx
@@ -1,4 +1,4 @@
-import { isSecured, Nullable, SecuredProp } from '~/common';
+import { asDate, isSecured, Nullable, SecuredProp } from '~/common';
 import { Redacted } from '../Redacted';
 import { PeriodicReportFragment } from './PeriodicReport.graphql';
 
@@ -26,7 +26,8 @@ export const ReportLabel = ({
 };
 
 export const getReportLabel = (report?: Report) => {
-  const { start, end } = report ?? {};
+  const start = asDate(report?.start);
+  const end = asDate(report?.end);
 
   if (!start || !end) return null;
   return +start === +end

--- a/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
+++ b/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
@@ -3,7 +3,7 @@ import { Edit } from '@mui/icons-material';
 import { useSnackbar } from 'notistack';
 import { getErrorInfo, isErrorCode } from '~/api';
 import { ProductStepLabels } from '~/api/schema.graphql';
-import { CalendarDate } from '~/common';
+import { CalendarDateOrISO } from '~/common';
 import { useUploadFiles } from '../../files/hooks';
 import { IconButton } from '../../IconButton';
 import { Link, useNavigate } from '../../Routing';
@@ -21,7 +21,7 @@ export const useUpdatePeriodicReport = () => {
   return async (
     id: string,
     files?: File[],
-    receivedDate?: CalendarDate | null,
+    receivedDate?: CalendarDateOrISO | null,
     skippedReason?: string | null
   ) => {
     const updateReport = async (uploadId?: string, name?: string) => {

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -12,10 +12,11 @@ import {
 } from '@mui/x-date-pickers/internals';
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import { MuiPickersAdapterContextValue } from '@mui/x-date-pickers/LocalizationProvider/LocalizationProvider';
+import { Nil } from '@seedcompany/common';
 import { DateTime } from 'luxon';
 import { useContext, useRef } from 'react';
 import { Except } from 'type-fest';
-import { CalendarDate, Nullable } from '~/common';
+import { CalendarDate, CalendarDateOrISO, Nullable } from '~/common';
 import { AllowFormCloseContext } from './AllowClose';
 import { FieldConfig, useField } from './useField';
 import { getHelperText, showError } from './util';
@@ -26,7 +27,7 @@ export type DateFieldProps = Except<
   'defaultValue' | 'initialValue' | 'validate'
 > &
   Except<
-    DatePickerProps<string | CalendarDate | null, CalendarDate>,
+    DatePickerProps<CalendarDateOrISO | null, CalendarDate>,
     'value' | 'onChange' | 'renderInput'
   > &
   Pick<
@@ -34,8 +35,8 @@ export type DateFieldProps = Except<
     'label' | 'disabled' | 'helperText' | 'placeholder' | 'fullWidth'
   > & {
     name: string;
-    defaultValue?: string | CalendarDate | null;
-    initialValue?: string | CalendarDate | null;
+    defaultValue?: CalendarDateOrISO | null;
+    initialValue?: CalendarDateOrISO | null;
     errorMessages?: Record<DateError, string>;
     // Disable replacing helper text with format while text input is focused
     disableFormatHelperText?: boolean;
@@ -197,16 +198,16 @@ const defaultMessages: Record<DateError, string> = {
   shouldDisableDate: 'Date is unavailable',
 };
 
-type DateInput = string | CalendarDate | null | undefined;
+type DateInput = CalendarDateOrISO | Nil;
 
 const uninitialized = Symbol('uninitialized');
 
 /**
  * Memoizes date objects to prevent re-renders & parses ISO strings
  */
-const useDate = (valIn: DateInput): CalendarDate | null | undefined => {
+const useDate = (valIn: DateInput): CalendarDate | Nil => {
   const curr = useRef(valIn);
-  const parsed = useRef<CalendarDate | null | undefined | typeof uninitialized>(
+  const parsed = useRef<CalendarDate | Nil | typeof uninitialized>(
     uninitialized
   );
   if (parsed.current !== uninitialized && isDateEqual(curr.current, valIn)) {

--- a/src/components/form/SavingStatus.tsx
+++ b/src/components/form/SavingStatus.tsx
@@ -1,6 +1,5 @@
-import { DateTime } from 'luxon';
 import { ReactElement } from 'react';
-import { Nullable } from '../../common';
+import { DateTimeOrISO, Nullable } from '~/common';
 import { RelativeDateTime } from '../Formatters';
 
 export const SavingStatus = ({
@@ -8,7 +7,7 @@ export const SavingStatus = ({
   savedAt,
 }: {
   submitting: boolean;
-  savedAt?: Nullable<DateTime>;
+  savedAt?: Nullable<DateTimeOrISO>;
 }): ReactElement | null =>
   submitting ? (
     <>Saving...</>

--- a/src/scenes/Engagement/CeremonyCard/LargeDate.tsx
+++ b/src/scenes/Engagement/CeremonyCard/LargeDate.tsx
@@ -1,7 +1,12 @@
 import { Skeleton, Typography } from '@mui/material';
 import { useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
-import { CalendarDate, Nullable, SecuredProp } from '~/common';
+import {
+  CalendarDate,
+  CalendarDateOrISO,
+  Nullable,
+  SecuredProp,
+} from '~/common';
 import { FormattedDate } from '../../../components/Formatters';
 import { Redacted } from '../../../components/Redacted';
 
@@ -32,7 +37,7 @@ const useStyles = makeStyles()(({ palette, spacing }) => ({
 }));
 
 interface LargeDateProps {
-  date?: Nullable<SecuredProp<CalendarDate>>;
+  date?: Nullable<SecuredProp<CalendarDateOrISO>>;
   className?: string;
 }
 

--- a/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
+++ b/src/scenes/Engagement/EditEngagement/EditEngagementDialog.tsx
@@ -15,6 +15,7 @@ import {
   UpdateLanguageEngagement,
 } from '~/api/schema.graphql';
 import {
+  asDate,
   DisplayLocationFragment,
   ExtractStrict,
   labelFrom,
@@ -265,8 +266,8 @@ export const EditEngagementDialog = ({
       {...props}
       initialValues={initialValues}
       validate={(values) => {
-        const start = values.engagement.startDateOverride;
-        const end = values.engagement.endDateOverride;
+        const start = asDate(values.engagement.startDateOverride);
+        const end = asDate(values.engagement.endDateOverride);
 
         if (start && end) {
           if (start > end) {
@@ -283,7 +284,7 @@ export const EditEngagementDialog = ({
         if (
           start &&
           engagement.dateRange.value.end &&
-          start > engagement.dateRange.value.end
+          start > asDate(engagement.dateRange.value.end)
         ) {
           return {
             engagement: {
@@ -295,7 +296,7 @@ export const EditEngagementDialog = ({
         if (
           end &&
           engagement.dateRange.value.start &&
-          end < engagement.dateRange.value.start
+          end < asDate(engagement.dateRange.value.start)
         ) {
           return {
             engagement: {

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
 import { PartialDeep } from 'type-fest';
 import { removeItemFromList } from '~/api';
-import { canEditAny, listOrPlaceholders } from '~/common';
+import { asDate, canEditAny, listOrPlaceholders } from '~/common';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
 import { BooleanProperty } from '../../../components/BooleanProperty';
 import { useComments } from '../../../components/Comments/CommentsContext';
@@ -216,7 +216,7 @@ export const LanguageDetail = () => {
           />
           <DisplayProperty
             label="Sponsor Estimated End Fiscal Year"
-            value={sponsorEstimatedEndDate?.value?.fiscalYear}
+            value={asDate(sponsorEstimatedEndDate?.value)?.fiscalYear}
             loading={!language}
           />
 

--- a/src/scenes/Languages/Edit/EditLanguage.tsx
+++ b/src/scenes/Languages/Edit/EditLanguage.tsx
@@ -4,7 +4,7 @@ import { pick as lodashPick } from 'lodash';
 import { useMemo } from 'react';
 import { Except, PartialDeep, Paths, PickDeep } from 'type-fest';
 import { UpdateLanguage } from '~/api/schema.graphql';
-import { CalendarDate } from '~/common';
+import { asDate, CalendarDate } from '~/common';
 import {
   LanguageForm,
   LanguageFormProps,
@@ -50,8 +50,9 @@ export const EditLanguage = (props: EditLanguageProps) => {
               isSignLanguage: language.isSignLanguage.value,
               signLanguageCode: language.signLanguageCode.value,
               sensitivity: language.sensitivity,
-              sponsorEstimatedEndFY:
-                language.sponsorEstimatedEndDate.value?.fiscalYear,
+              sponsorEstimatedEndFY: asDate(
+                language.sponsorEstimatedEndDate.value
+              )?.fiscalYear,
               hasExternalFirstScripture:
                 language.hasExternalFirstScripture.value,
             },

--- a/src/scenes/Partnerships/Edit/EditPartnership.tsx
+++ b/src/scenes/Partnerships/Edit/EditPartnership.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { Except } from 'type-fest';
 import { onUpdateInvalidateProps, removeItemFromList } from '~/api';
 import { PeriodType, UpdatePartnershipInput } from '~/api/schema.graphql';
-import { callAll } from '~/common';
+import { asDate, callAll } from '~/common';
 import { SubmitAction, SubmitButton } from '../../../components/form';
 import { PartnerLookupItem } from '../../../components/form/Lookup';
 import { invalidateBudgetRecords } from '../InvalidateBudget';
@@ -119,8 +119,8 @@ export const EditPartnership = (props: EditPartnershipProps) => {
       {...props}
       sendIfClean="delete" // Lets us delete without changing any fields
       validate={(values) => {
-        const start = values.partnership.mouStartOverride;
-        const end = values.partnership.mouEndOverride;
+        const start = asDate(values.partnership.mouStartOverride);
+        const end = asDate(values.partnership.mouEndOverride);
 
         if (start && end) {
           if (start > end) {
@@ -137,7 +137,7 @@ export const EditPartnership = (props: EditPartnershipProps) => {
         if (
           start &&
           partnership.mouRange.value.end &&
-          start > partnership.mouRange.value.end
+          start > asDate(partnership.mouRange.value.end)
         ) {
           return {
             partnership: {
@@ -149,7 +149,7 @@ export const EditPartnership = (props: EditPartnershipProps) => {
         if (
           end &&
           partnership.mouRange.value.start &&
-          end < partnership.mouRange.value.start
+          end < asDate(partnership.mouRange.value.start)
         ) {
           return {
             partnership: {

--- a/src/scenes/ProgressReports/EditForm/ReportDue.tsx
+++ b/src/scenes/ProgressReports/EditForm/ReportDue.tsx
@@ -1,11 +1,12 @@
 import { Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { DateTime } from 'luxon';
-import { CalendarDate } from '~/common';
+import { asDate, CalendarDateOrISO } from '~/common';
 
-export const ReportDue = ({ date }: { date: CalendarDate }) => {
+export const ReportDue = ({ date: input }: { date: CalendarDateOrISO }) => {
   const theme = useTheme();
 
+  const date = asDate(input);
   const past = date <= DateTime.now();
 
   return (

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -362,9 +362,7 @@ export const ProjectOverview = () => {
               <ChangesetPropertyBadge
                 current={project}
                 prop="mouRange"
-                identifyBy={(range) =>
-                  `${range.start?.toMillis()}/${range.end?.toMillis()}`
-                }
+                identifyBy={(range) => `${range.start}/${range.end}`}
                 labelBy={({ start, end }) => (
                   <FormattedDateRange start={start} end={end} />
                 )}

--- a/src/scenes/Projects/Update/UpdateProjectDialog.tsx
+++ b/src/scenes/Projects/Update/UpdateProjectDialog.tsx
@@ -8,6 +8,7 @@ import { Except, Merge } from 'type-fest';
 import { invalidateProps } from '~/api';
 import { SensitivityList, UpdateProject } from '~/api/schema.graphql';
 import {
+  asDate,
   CalendarDate,
   DisplayFieldRegionFragment,
   DisplayLocationFragment,
@@ -170,7 +171,7 @@ export const UpdateProjectDialog = ({
         const start = values.project.mouStart;
         const end = values.project.mouEnd;
 
-        if (start && end && start > end) {
+        if (start && end && asDate(start) > asDate(end)) {
           return {
             project: {
               mouStart: 'Start date should come before end date',


### PR DESCRIPTION
Now do it explicitly when/where needed.

It is too hard to get right currently.
The outstanding apollo client issue doesn't have any appearance of resolving this read issue.

This change better reflects reality, as we're no longer assuming luxon instances when the values are actually ISO strings.

Though I did cheat a little bit and say that they could be either an ISO string or a luxon instance, which isn't really true. But it seemed easiest to go with this for now, and then narrow to luxon instance explicitly with a function call.