### PR TITLE
Add Projects & Partners Grids to Users page

### DIFF
--- a/src/api/schema/typePolicies/typePolicies.base.ts
+++ b/src/api/schema/typePolicies/typePolicies.base.ts
@@ -90,6 +90,7 @@ export const typePolicies: TypePolicies = {
   User: {
     fields: {
       projects: {}, // no page merging (infinite scroll)
+      partners: {}, // no page merging (infinite scroll)
     },
   },
   Query: {

--- a/src/api/schema/typePolicies/typePolicies.base.ts
+++ b/src/api/schema/typePolicies/typePolicies.base.ts
@@ -87,6 +87,11 @@ export const typePolicies: TypePolicies = {
       engagements: {},
     },
   },
+  User: {
+    fields: {
+      projects: {}, // no page merging (infinite scroll)
+    },
+  },
   Query: {
     fields: {
       projects: {},

--- a/src/common/fragments/user.graphql
+++ b/src/common/fragments/user.graphql
@@ -39,6 +39,7 @@ fragment DisplayUser on User {
     value
   }
   partners {
+    canCreate
     items {
       id
       ...PartnerListItem

--- a/src/components/Grid/createAddItemFooter.tsx
+++ b/src/components/Grid/createAddItemFooter.tsx
@@ -18,7 +18,7 @@ export interface AddItemFooterOptions {
  *   () => ({
  *     footer: createAddItemFooter({
  *       addItem: handleAdd,
- *       label: 'Add Location',
+ *       label: 'Add Partner',
  *     }),
  *   }),
  *   [handleAdd]

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -15,3 +15,4 @@ export * from './ColumnTypes/dateColumn';
 export * from './isCellEditable';
 export * from './useGridMutation';
 export * from './createAddItemFooter';
+export * from './useDataGridSlots';

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -16,3 +16,4 @@ export * from './isCellEditable';
 export * from './useGridMutation';
 export * from './createAddItemFooter';
 export * from './useDataGridSlots';
+export * from './createAddItemFooter';

--- a/src/components/Grid/useDataGridSlots.ts
+++ b/src/components/Grid/useDataGridSlots.ts
@@ -1,0 +1,35 @@
+import { DataGridProProps as DataGridProps } from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { DefaultDataGridStyles } from './DefaultDataGridStyles';
+
+export const useDataGridSlots = (
+  dataGridProps: Pick<DataGridProps, 'slots' | 'slotProps'>,
+  overrides?: Pick<DataGridProps, 'slots' | 'slotProps'>
+) => {
+  const slots = useMemo(
+    () =>
+      merge(
+        {},
+        DefaultDataGridStyles.slots,
+        dataGridProps.slots,
+        overrides?.slots
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dataGridProps.slots, overrides?.slots]
+  );
+
+  const slotProps = useMemo(
+    () =>
+      merge(
+        {},
+        DefaultDataGridStyles.slotProps,
+        dataGridProps.slotProps,
+        overrides?.slotProps
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dataGridProps.slotProps, overrides?.slotProps]
+  );
+
+  return { slots, slotProps };
+};

--- a/src/components/ProjectDataGrid/ProjectColumns.tsx
+++ b/src/components/ProjectDataGrid/ProjectColumns.tsx
@@ -12,6 +12,7 @@ import {
   ProjectTypeLabels,
   ProjectTypeList,
 } from '~/api/schema.graphql';
+import { unmatchedIndexThrow } from '~/common';
 import {
   booleanColumn,
   dateColumn,
@@ -114,6 +115,18 @@ export const ProjectInitialState = {
     },
   },
 } satisfies DataGridProps['initialState'];
+
+export const ProjectNameField = 'name' as const;
+
+export const insertProjectColumnAfterField = <T extends Project>(
+  columns: Array<GridColDef<T>>,
+  field: string,
+  column: GridColDef<T>
+): Array<GridColDef<T>> => {
+  const index =
+    unmatchedIndexThrow(columns.findIndex((c) => c.field === field)) + 1;
+  return columns.toSpliced(index, 0, column);
+};
 
 export const ProjectToolbar = () => (
   <Toolbar sx={{ justifyContent: 'flex-start', gap: 2 }}>

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
@@ -1,11 +1,9 @@
 import { Box, Stack, Typography } from '@mui/material';
 import {
   DataGridPro,
-  DataGridProProps as DataGridProps,
   GridColDef,
   GridRenderCellParams as RenderCellParams,
 } from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
 import { useMemo } from 'react';
 import { SetOptional } from 'type-fest';
 import {
@@ -21,6 +19,7 @@ import {
   DefaultDataGridStyles,
   enumColumn,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import { LanguageNameColumn } from '../../../components/Grid/Columns/LanguageNameColumn';
@@ -185,22 +184,10 @@ export const ProgressReportsGrid = ({
     apiRef: props.apiRef,
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, props.slots),
-    [dataGridProps.slots, props.slots]
-  );
-
-  const slotProps = useMemo(
-    () =>
-      merge(
-        {},
-        DefaultDataGridStyles.slotProps,
-        dataGridProps.slotProps,
-        props.slotProps
-      ),
-    [dataGridProps.slotProps, props.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: props.slots,
+    slotProps: props.slotProps,
+  });
 
   return (
     <DataGridPro

--- a/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
+++ b/src/scenes/Dashboard/ProgressReportsWidget/ProgressReportsGrid.tsx
@@ -1,6 +1,7 @@
 import { Box, Stack, Typography } from '@mui/material';
 import {
   DataGridPro,
+  DataGridProProps as DataGridProps,
   GridColDef,
   GridRenderCellParams as RenderCellParams,
 } from '@mui/x-data-grid-pro';

--- a/src/scenes/Languages/List/LanguageGrid.tsx
+++ b/src/scenes/Languages/List/LanguageGrid.tsx
@@ -1,14 +1,10 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
@@ -29,18 +25,9 @@ export const LanguageGrid = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: LanguageToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: LanguageToolbar },
+  });
 
   return (
     <DataGrid<Language>

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -1,9 +1,4 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
 import {
   EngagementDataGridRowFragment as Engagement,
@@ -17,6 +12,7 @@ import {
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import { TabPanelContent } from '~/components/Tabs';
@@ -34,17 +30,9 @@ export const PartnerDetailEngagements = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, props.slots, {
-        toolbar: EngagementToolbar,
-      } satisfies DataGridProps['slots']),
-    [props.slots]
-  );
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
-    [props.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(props, {
+    slots: { toolbar: EngagementToolbar },
+  });
 
   const processEngagementUpdate = useProcessEngagementUpdate();
 

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -1,10 +1,4 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-  GridColDef,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
 import { PartnerTypeLabels, PartnerTypeList } from '~/api/schema.graphql';
 import { unmatchedIndexThrow } from '~/common';
@@ -14,6 +8,7 @@ import {
   multiEnumColumn,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
@@ -40,17 +35,9 @@ export const PartnerDetailProjects = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, props.slots, {
-        toolbar: ProjectToolbar,
-      } satisfies DataGridProps['slots']),
-    [props.slots]
-  );
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
-    [props.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(props, {
+    slots: { toolbar: ProjectToolbar },
+  });
 
   return (
     <TabPanelContent>

--- a/src/scenes/Partners/List/PartnerGrid.tsx
+++ b/src/scenes/Partners/List/PartnerGrid.tsx
@@ -1,14 +1,10 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
@@ -30,18 +26,9 @@ export const PartnerGrid = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: PartnerToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: PartnerToolbar },
+  });
 
   const processPartnerUpdate = useProcessPartnerUpdate();
 

--- a/src/scenes/Projects/List/EngagementsPanel.tsx
+++ b/src/scenes/Projects/List/EngagementsPanel.tsx
@@ -1,9 +1,4 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import {
   EngagementDataGridRowFragment as Engagement,
   EngagementColumns,
@@ -16,6 +11,7 @@ import {
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import { EngagementListDocument } from './EngagementList.graphql';
@@ -30,18 +26,9 @@ export const EngagementsPanel = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: EngagementToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: EngagementToolbar },
+  });
 
   const processEngagementUpdate = useProcessEngagementUpdate();
 

--- a/src/scenes/Projects/List/ProjectsPanel.tsx
+++ b/src/scenes/Projects/List/ProjectsPanel.tsx
@@ -1,14 +1,10 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
@@ -29,18 +25,9 @@ export const ProjectsPanel = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: ProjectToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: ProjectToolbar },
+  });
 
   return (
     <DataGrid<Project>

--- a/src/scenes/Users/Detail/Tabs/Partners/AddOrganizationToUserForm.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/AddOrganizationToUserForm.tsx
@@ -1,0 +1,49 @@
+import { useMutation } from '@apollo/client';
+import { Except } from 'type-fest';
+import { DialogForm, DialogFormProps } from '~/components/Dialog/DialogForm';
+import { SubmitError } from '~/components/form';
+import {
+  PartnerField,
+  PartnerLookupItem,
+} from '~/components/form/Lookup/Partner';
+import {
+  AssignOrganizationToUserDocument,
+  UserPartnersDocument,
+} from './UserPartnerPanel/UserPartnerList.graphql';
+
+interface FormValues {
+  partner: PartnerLookupItem;
+}
+
+type AddOrganizationToUserFormProps = Except<
+  DialogFormProps<FormValues>,
+  'onSubmit' | 'initialValues'
+> & {
+  userId: string;
+};
+
+export const AddOrganizationToUserForm = ({
+  userId,
+  ...props
+}: AddOrganizationToUserFormProps) => {
+  const [assignOrganization] = useMutation(AssignOrganizationToUserDocument);
+
+  return (
+    <DialogForm<FormValues>
+      title="Add Partner"
+      {...props}
+      onSubmit={async ({ partner }) => {
+        await assignOrganization({
+          variables: {
+            user: userId,
+            org: partner.organization.value!.id,
+          },
+          refetchQueries: [UserPartnersDocument],
+        });
+      }}
+    >
+      <SubmitError />
+      <PartnerField name="partner" required />
+    </DialogForm>
+  );
+};

--- a/src/scenes/Users/Detail/Tabs/Partners/UserDetailPartners.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserDetailPartners.tsx
@@ -1,0 +1,10 @@
+import { TabPanelContent } from '~/components/Tabs';
+import { UserPartnersPanel } from './UserPartnerPanel/UserPartnersPanel';
+
+export const UserDetailPartners = () => {
+  return (
+    <TabPanelContent>
+      <UserPartnersPanel />
+    </TabPanelContent>
+  );
+};

--- a/src/scenes/Users/Detail/Tabs/Partners/UserDetailPartners.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserDetailPartners.tsx
@@ -1,10 +1,14 @@
 import { TabPanelContent } from '~/components/Tabs';
 import { UserPartnersPanel } from './UserPartnerPanel/UserPartnersPanel';
 
-export const UserDetailPartners = () => {
+interface UserDetailPartnersProps {
+  canCreate: boolean;
+}
+
+export const UserDetailPartners = ({ canCreate }: UserDetailPartnersProps) => {
   return (
     <TabPanelContent>
-      <UserPartnersPanel />
+      <UserPartnersPanel canCreate={canCreate} />
     </TabPanelContent>
   );
 };

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnerList.graphql
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnerList.graphql
@@ -1,0 +1,13 @@
+query UserPartners($userId: ID!, $input: PartnerListInput) {
+  user(id: $userId) {
+    id
+    partners(input: $input) {
+      canRead
+      hasMore
+      total
+      items {
+        ...partnerDataGridRow
+      }
+    }
+  }
+}

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnerList.graphql
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnerList.graphql
@@ -11,3 +11,19 @@ query UserPartners($userId: ID!, $input: PartnerListInput) {
     }
   }
 }
+
+mutation AssignOrganizationToUser($user: ID!, $org: ID!) {
+  assignOrganizationToUser(user: $user, org: $org) {
+    user {
+      id
+    }
+  }
+}
+
+mutation RemoveOrganizationFromUser($user: ID!, $org: ID!) {
+  removeOrganizationFromUser(user: $user, org: $org) {
+    user {
+      id
+    }
+  }
+}

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
@@ -1,0 +1,61 @@
+import {
+  DataGridPro as DataGrid,
+  DataGridProProps as DataGridProps,
+} from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  PartnerColumns,
+  PartnerInitialState,
+  PartnerToolbar,
+} from '~/components/PartnersDataGrid/PartnerColumns';
+import { PartnerDataGridRowFragment as UserPartner } from '~/components/PartnersDataGrid/partnerDataGridRow.graphql';
+import { UserPartnersDocument } from './UserPartnerList.graphql';
+
+export const UserPartnersPanel = () => {
+  const { userId = '' } = useParams();
+
+  const [dataGridProps] = useDataGridSource({
+    query: UserPartnersDocument,
+    variables: { userId },
+    listAt: 'user.partners',
+    initialInput: {
+      sort: 'organization.name',
+    },
+  });
+
+  const slots = useMemo(
+    () =>
+      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
+        toolbar: PartnerToolbar,
+      } satisfies DataGridProps['slots']),
+    [dataGridProps.slots]
+  );
+
+  const slotProps = useMemo(
+    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
+    [dataGridProps.slotProps]
+  );
+
+  return (
+    <DataGrid<UserPartner>
+      {...DefaultDataGridStyles}
+      {...dataGridProps}
+      slots={slots}
+      slotProps={slotProps}
+      columns={PartnerColumns}
+      initialState={PartnerInitialState}
+      headerFilters
+      hideFooter
+      sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+    />
+  );
+};

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
@@ -1,15 +1,11 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
@@ -32,18 +28,9 @@ export const UserPartnersPanel = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: PartnerToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: PartnerToolbar },
+  });
 
   return (
     <DataGrid<UserPartner>

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
@@ -13,7 +13,7 @@ import {
   PartnerInitialState,
   PartnerToolbar,
 } from '~/components/PartnersDataGrid/PartnerColumns';
-import { PartnerDataGridRowFragment as UserPartner } from '~/components/PartnersDataGrid/partnerDataGridRow.graphql';
+import type { PartnerDataGridRowFragment as UserPartner } from '~/components/PartnersDataGrid/partnerDataGridRow.graphql';
 import { UserPartnersDocument } from './UserPartnerList.graphql';
 
 export const UserPartnersPanel = () => {

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
@@ -1,6 +1,12 @@
-import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import { useMutation } from '@apollo/client';
+import { Delete as DeleteIcon } from '@mui/icons-material';
+import { IconButton, Tooltip } from '@mui/material';
+import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
+import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { useDialog } from '~/components/Dialog';
 import {
+  createAddItemFooter,
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
@@ -14,10 +20,21 @@ import {
   PartnerToolbar,
 } from '~/components/PartnersDataGrid/PartnerColumns';
 import type { PartnerDataGridRowFragment as UserPartner } from '~/components/PartnersDataGrid/partnerDataGridRow.graphql';
-import { UserPartnersDocument } from './UserPartnerList.graphql';
+import { AddOrganizationToUserForm } from '../AddOrganizationToUserForm';
+import {
+  RemoveOrganizationFromUserDocument,
+  UserPartnersDocument,
+} from './UserPartnerList.graphql';
 
-export const UserPartnersPanel = () => {
+interface UserPartnersPanelProps {
+  canCreate: boolean;
+}
+
+export const UserPartnersPanel = ({ canCreate }: UserPartnersPanelProps) => {
   const { userId = '' } = useParams();
+  const [addPartnerState, openAddPartner] = useDialog();
+
+  const [removeOrganization] = useMutation(RemoveOrganizationFromUserDocument);
 
   const [dataGridProps] = useDataGridSource({
     query: UserPartnersDocument,
@@ -28,21 +45,70 @@ export const UserPartnersPanel = () => {
     },
   });
 
+  const columns = useMemo(() => {
+    const actionsCol: GridColDef<UserPartner> = {
+      field: 'actions',
+      headerName: '',
+      width: 60,
+      align: 'center',
+      sortable: false,
+      filterable: false,
+      disableColumnMenu: true,
+      hideable: false,
+      renderCell: ({ row: partner }) => (
+        <Tooltip title="Remove Partner">
+          <IconButton
+            size="small"
+            onClick={() =>
+              void removeOrganization({
+                variables: {
+                  user: userId,
+                  org: partner.organization.value!.id,
+                },
+                refetchQueries: [UserPartnersDocument],
+              })
+            }
+          >
+            <DeleteIcon fontSize="small" color="error" />
+          </IconButton>
+        </Tooltip>
+      ),
+    };
+    return [...PartnerColumns, ...(canCreate ? [actionsCol] : [])];
+  }, [canCreate, userId, removeOrganization]);
+
+  const AddPartnerFooter = useMemo(
+    () =>
+      createAddItemFooter({
+        addItem: openAddPartner,
+        tooltipTitle: 'Add Partner to User',
+      }),
+    [openAddPartner]
+  );
+
   const { slots, slotProps } = useDataGridSlots(dataGridProps, {
-    slots: { toolbar: PartnerToolbar },
+    slots: {
+      toolbar: PartnerToolbar,
+      footer: AddPartnerFooter,
+    },
   });
 
   return (
-    <DataGrid<UserPartner>
-      {...DefaultDataGridStyles}
-      {...dataGridProps}
-      slots={slots}
-      slotProps={slotProps}
-      columns={PartnerColumns}
-      initialState={PartnerInitialState}
-      headerFilters
-      hideFooter
-      sx={[flexLayout, noHeaderFilterButtons, noFooter]}
-    />
+    <>
+      <DataGrid<UserPartner>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={columns}
+        initialState={PartnerInitialState}
+        headerFilters
+        hideFooter={!canCreate}
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+      {canCreate && (
+        <AddOrganizationToUserForm userId={userId} {...addPartnerState} />
+      )}
+    </>
   );
 };

--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.graphql
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.graphql
@@ -1,0 +1,4 @@
+fragment UserProfile on User {
+  ...DisplayUser
+  ...UserForm
+}

--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
@@ -1,0 +1,157 @@
+import { Edit } from '@mui/icons-material';
+import {
+  Box,
+  IconButton,
+  Paper,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useInterval } from 'ahooks';
+import { DateTime } from 'luxon';
+import { useState } from 'react';
+import { RoleLabels } from '~/api/schema.graphql';
+import { canEditAny, labelsFrom } from '~/common';
+import { useDialog } from '~/components/Dialog';
+import {
+  DisplaySimpleProperty,
+  DisplaySimplePropertyProps,
+} from '~/components/DisplaySimpleProperty';
+import { PartnerListItemCard } from '~/components/PartnerListItemCard';
+import { EditUser } from '../../../Edit';
+import { UserProfileFragment } from './UserDetailProfile.graphql';
+
+interface UserDetailProfileProps {
+  user: UserProfileFragment;
+}
+
+export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
+  const [editUserState, editUser] = useDialog();
+
+  const canEditAnyFields = canEditAny(user);
+
+  return (
+    <Box
+      component={Paper}
+      sx={(theme) => ({
+        display: 'flex',
+        justifyContent: 'space-between',
+        width: theme.breakpoints.values.md,
+      })}
+    >
+      <Stack
+        sx={{
+          p: 2,
+          gap: 2,
+        }}
+      >
+        <DisplayProperty
+          label="Email"
+          value={user.email.value}
+          loading={!user}
+        />
+        <DisplayProperty
+          label="Title"
+          value={user.title.value}
+          loading={!user}
+        />
+        <DisplayProperty
+          label="Roles"
+          value={labelsFrom(RoleLabels)(user.roles.value)}
+          loading={!user}
+        />
+        <DisplayProperty
+          label="Local Time"
+          value={
+            user.timezone.value?.name ? (
+              <LocalTime timezone={user.timezone.value.name} />
+            ) : null
+          }
+          loading={!user}
+        />
+        <DisplayProperty
+          label="Phone"
+          value={user.phone.value}
+          loading={!user}
+        />
+        <DisplayProperty
+          label="About"
+          value={user.about.value}
+          loading={!user}
+        />
+
+        {!!user.partners.items.length && (
+          <>
+            <Typography variant="h3">Partners</Typography>
+            <Box sx={{ mt: 1 }}>
+              {user.partners.items.map((item) => (
+                <Box key={item.id} sx={{ mb: 2 }}>
+                  <PartnerListItemCard partner={item} />
+                </Box>
+              ))}
+            </Box>
+          </>
+        )}
+      </Stack>
+      <Box sx={{ p: 1 }}>
+        {canEditAnyFields ? (
+          <Tooltip title="Edit Person">
+            <IconButton aria-label="edit person" onClick={editUser}>
+              <Edit />
+            </IconButton>
+          </Tooltip>
+        ) : null}
+      </Box>
+      <EditUser user={user} {...editUserState} />
+    </Box>
+  );
+};
+
+const LocalTime = ({ timezone }: { timezone?: string }) => {
+  const now = useNow();
+  const formatted = now.toLocaleString({
+    timeZone: timezone,
+    ...DateTime.TIME_SIMPLE,
+    timeZoneName: 'short',
+  });
+  return <>{formatted}</>;
+};
+
+const useNow = (updateInterval = 1_000) => {
+  const [now, setNow] = useState(() => DateTime.local());
+  useInterval(() => {
+    setNow(DateTime.local());
+  }, updateInterval);
+  return now;
+};
+
+const DisplayProperty = (props: DisplaySimplePropertyProps) =>
+  !props.value && !props.loading ? null : (
+    <DisplaySimpleProperty
+      variant="body1"
+      {...{ component: 'div' }}
+      {...props}
+      loading={
+        props.loading ? (
+          <>
+            <Typography variant="body2">
+              <Skeleton width="10%" />
+            </Typography>
+            <Typography variant="body1">
+              <Skeleton width="40%" />
+            </Typography>
+          </>
+        ) : null
+      }
+      LabelProps={{
+        color: 'textSecondary',
+        variant: 'body2',
+        ...props.LabelProps,
+      }}
+      ValueProps={{
+        color: 'textPrimary',
+        ...props.ValueProps,
+      }}
+    />
+  );

--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
@@ -11,14 +11,13 @@ import {
 import { useInterval } from 'ahooks';
 import { DateTime } from 'luxon';
 import { useState } from 'react';
-import { RoleLabels } from '~/api/schema.graphql';
-import { canEditAny, labelsFrom } from '~/common';
+import { GenderLabels, RoleLabels } from '~/api/schema.graphql';
+import { canEditAny, labelFrom, labelsFrom } from '~/common';
 import { useDialog } from '~/components/Dialog';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
-import { PartnerListItemCard } from '~/components/PartnerListItemCard';
 import { EditUser } from '../../../Edit';
 import { UserProfileFragment } from './UserDetailProfile.graphql';
 
@@ -46,6 +45,16 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
           gap: 2,
         }}
       >
+        <DisplayProperty
+          label="Status"
+          value={user.status.value}
+          loading={!user}
+        />
+        <DisplayProperty
+          label="Gender"
+          value={labelFrom(GenderLabels)(user.gender.value)}
+          loading={!user}
+        />
         <DisplayProperty
           label="Email"
           value={user.email.value}
@@ -80,19 +89,6 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
           value={user.about.value}
           loading={!user}
         />
-
-        {!!user.partners.items.length && (
-          <>
-            <Typography variant="h3">Partners</Typography>
-            <Box sx={{ mt: 1 }}>
-              {user.partners.items.map((item) => (
-                <Box key={item.id} sx={{ mb: 2 }}>
-                  <PartnerListItemCard partner={item} />
-                </Box>
-              ))}
-            </Box>
-          </>
-        )}
       </Stack>
       <Box sx={{ p: 1 }}>
         {canEditAnyFields ? (

--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
@@ -45,30 +45,16 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
           gap: 2,
         }}
       >
-        <DisplayProperty
-          label="Status"
-          value={user.status.value}
-          loading={!user}
-        />
+        <DisplayProperty label="Status" value={user.status.value} />
         <DisplayProperty
           label="Gender"
           value={labelFrom(GenderLabels)(user.gender.value)}
-          loading={!user}
         />
-        <DisplayProperty
-          label="Email"
-          value={user.email.value}
-          loading={!user}
-        />
-        <DisplayProperty
-          label="Title"
-          value={user.title.value}
-          loading={!user}
-        />
+        <DisplayProperty label="Email" value={user.email.value} />
+        <DisplayProperty label="Title" value={user.title.value} />
         <DisplayProperty
           label="Roles"
           value={labelsFrom(RoleLabels)(user.roles.value)}
-          loading={!user}
         />
         <DisplayProperty
           label="Local Time"
@@ -77,18 +63,9 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
               <LocalTime timezone={user.timezone.value.name} />
             ) : null
           }
-          loading={!user}
         />
-        <DisplayProperty
-          label="Phone"
-          value={user.phone.value}
-          loading={!user}
-        />
-        <DisplayProperty
-          label="About"
-          value={user.about.value}
-          loading={!user}
-        />
+        <DisplayProperty label="Phone" value={user.phone.value} />
+        <DisplayProperty label="About" value={user.about.value} />
       </Stack>
       <Box sx={{ p: 1 }}>
         {canEditAnyFields ? (

--- a/src/scenes/Users/Detail/Tabs/Projects/UserDetailProjects.tsx
+++ b/src/scenes/Users/Detail/Tabs/Projects/UserDetailProjects.tsx
@@ -1,0 +1,10 @@
+import { TabPanelContent } from '~/components/Tabs';
+import { UserProjectsPanel } from './UserProjectPanel/UserProjectsPanel';
+
+export const UserDetailProjects = () => {
+  return (
+    <TabPanelContent>
+      <UserProjectsPanel />
+    </TabPanelContent>
+  );
+};

--- a/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectList.graphql
+++ b/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectList.graphql
@@ -1,0 +1,23 @@
+query UserProjects($userId: ID!, $input: ProjectListInput) {
+  user(id: $userId) {
+    id
+    projects(input: $input) {
+      canRead
+      hasMore
+      total
+      items {
+        ...userProjectDataGridRow
+      }
+    }
+  }
+}
+
+fragment userProjectDataGridRow on Project {
+  membership(user: $userId) {
+    id
+    roles {
+      value
+    }
+  }
+  ...projectDataGridRow
+}

--- a/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectsPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectsPanel.tsx
@@ -1,0 +1,82 @@
+import {
+  DataGridPro as DataGrid,
+  DataGridProProps as DataGridProps,
+  GridColDef,
+} from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { RoleLabels, RoleList } from '~/api/schema.graphql';
+import { unmatchedIndexThrow } from '~/common';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  multiEnumColumn,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  ProjectColumns,
+  ProjectInitialState,
+  ProjectToolbar,
+} from '~/components/ProjectDataGrid';
+import {
+  UserProjectDataGridRowFragment as UserProject,
+  UserProjectsDocument,
+} from './UserProjectList.graphql';
+
+export const UserProjectsPanel = () => {
+  const { userId = '' } = useParams();
+
+  const [dataGridProps] = useDataGridSource({
+    query: UserProjectsDocument,
+    variables: { userId },
+    listAt: 'user.projects',
+    initialInput: {
+      sort: 'name',
+    },
+  });
+
+  const slots = useMemo(
+    () =>
+      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
+        toolbar: ProjectToolbar,
+      } satisfies DataGridProps['slots']),
+    [dataGridProps.slots]
+  );
+
+  const slotProps = useMemo(
+    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
+    [dataGridProps.slotProps]
+  );
+
+  return (
+    <DataGrid<UserProject>
+      {...DefaultDataGridStyles}
+      {...dataGridProps}
+      slots={slots}
+      slotProps={slotProps}
+      columns={UserProjectColumns}
+      initialState={ProjectInitialState}
+      headerFilters
+      hideFooter
+      sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+    />
+  );
+};
+
+const UserProjectRoleColumn: GridColDef<UserProject> = {
+  field: 'user.membership',
+  headerName: 'Role',
+  width: 300,
+  ...multiEnumColumn(RoleList, RoleLabels),
+  valueGetter: (_, { membership }) => membership.roles.value,
+};
+
+const indexAfterName =
+  unmatchedIndexThrow(ProjectColumns.findIndex((c) => c.field === 'name')) + 1;
+
+const UserProjectColumns = (ProjectColumns as Array<GridColDef<UserProject>>)
+  // Add roles' column after name
+  .toSpliced(indexAfterName, 0, UserProjectRoleColumn);

--- a/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectsPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectsPanel.tsx
@@ -1,24 +1,21 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-  GridColDef,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
 import { RoleLabels, RoleList } from '~/api/schema.graphql';
-import { unmatchedIndexThrow } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
   multiEnumColumn,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
+  insertProjectColumnAfterField,
+  ProjectDataGridRowFragment as Project,
   ProjectColumns,
   ProjectInitialState,
+  ProjectNameField,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
 import {
@@ -38,18 +35,9 @@ export const UserProjectsPanel = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: ProjectToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: ProjectToolbar },
+  });
 
   return (
     <DataGrid<UserProject>
@@ -74,9 +62,13 @@ const UserProjectRoleColumn: GridColDef<UserProject> = {
   valueGetter: (_, { membership }) => membership.roles.value,
 };
 
-const indexAfterName =
-  unmatchedIndexThrow(ProjectColumns.findIndex((c) => c.field === 'name')) + 1;
+const UserProjectColumns = insertProjectColumnAfterField(
+  // MUI DataGrid column defs are invariant in row type due to callback signatures.
+  // The runtime usage is safe because UserProject includes all fields consumed below.
+  ProjectColumns as Array<GridColDef<UserProject>>,
+  ProjectNameField,
+  UserProjectRoleColumn
+);
 
-const UserProjectColumns = (ProjectColumns as Array<GridColDef<UserProject>>)
-  // Add roles' column after name
-  .toSpliced(indexAfterName, 0, UserProjectRoleColumn);
+const _EnforceUserProjectIsSupersetOfProject: Project =
+  undefined as unknown as UserProject;

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -101,9 +101,7 @@ export const UserDetail = () => {
               >
                 <Tab label="Profile" value="profile" />
                 <Tab label="Projects" value="projects" />
-                {!!user?.partners.items.length && (
-                  <Tab label="Partners" value="partners" />
-                )}
+                <Tab label="Partners" value="partners" />
               </TabList>
               <TabPanel value="profile">
                 {user && <UserDetailProfile user={user} />}
@@ -111,11 +109,11 @@ export const UserDetail = () => {
               <TabPanel value="projects">
                 <UserDetailProjects />
               </TabPanel>
-              {!!user?.partners.items.length && (
-                <TabPanel value="partners">
-                  <UserDetailPartners />
-                </TabPanel>
-              )}
+              <TabPanel value="partners">
+                {user && (
+                  <UserDetailPartners canCreate={user.partners.canCreate} />
+                )}
+              </TabPanel>
             </TabContext>
           </TabsContainer>
         </>

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -1,30 +1,27 @@
 import { useQuery } from '@apollo/client';
-import { Edit } from '@mui/icons-material';
-import { Box, Skeleton, Stack, Tooltip, Typography } from '@mui/material';
-import { useInterval } from 'ahooks';
-import { DateTime } from 'luxon';
-import { useState } from 'react';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Skeleton, Stack, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { PartialDeep } from 'type-fest';
-import { GenderLabels, RoleLabels } from '~/api/schema.graphql';
-import { canEditAny, labelFrom, labelsFrom } from '~/common';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
+import { Error } from '~/components/Error';
+import { Redacted } from '~/components/Redacted';
+import { Tab, TabsContainer } from '~/components/Tabs';
+import { TogglePinButton } from '~/components/TogglePinButton';
 import { UserPhoto } from '~/components/UserPhoto';
+import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
-import { useDialog } from '../../../components/Dialog';
-import {
-  DisplaySimpleProperty,
-  DisplaySimplePropertyProps,
-} from '../../../components/DisplaySimpleProperty';
-import { IconButton } from '../../../components/IconButton';
-import { PartnerListItemCard } from '../../../components/PartnerListItemCard';
-import { Redacted } from '../../../components/Redacted';
-import { TogglePinButton } from '../../../components/TogglePinButton';
-import { EditUser } from '../Edit';
 import { UsersQueryVariables } from '../List/users.graphql';
 import { ImpersonationToggle } from './ImpersonationToggle';
+import { UserDetailPartners } from './Tabs/Partners/UserDetailPartners';
+import { UserDetailProfile } from './Tabs/Profile/UserDetailProfile';
+import { UserDetailProjects } from './Tabs/Projects/UserDetailProjects';
 import { UserDocument } from './UserDetail.graphql';
+
+const useUserDetailsFilters = makeQueryHandler({
+  tab: withDefault(EnumParam(['profile', 'projects', 'partners']), 'profile'),
+});
 
 export const UserDetail = () => {
   const { userId = '' } = useParams();
@@ -33,12 +30,8 @@ export const UserDetail = () => {
     fetchPolicy: 'cache-and-network',
   });
   useComments(userId);
-
-  const [editUserState, editUser] = useDialog();
-
+  const [filters, setFilters] = useUserDetailsFilters();
   const user = data?.user;
-
-  const canEditAnyFields = canEditAny(user);
 
   return (
     <Stack
@@ -47,17 +40,22 @@ export const UserDetail = () => {
         overflowY: 'auto',
         p: 4,
         gap: 3,
-        maxWidth: (theme) => theme.breakpoints.values.md,
+        flex: 1,
+        maxWidth: (theme) => theme.breakpoints.values.xl,
       }}
     >
       <Helmet title={user?.fullName ?? undefined} />
-      {error ? (
-        <Typography variant="h4">Error loading person</Typography>
-      ) : (
+
+      <Error error={error}>
+        {{
+          NotFound: 'Could not find user',
+          Default: 'Error loading user',
+        }}
+      </Error>
+      {!error && (
         <>
           <Box
             sx={{
-              flex: 1,
               display: 'flex',
               gap: 1,
             }}
@@ -65,8 +63,8 @@ export const UserDetail = () => {
             <Typography
               variant="h2"
               sx={{
-                mr: 2, // a little extra between text and buttons
-                lineHeight: 'inherit', // centers text with buttons better
+                mr: 2,
+                lineHeight: 'inherit',
               }}
             >
               {!user ? (
@@ -80,13 +78,6 @@ export const UserDetail = () => {
                 )
               )}
             </Typography>
-            {canEditAnyFields ? (
-              <Tooltip title="Edit Person">
-                <IconButton aria-label="edit person" onClick={editUser}>
-                  <Edit />
-                </IconButton>
-              </Tooltip>
-            ) : null}
             <TogglePinButton
               object={user}
               label="Person"
@@ -98,113 +89,37 @@ export const UserDetail = () => {
             <ToggleCommentsButton loading={!user} />
             <ImpersonationToggle user={user} />
           </Box>
-          {user && <UserPhoto user={user} sx={{ alignSelf: 'start' }} />}
-          <DisplayProperty
-            label="Status"
-            value={user?.status.value}
-            loading={!user}
-          />
-          <DisplayProperty
-            label="Gender"
-            value={labelFrom(GenderLabels)(user?.gender.value)}
-            loading={!user}
-          />
-          <DisplayProperty
-            label="Email"
-            value={user?.email.value}
-            loading={!user}
-          />
-          <DisplayProperty
-            label="Title"
-            value={user?.title.value}
-            loading={!user}
-          />
-          <DisplayProperty
-            label="Roles"
-            value={labelsFrom(RoleLabels)(user?.roles.value)}
-            loading={!user}
-          />
-          <DisplayProperty
-            label="Local Time"
-            value={
-              user?.timezone.value?.name ? (
-                <LocalTime timezone={user.timezone.value.name} />
-              ) : null
-            }
-            loading={!user}
-          />
-          <DisplayProperty
-            label="Phone"
-            value={user?.phone.value}
-            loading={!user}
-          />
-          <DisplayProperty
-            label="About"
-            value={user?.about.value}
-            loading={!user}
-          />
-          {user ? <EditUser user={user} {...editUserState} /> : null}
 
-          {!!user?.partners.items.length && (
-            <>
-              <Typography variant="h3">Partners</Typography>
-              <Stack sx={{ mt: 1, gap: 2 }}>
-                {user.partners.items.map((item) => (
-                  <PartnerListItemCard key={item.id} partner={item} />
-                ))}
-              </Stack>
-            </>
-          )}
+          {user && <UserPhoto user={user} sx={{ alignSelf: 'start' }} />}
+
+          <TabsContainer>
+            <TabContext value={filters.tab}>
+              <TabList
+                onChange={(_e, tab) => setFilters({ ...filters, tab })}
+                aria-label="user navigation tabs"
+                variant="scrollable"
+              >
+                <Tab label="Profile" value="profile" />
+                <Tab label="Projects" value="projects" />
+                {!!user?.partners.items.length && (
+                  <Tab label="Partners" value="partners" />
+                )}
+              </TabList>
+              <TabPanel value="profile">
+                {user && <UserDetailProfile user={user} />}
+              </TabPanel>
+              <TabPanel value="projects">
+                <UserDetailProjects />
+              </TabPanel>
+              {!!user?.partners.items.length && (
+                <TabPanel value="partners">
+                  <UserDetailPartners />
+                </TabPanel>
+              )}
+            </TabContext>
+          </TabsContainer>
         </>
       )}
     </Stack>
   );
 };
-
-const LocalTime = ({ timezone }: { timezone?: string }) => {
-  const now = useNow();
-  const formatted = now.toLocaleString({
-    timeZone: timezone,
-    ...DateTime.TIME_SIMPLE,
-    timeZoneName: 'short',
-  });
-  return <>{formatted}</>;
-};
-
-const useNow = (updateInterval = 1_000) => {
-  const [now, setNow] = useState(() => DateTime.local());
-  useInterval(() => {
-    setNow(DateTime.local());
-  }, updateInterval);
-  return now;
-};
-
-const DisplayProperty = (props: DisplaySimplePropertyProps) =>
-  !props.value && !props.loading ? null : (
-    <DisplaySimpleProperty
-      variant="body1"
-      {...{ component: 'div' }}
-      {...props}
-      loading={
-        props.loading ? (
-          <>
-            <Typography variant="body2">
-              <Skeleton width="10%" />
-            </Typography>
-            <Typography variant="body1">
-              <Skeleton width="40%" />
-            </Typography>
-          </>
-        ) : null
-      }
-      LabelProps={{
-        color: 'textSecondary',
-        variant: 'body2',
-        ...props.LabelProps,
-      }}
-      ValueProps={{
-        color: 'textPrimary',
-        ...props.ValueProps,
-      }}
-    />
-  );

--- a/src/scenes/Users/List/UserGrid.tsx
+++ b/src/scenes/Users/List/UserGrid.tsx
@@ -1,14 +1,10 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import {
@@ -29,18 +25,9 @@ export const UserGrid = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, dataGridProps.slots, {
-        toolbar: UserToolbar,
-      } satisfies DataGridProps['slots']),
-    [dataGridProps.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, dataGridProps.slotProps),
-    [dataGridProps.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: UserToolbar },
+  });
 
   return (
     <DataGrid<People>


### PR DESCRIPTION
Adds Projects and Partners tables prefiltered by `userId` to the User detail and also creates a new tab list where `Profile` is separated out from `Projects` and `Partners`.

Also the ability to add/remove partners to a User.