### PR TITLE
Fix error while creating resource with datagrid interaction

### DIFF
--- a/src/components/ProjectDataGrid/ProjectColumns.tsx
+++ b/src/components/ProjectDataGrid/ProjectColumns.tsx
@@ -67,7 +67,7 @@ export const ProjectColumns: Array<GridColDef<Project>> = [
     width: 160,
   },
   {
-    field: 'engagements',
+    field: 'engagements.total',
     type: 'number',
     valueGetter: (_, { engagements }) => engagements.total,
     filterable: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4065,8 +4065,8 @@ __metadata:
   linkType: hard
 
 "@seedcompany/common@npm:>=0.14 <1":
-  version: 0.18.1
-  resolution: "@seedcompany/common@npm:0.18.1"
+  version: 0.19.2
+  resolution: "@seedcompany/common@npm:0.19.2"
   dependencies:
     type-fest: "npm:^4.37.0"
   peerDependencies:
@@ -4074,7 +4074,7 @@ __metadata:
   peerDependenciesMeta:
     luxon:
       optional: true
-  checksum: 10c0/54f1cdd5cf5b818ee6a8f1a3ca4e8379e26c2011abe132105cb117f3c207e47e316b8e3dab21e8eec682b56a7a08a20d60b6512b1ab35591a9e708a6703ea472
+  checksum: 10c0/a66e92ba97d3912b7bf77d7f131d3ae1c07d167d19eff8553e60985663faa7ac46fa681e4b4f73587e04277e63ab96239b95789ed4e5a35452f3d7afdb1d6bf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Situation:
1. Look at project list & sort by the engagements (count) column
2. Create a project
3. We call `addItemToList`. This adds the new project to all cached lists.
4. One of the cached lists is the sorted by `engagements` as used in (1).
5. We try to sort that list using `Project.engagements` which is a `SecuredEngagementList` object.
6. `sortBy` fails - cycling on that object, which is not a "sortable value", giving a "max call stack exceeded" error to the UI.

25acf405ebeec34ff2d948acb2e26a87798a7dfb / https://github.com/SeedCompany/libs/commit/17ffe889405a210cb34be0c9cb894119aff1a00e fixes the cycling problem. Now if we encounter objects while sorting the list probably just remains unsorted (sorting by `"[object Object]"`).

This also fixes this specific case of adding a project while sorting projects by engagement count by changing the `field` to `"engagements.total"`.
SeedCompany/cord-api-v3#3417 supports this, and this now matches the "path" that our GQL objects have.

1a600b1bbf1a299b924b86a5e02d492ec4866c48 updates `addItemToList` to traverse these nested props and unwrapped secured objects where needed. So `engagements.total` works to get the engagement total as the API declares.
This is generic though, and another case could be: `engagements.language.name`. which actually traverses as `engagements.items.language.value.name.value`.
