### PR TITLE
Field Region & Field Zone project grids

### DIFF
--- a/src/api/schema/typePolicies/typePolicies.base.ts
+++ b/src/api/schema/typePolicies/typePolicies.base.ts
@@ -81,6 +81,16 @@ export const typePolicies: TypePolicies = {
       },
     },
   },
+  FieldRegion: {
+    fields: {
+      projects: {}, // no page merging (infinite scroll)
+    },
+  },
+  FieldZone: {
+    fields: {
+      projects: {}, // no page merging (infinite scroll)
+    },
+  },
   Partner: {
     fields: {
       projects: {}, // no page merging (infinite scroll)

--- a/src/scenes/FieldRegions/Detail/FieldRegionDetail.graphql
+++ b/src/scenes/FieldRegions/Detail/FieldRegionDetail.graphql
@@ -15,5 +15,8 @@ query FieldRegionDetail($fieldRegionId: ID!) @live {
       }
     }
     ...FieldRegionForm
+    projects {
+      canRead
+    }
   }
 }

--- a/src/scenes/FieldRegions/Detail/FieldRegionDetail.test.tsx
+++ b/src/scenes/FieldRegions/Detail/FieldRegionDetail.test.tsx
@@ -1,0 +1,150 @@
+import { MockedProvider } from '@apollo/client/testing';
+import type { MockedResponse } from '@apollo/client/testing';
+import { render, screen, waitFor } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FieldRegionDetail } from './FieldRegionDetail';
+import { FieldRegionDetailDocument } from './FieldRegionDetail.graphql';
+
+jest.mock('./Tabs/Projects/FieldRegionProjectsPanel', () => ({
+  FieldRegionProjectsPanel: () => <div data-testid="projects-panel" />,
+}));
+
+jest.mock('~/components/FieldRegion', () => ({
+  EditFieldRegion: () => null,
+}));
+
+jest.mock('~/components/Error', () => ({
+  Error: () => null,
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeFieldRegion = (overrides = {}) => ({
+  __typename: 'FieldRegion',
+  id: 'region-1',
+  name: {
+    __typename: 'SecuredString',
+    value: 'East Asia',
+    canRead: true,
+    canEdit: false,
+  },
+  director: {
+    __typename: 'SecuredUser',
+    canRead: true,
+    canEdit: false,
+    value: null,
+  },
+  fieldZone: {
+    __typename: 'SecuredFieldZone',
+    canRead: true,
+    canEdit: false,
+    value: null,
+  },
+  projects: { canRead: true },
+  ...overrides,
+});
+
+const makeDetailMock = (fieldRegion = makeFieldRegion()): MockedResponse => ({
+  request: {
+    query: FieldRegionDetailDocument,
+    variables: { fieldRegionId: 'region-1' },
+  },
+  result: { data: { fieldRegion } },
+});
+
+const renderDetail = (
+  mocks: readonly MockedResponse[] = [makeDetailMock()]
+) => {
+  render(
+    <HelmetProvider>
+      <MockedProvider mocks={mocks}>
+        <MemoryRouter initialEntries={['/field-regions/region-1']}>
+          <Routes>
+            <Route
+              path="/field-regions/:fieldRegionId"
+              element={<FieldRegionDetail />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    </HelmetProvider>
+  );
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('FieldRegionDetail', () => {
+  it('renders the region name', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('East Asia')).toBeInTheDocument();
+    });
+  });
+
+  describe('tabs', () => {
+    it('always shows the Profile tab', async () => {
+      renderDetail();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('tab', { name: 'Profile' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows Projects tab when projects.canRead is true', async () => {
+      renderDetail();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('tab', { name: 'Projects' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides Projects tab when projects.canRead is false', async () => {
+      renderDetail([
+        makeDetailMock(makeFieldRegion({ projects: { canRead: false } })),
+      ]);
+      await waitFor(() => {
+        // Both assertions together so waitFor retries until the query has
+        // resolved and canReadProjects has updated to false.
+        expect(screen.getByText('East Asia')).toBeInTheDocument();
+        expect(
+          screen.queryByRole('tab', { name: 'Projects' })
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('edit button', () => {
+    it('shows when user has edit permission on any field', async () => {
+      renderDetail([
+        makeDetailMock(
+          makeFieldRegion({
+            name: {
+              __typename: 'SecuredString',
+              value: 'East Asia',
+              canRead: true,
+              canEdit: true,
+            },
+          })
+        ),
+      ]);
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /edit region/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides when user lacks edit permission on all fields', async () => {
+      renderDetail();
+      await waitFor(() => {
+        expect(screen.getByText('East Asia')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole('button', { name: /edit region/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/scenes/FieldRegions/Detail/FieldRegionDetail.tsx
+++ b/src/scenes/FieldRegions/Detail/FieldRegionDetail.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { Box, Skeleton, Typography } from '@mui/material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
+import { useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { canEditAny } from '~/common';
@@ -11,13 +13,21 @@ import {
 } from '~/components/DisplaySimpleProperty';
 import { EditFieldRegion } from '~/components/FieldRegion';
 import { Link } from '~/components/Routing';
+import { Tab, TabsContainer } from '~/components/Tabs';
+import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { Error } from '../../../components/Error';
-import { Fab } from '../../../components/Fab';
+import { IconButton } from '../../../components/IconButton';
 import { Redacted } from '../../../components/Redacted';
 import { FieldRegionDetailDocument } from './FieldRegionDetail.graphql';
+import { FieldRegionProjectsPanel } from './Tabs/Projects/FieldRegionProjectsPanel';
+
+const useFieldRegionDetailFilters = makeQueryHandler({
+  tab: withDefault(EnumParam(['profile', 'projects']), 'profile'),
+});
 
 export const FieldRegionDetail = () => {
   const { fieldRegionId = '' } = useParams();
+  const [filters, setFilters] = useFieldRegionDetailFilters();
 
   const [editRegionState, editRegion] = useDialog();
 
@@ -27,14 +37,31 @@ export const FieldRegionDetail = () => {
   });
 
   const fieldRegion = data?.fieldRegion;
+  const canReadProjects = fieldRegion?.projects.canRead !== false;
+
+  const readableTabs = useMemo(
+    () => ['profile', ...(canReadProjects ? ['projects'] : [])],
+    [canReadProjects]
+  );
+
+  useEffect(() => {
+    if (!readableTabs.includes(filters.tab)) {
+      setFilters({ tab: 'profile' });
+    }
+  }, [filters.tab, readableTabs, setFilters]);
 
   return (
     <Box
       component="main"
-      sx={{
+      sx={(theme) => ({
+        display: 'flex',
+        flexDirection: 'column',
         flex: 1,
-        p: 4,
-      }}
+        overflowY: 'auto',
+        padding: 4,
+        gap: 3,
+        maxWidth: theme.breakpoints.values.xl,
+      })}
     >
       <Helmet title={fieldRegion?.name.value || undefined} />
       <Error error={error}>
@@ -44,81 +71,83 @@ export const FieldRegionDetail = () => {
         }}
       </Error>
       {!error && (
-        <Box
-          sx={{
-            maxWidth: (theme) => theme.breakpoints.values.md,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 3,
-          }}
-        >
-          <Box
-            component="header"
-            sx={{
-              flex: 1,
-              display: 'flex',
-            }}
-          >
-            <Typography
-              variant="h2"
-              sx={{
-                mr: 4,
-                width: !fieldRegion?.name.value ? '40%' : undefined,
-              }}
-            >
+        <>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Typography variant="h2" sx={{ mr: 2, lineHeight: 'inherit' }}>
               {!fieldRegion ? (
-                <Skeleton width="100%" />
+                <Skeleton width="20ch" />
               ) : (
                 fieldRegion.name.value ?? (
                   <Redacted
                     info="You don't have permission to view this field region's name"
-                    width="40%"
+                    width="20ch"
                   />
                 )
               )}
             </Typography>
-            {canEditAny(fieldRegion, true) && (
-              <Fab
-                color="primary"
-                aria-label="edit region"
-                onClick={editRegion}
-                loading={!fieldRegion}
-              >
-                <Edit />
-              </Fab>
-            )}
+            {canEditAny(fieldRegion, true) ? (
+              <Tooltip title="Edit Field Region">
+                <IconButton aria-label="edit region" onClick={editRegion}>
+                  <Edit />
+                </IconButton>
+              </Tooltip>
+            ) : null}
           </Box>
-          <Box
-            sx={{
-              display: 'flex',
-            }}
-          >
-            <Typography variant="h4">
-              {fieldRegion ? 'Field Region' : <Skeleton width={200} />}
-            </Typography>
-          </Box>
-          <DisplayProperty
-            label="Field Zone"
-            value={
-              <Link to={`/field-zones/${fieldRegion?.fieldZone.value?.id}`}>
-                {fieldRegion?.fieldZone.value?.name.value}
-              </Link>
-            }
-            loading={!fieldRegion}
-          />
-          <DisplayProperty
-            label="Director"
-            value={
-              <Link to={`/users/${fieldRegion?.director.value?.id}`}>
-                {fieldRegion?.director.value?.fullName}
-              </Link>
-            }
-            loading={!fieldRegion}
-          />
-        </Box>
-      )}
-      {fieldRegion && (
-        <EditFieldRegion fieldRegion={fieldRegion} {...editRegionState} />
+
+          <TabsContainer>
+            <TabContext
+              value={
+                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
+              }
+            >
+              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+                <Tab label="Profile" value="profile" />
+                {canReadProjects && <Tab label="Projects" value="projects" />}
+              </TabList>
+              <TabPanel value="profile">
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
+                    py: 2,
+                    px: 1,
+                  }}
+                >
+                  <DisplayProperty
+                    label="Field Zone"
+                    value={
+                      <Link
+                        to={`/field-zones/${fieldRegion?.fieldZone.value?.id}`}
+                      >
+                        {fieldRegion?.fieldZone.value?.name.value}
+                      </Link>
+                    }
+                    loading={!fieldRegion}
+                  />
+                  <DisplayProperty
+                    label="Director"
+                    value={
+                      <Link to={`/users/${fieldRegion?.director.value?.id}`}>
+                        {fieldRegion?.director.value?.fullName}
+                      </Link>
+                    }
+                    loading={!fieldRegion}
+                  />
+                </Box>
+              </TabPanel>
+              {canReadProjects && (
+                <TabPanel value="projects">
+                  <FieldRegionProjectsPanel />
+                </TabPanel>
+              )}
+            </TabContext>
+          </TabsContainer>
+
+          {fieldRegion && (
+            <EditFieldRegion fieldRegion={fieldRegion} {...editRegionState} />
+          )}
+        </>
       )}
     </Box>
   );

--- a/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjects.graphql
+++ b/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjects.graphql
@@ -1,0 +1,18 @@
+query FieldRegionProjects($fieldRegionId: ID!, $input: ProjectListInput) {
+  fieldRegion(id: $fieldRegionId) {
+    id
+    projects(input: $input) {
+      canRead
+      canCreate
+      hasMore
+      total
+      items {
+        ...fieldRegionProjectDataGridRow
+      }
+    }
+  }
+}
+
+fragment fieldRegionProjectDataGridRow on Project {
+  ...projectDataGridRow
+}

--- a/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjectsPanel.tsx
+++ b/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjectsPanel.tsx
@@ -1,0 +1,57 @@
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import { useParams } from 'react-router-dom';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSlots,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  ProjectDataGridRowFragment as Project,
+  ProjectColumns,
+  ProjectInitialState,
+  ProjectToolbar,
+} from '~/components/ProjectDataGrid';
+import { TabPanelContent } from '~/components/Tabs';
+import {
+  type FieldRegionProjectDataGridRowFragment as FieldRegionProject,
+  FieldRegionProjectsDocument,
+} from './FieldRegionProjects.graphql';
+
+export const FieldRegionProjectsPanel = () => {
+  const { fieldRegionId = '' } = useParams();
+
+  const [dataGridProps] = useDataGridSource({
+    query: FieldRegionProjectsDocument,
+    variables: { fieldRegionId },
+    listAt: 'fieldRegion.projects',
+    initialInput: {
+      sort: 'name',
+    },
+  });
+
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: ProjectToolbar },
+  });
+
+  return (
+    <TabPanelContent>
+      <DataGrid<FieldRegionProject>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={ProjectColumns}
+        initialState={ProjectInitialState}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
+  );
+};
+
+const _EnforceFieldRegionProjectIsSupersetOfProject: Project =
+  undefined as unknown as FieldRegionProject;

--- a/src/scenes/FieldZones/Detail/FieldZoneDetail.graphql
+++ b/src/scenes/FieldZones/Detail/FieldZoneDetail.graphql
@@ -10,5 +10,8 @@ query FieldZoneDetail($fieldZoneId: ID!) @live {
       }
     }
     ...FieldZoneForm
+    projects {
+      canRead
+    }
   }
 }

--- a/src/scenes/FieldZones/Detail/FieldZoneDetail.test.tsx
+++ b/src/scenes/FieldZones/Detail/FieldZoneDetail.test.tsx
@@ -1,0 +1,144 @@
+import { MockedProvider } from '@apollo/client/testing';
+import type { MockedResponse } from '@apollo/client/testing';
+import { render, screen, waitFor } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FieldZoneDetail } from './FieldZoneDetail';
+import { FieldZoneDetailDocument } from './FieldZoneDetail.graphql';
+
+jest.mock('./Tabs/Projects/FieldZoneProjectsPanel', () => ({
+  FieldZoneProjectsPanel: () => <div data-testid="projects-panel" />,
+}));
+
+jest.mock('~/components/FieldZone', () => ({
+  EditFieldZone: () => null,
+}));
+
+jest.mock('~/components/Error', () => ({
+  Error: () => null,
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeFieldZone = (overrides = {}) => ({
+  __typename: 'FieldZone',
+  id: 'zone-1',
+  name: {
+    __typename: 'SecuredString',
+    value: 'Asia Pacific',
+    canRead: true,
+    canEdit: false,
+  },
+  director: {
+    __typename: 'SecuredUser',
+    canRead: true,
+    canEdit: false,
+    value: null,
+  },
+  projects: { canRead: true },
+  ...overrides,
+});
+
+const makeDetailMock = (fieldZone = makeFieldZone()): MockedResponse => ({
+  request: {
+    query: FieldZoneDetailDocument,
+    variables: { fieldZoneId: 'zone-1' },
+  },
+  result: { data: { fieldZone } },
+});
+
+const renderDetail = (
+  mocks: readonly MockedResponse[] = [makeDetailMock()]
+) => {
+  render(
+    <HelmetProvider>
+      <MockedProvider mocks={mocks}>
+        <MemoryRouter initialEntries={['/field-zones/zone-1']}>
+          <Routes>
+            <Route
+              path="/field-zones/:fieldZoneId"
+              element={<FieldZoneDetail />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    </HelmetProvider>
+  );
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('FieldZoneDetail', () => {
+  it('renders the zone name', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('Asia Pacific')).toBeInTheDocument();
+    });
+  });
+
+  describe('tabs', () => {
+    it('always shows the Profile tab', async () => {
+      renderDetail();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('tab', { name: 'Profile' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows Projects tab when projects.canRead is true', async () => {
+      renderDetail();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('tab', { name: 'Projects' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides Projects tab when projects.canRead is false', async () => {
+      renderDetail([
+        makeDetailMock(makeFieldZone({ projects: { canRead: false } })),
+      ]);
+      await waitFor(() => {
+        // Both assertions together so waitFor retries until the query has
+        // resolved and canReadProjects has updated to false.
+        expect(screen.getByText('Asia Pacific')).toBeInTheDocument();
+        expect(
+          screen.queryByRole('tab', { name: 'Projects' })
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('edit button', () => {
+    it('shows when user has edit permission on any field', async () => {
+      renderDetail([
+        makeDetailMock(
+          makeFieldZone({
+            name: {
+              __typename: 'SecuredString',
+              value: 'Asia Pacific',
+              canRead: true,
+              canEdit: true,
+            },
+          })
+        ),
+      ]);
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /edit zone/i })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('hides when user lacks edit permission on all fields', async () => {
+      renderDetail();
+      await waitFor(() => {
+        expect(screen.getByText('Asia Pacific')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole('button', { name: /edit zone/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/scenes/FieldZones/Detail/FieldZoneDetail.tsx
+++ b/src/scenes/FieldZones/Detail/FieldZoneDetail.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { Box, Skeleton, Typography } from '@mui/material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
+import { useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { canEditAny } from '~/common';
@@ -10,14 +12,22 @@ import {
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
 import { Link } from '~/components/Routing';
+import { Tab, TabsContainer } from '~/components/Tabs';
+import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { Error } from '../../../components/Error';
-import { Fab } from '../../../components/Fab';
 import { EditFieldZone } from '../../../components/FieldZone';
+import { IconButton } from '../../../components/IconButton';
 import { Redacted } from '../../../components/Redacted';
 import { FieldZoneDetailDocument } from './FieldZoneDetail.graphql';
+import { FieldZoneProjectsPanel } from './Tabs/Projects/FieldZoneProjectsPanel';
+
+const useFieldZoneDetailFilters = makeQueryHandler({
+  tab: withDefault(EnumParam(['profile', 'projects']), 'profile'),
+});
 
 export const FieldZoneDetail = () => {
   const { fieldZoneId = '' } = useParams();
+  const [filters, setFilters] = useFieldZoneDetailFilters();
 
   const [editZoneState, editZone] = useDialog();
 
@@ -27,14 +37,31 @@ export const FieldZoneDetail = () => {
   });
 
   const fieldZone = data?.fieldZone;
+  const canReadProjects = fieldZone?.projects.canRead !== false;
+
+  const readableTabs = useMemo(
+    () => ['profile', ...(canReadProjects ? ['projects'] : [])],
+    [canReadProjects]
+  );
+
+  useEffect(() => {
+    if (!readableTabs.includes(filters.tab)) {
+      setFilters({ tab: 'profile' });
+    }
+  }, [filters.tab, readableTabs, setFilters]);
 
   return (
     <Box
       component="main"
-      sx={{
+      sx={(theme) => ({
+        display: 'flex',
+        flexDirection: 'column',
         flex: 1,
-        p: 4,
-      }}
+        overflowY: 'auto',
+        padding: 4,
+        gap: 3,
+        maxWidth: theme.breakpoints.values.xl,
+      })}
     >
       <Helmet title={fieldZone?.name.value || undefined} />
       <Error error={error}>
@@ -44,74 +71,75 @@ export const FieldZoneDetail = () => {
         }}
       </Error>
       {!error && (
-        <Box
-          sx={{
-            maxWidth: (theme) => theme.breakpoints.values.md,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 3,
-          }}
-        >
-          <Box
-            component="header"
-            sx={{
-              flex: 1,
-              display: 'flex',
-            }}
-          >
-            <Typography
-              variant="h2"
-              sx={{
-                mr: 4,
-                width: !fieldZone?.name.value ? '40%' : undefined,
-              }}
-            >
+        <>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Typography variant="h2" sx={{ mr: 2, lineHeight: 'inherit' }}>
               {!fieldZone ? (
-                <Skeleton width="100%" />
+                <Skeleton width="20ch" />
               ) : (
                 fieldZone.name.value ?? (
                   <Redacted
                     info="You don't have permission to view this field zone's name"
-                    width="40%"
+                    width="20ch"
                   />
                 )
               )}
             </Typography>
-            {canEditAny(fieldZone, true) && (
-              <Fab
-                color="primary"
-                aria-label="edit zone"
-                onClick={editZone}
-                loading={!fieldZone}
-              >
-                <Edit />
-              </Fab>
-            )}
-          </Box>
-          <Box
-            sx={{
-              display: 'flex',
-            }}
-          >
-            <Typography variant="h4">
-              {fieldZone ? 'Field Zone' : <Skeleton width={200} />}
-            </Typography>
+            {canEditAny(fieldZone, true) ? (
+              <Tooltip title="Edit Field Zone">
+                <IconButton aria-label="edit zone" onClick={editZone}>
+                  <Edit />
+                </IconButton>
+              </Tooltip>
+            ) : null}
           </Box>
 
-          <DisplayProperty
-            label="Director"
-            value={
-              fieldZone?.director.value && (
-                <Link to={`/users/${fieldZone.director.value.id}`}>
-                  {fieldZone.director.value.fullName}
-                </Link>
-              )
-            }
-            loading={!fieldZone}
-          />
-        </Box>
+          <TabsContainer>
+            <TabContext
+              value={
+                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
+              }
+            >
+              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+                <Tab label="Profile" value="profile" />
+                {canReadProjects && <Tab label="Projects" value="projects" />}
+              </TabList>
+              <TabPanel value="profile">
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
+                    py: 2,
+                    px: 1,
+                  }}
+                >
+                  <DisplayProperty
+                    label="Director"
+                    value={
+                      fieldZone?.director.value && (
+                        <Link to={`/users/${fieldZone.director.value.id}`}>
+                          {fieldZone.director.value.fullName}
+                        </Link>
+                      )
+                    }
+                    loading={!fieldZone}
+                  />
+                </Box>
+              </TabPanel>
+              {canReadProjects && (
+                <TabPanel value="projects">
+                  <FieldZoneProjectsPanel />
+                </TabPanel>
+              )}
+            </TabContext>
+          </TabsContainer>
+
+          {fieldZone && (
+            <EditFieldZone fieldZone={fieldZone} {...editZoneState} />
+          )}
+        </>
       )}
-      {fieldZone && <EditFieldZone fieldZone={fieldZone} {...editZoneState} />}
     </Box>
   );
 };

--- a/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjects.graphql
+++ b/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjects.graphql
@@ -1,0 +1,18 @@
+query FieldZoneProjects($fieldZoneId: ID!, $input: ProjectListInput) {
+  fieldZone(id: $fieldZoneId) {
+    id
+    projects(input: $input) {
+      canRead
+      canCreate
+      hasMore
+      total
+      items {
+        ...fieldZoneProjectDataGridRow
+      }
+    }
+  }
+}
+
+fragment fieldZoneProjectDataGridRow on Project {
+  ...projectDataGridRow
+}

--- a/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjectsPanel.tsx
+++ b/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjectsPanel.tsx
@@ -1,0 +1,57 @@
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import { useParams } from 'react-router-dom';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSlots,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  ProjectDataGridRowFragment as Project,
+  ProjectColumns,
+  ProjectInitialState,
+  ProjectToolbar,
+} from '~/components/ProjectDataGrid';
+import { TabPanelContent } from '~/components/Tabs';
+import {
+  type FieldZoneProjectDataGridRowFragment as FieldZoneProject,
+  FieldZoneProjectsDocument,
+} from './FieldZoneProjects.graphql';
+
+export const FieldZoneProjectsPanel = () => {
+  const { fieldZoneId = '' } = useParams();
+
+  const [dataGridProps] = useDataGridSource({
+    query: FieldZoneProjectsDocument,
+    variables: { fieldZoneId },
+    listAt: 'fieldZone.projects',
+    initialInput: {
+      sort: 'name',
+    },
+  });
+
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: ProjectToolbar },
+  });
+
+  return (
+    <TabPanelContent>
+      <DataGrid<FieldZoneProject>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={ProjectColumns}
+        initialState={ProjectInitialState}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
+  );
+};
+
+const _EnforceFieldZoneProjectIsSupersetOfProject: Project =
+  undefined as unknown as FieldZoneProject;

--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
@@ -1,24 +1,13 @@
-import { Edit } from '@mui/icons-material';
-import {
-  Box,
-  IconButton,
-  Paper,
-  Skeleton,
-  Stack,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import { Box, Paper, Skeleton, Stack, Typography } from '@mui/material';
 import { useInterval } from 'ahooks';
 import { DateTime } from 'luxon';
 import { useState } from 'react';
 import { GenderLabels, RoleLabels } from '~/api/schema.graphql';
-import { canEditAny, labelFrom, labelsFrom } from '~/common';
-import { useDialog } from '~/components/Dialog';
+import { labelFrom, labelsFrom } from '~/common';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
-import { EditUser } from '../../../Edit';
 import { UserProfileFragment } from './UserDetailProfile.graphql';
 
 interface UserDetailProfileProps {
@@ -26,16 +15,10 @@ interface UserDetailProfileProps {
 }
 
 export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
-  const [editUserState, editUser] = useDialog();
-
-  const canEditAnyFields = canEditAny(user);
-
   return (
     <Box
       component={Paper}
       sx={(theme) => ({
-        display: 'flex',
-        justifyContent: 'space-between',
         width: theme.breakpoints.values.md,
       })}
     >
@@ -67,16 +50,6 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
         <DisplayProperty label="Phone" value={user.phone.value} />
         <DisplayProperty label="About" value={user.about.value} />
       </Stack>
-      <Box sx={{ p: 1 }}>
-        {canEditAnyFields ? (
-          <Tooltip title="Edit Person">
-            <IconButton aria-label="edit person" onClick={editUser}>
-              <Edit />
-            </IconButton>
-          </Tooltip>
-        ) : null}
-      </Box>
-      <EditUser user={user} {...editUserState} />
     </Box>
   );
 };

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -1,17 +1,22 @@
 import { useQuery } from '@apollo/client';
+import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
-import { Box, Skeleton, Stack, Typography } from '@mui/material';
+import { Box, Skeleton, Stack, Tooltip, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { PartialDeep } from 'type-fest';
+import { canEditAny } from '~/common';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
+import { useDialog } from '~/components/Dialog';
 import { Error } from '~/components/Error';
+import { IconButton } from '~/components/IconButton';
 import { Redacted } from '~/components/Redacted';
 import { Tab, TabsContainer } from '~/components/Tabs';
 import { TogglePinButton } from '~/components/TogglePinButton';
 import { UserPhoto } from '~/components/UserPhoto';
 import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
+import { EditUser } from '../Edit';
 import { UsersQueryVariables } from '../List/users.graphql';
 import { ImpersonationToggle } from './ImpersonationToggle';
 import { UserDetailPartners } from './Tabs/Partners/UserDetailPartners';
@@ -31,6 +36,7 @@ export const UserDetail = () => {
   });
   useComments(userId);
   const [filters, setFilters] = useUserDetailsFilters();
+  const [editUserState, editUser] = useDialog();
   const user = data?.user;
 
   return (
@@ -78,6 +84,13 @@ export const UserDetail = () => {
                 )
               )}
             </Typography>
+            {canEditAny(user) ? (
+              <Tooltip title="Edit Person">
+                <IconButton aria-label="edit person" onClick={editUser}>
+                  <Edit />
+                </IconButton>
+              </Tooltip>
+            ) : null}
             <TogglePinButton
               object={user}
               label="Person"
@@ -116,6 +129,7 @@ export const UserDetail = () => {
               </TabPanel>
             </TabContext>
           </TabsContainer>
+          {user && <EditUser user={user} {...editUserState} />}
         </>
       )}
     </Stack>


### PR DESCRIPTION
API PR: https://github.com/SeedCompany/cord-api-v3/pull/3530

### Add Projects grids to Field Region and Zone detail pages

- Adds a paginated, filterable Projects data grid to both the Field Region and Field Zone detail pages, backed by the new `projects` field on each type in the GraphQL API
- Refactors both detail pages from flat layouts to a tabbed layout (Profile / Projects), matching the pattern established by Language and User detail pages
- Field Zone grid is read-only (`canCreate` is always false from the API since zones don't own projects directly; region grid respects `canCreate` from the user's permissions)
- Adds `FieldRegion` and `FieldZone` entries to Apollo type policies to disable page merging for the new list fields, consistent with how `Language`, `Partner`, and `User` projects lists are configured
- Lifts the edit button in the User detail page out of the profile card and into the page header, consistent with the pattern used on Language, Field Region, and Field Zone pages