### PR TITLE
Fix potential bug in project visibility for languages

### DIFF
--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -301,14 +301,14 @@ export const LanguageDetail = () => {
                   className={classes.listItem}
                 />
               ))}
-              {projects?.items.length === 0 ? (
-                <Typography color="textSecondary">
-                  This language is not engaged in any projects
-                </Typography>
-              ) : projects?.canRead === false ? (
+              {projects?.canRead === false ? (
                 <Typography color="textSecondary">
                   You don't have permission to see the projects this language is
                   engaged in
+                </Typography>
+              ) : projects?.items.length === 0 ? (
+                <Typography color="textSecondary">
+                  This language is not engaged in any projects
                 </Typography>
               ) : null}
             </Grid>


### PR DESCRIPTION
Add a check for `canRead` before determining if projects are empty. This change prevents misleading messages about project engagement when the user lacks permission to view the projects. Fixes #1018