### PR TITLE
Clarify First Scripture description in the UI

### DIFF
--- a/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
+++ b/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
@@ -88,7 +88,7 @@ export const FirstScripture = ({ data }: { data?: FirstScriptureFragment }) => {
           to={`/engagements/${scripture.engagement.id}`}
           underline={!project.name.canRead ? undefined : 'none'}
         >
-          {!project.name.canRead ? (
+          {project.name.canRead ? (
             project.name.value
           ) : (
             <Redacted info="You cannot view the project's name" width={200} />

--- a/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
+++ b/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
@@ -86,7 +86,7 @@ export const FirstScripture = ({ data }: { data?: FirstScriptureFragment }) => {
         First Scripture was recorded in the&nbsp;
         <Link
           to={`/engagements/${scripture.engagement.id}`}
-          underline={!project.name.canRead ? undefined : 'none'}
+          underline={project.name.canRead ? undefined : 'none'}
         >
           {project.name.canRead ? (
             project.name.value

--- a/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
+++ b/src/scenes/Languages/Detail/FirstScripture/FirstScripture.tsx
@@ -78,21 +78,23 @@ export const FirstScripture = ({ data }: { data?: FirstScriptureFragment }) => {
   }
 
   const project = scripture.engagement.project;
+
   return (
     <div className={classes.root}>
       <Check color="primary" className={classes.icon} />
       <Typography className={classes.text}>
-        First Scripture:&nbsp;&nbsp;
+        First Scripture was recorded in the&nbsp;
         <Link
           to={`/engagements/${scripture.engagement.id}`}
-          underline={project.name.canRead ? undefined : 'none'}
+          underline={!project.name.canRead ? undefined : 'none'}
         >
-          {project.name.canRead ? (
+          {!project.name.canRead ? (
             project.name.value
           ) : (
             <Redacted info="You cannot view the project's name" width={200} />
           )}
         </Link>
+        &nbsp;Project
       </Typography>
     </div>
   );


### PR DESCRIPTION
Update the UI text to make it clear that First Scripture was recored in the context of the listed/linked project.