### PR TITLE
Fix Total Row Count on Grid

### DIFF
--- a/docs/data-grid-source.md
+++ b/docs/data-grid-source.md
@@ -1,0 +1,230 @@
+# useDataGridSource
+
+A React hook that connects a GraphQL-backed list to an MUI DataGrid Pro. It
+handles server-side paging, incremental cache accumulation, and an automatic
+switch to fully client-side filtering and sorting once every row has been
+loaded.
+
+---
+
+## Non-technical overview
+
+Every list screen in the app — Projects, Partners, Languages, etc. — shows a
+table of rows. Those rows live on the server, often in the thousands, so the
+app can't download them all at once. Instead it fetches one page at a time as
+the user scrolls.
+
+At the same time, filters and sorts the user applies need to feel instant.
+Waiting for a server round-trip every time someone clicks a column header is
+too slow. So the hook strikes a balance:
+
+- **Before all rows are loaded:** sort and filter requests go to the server,
+  which returns the right page.
+- **After all rows are loaded** (either because the list is small, or because
+  the user has scrolled through everything): the app switches to doing its
+  own sorting and filtering in the browser, with no extra network calls.
+
+The user's sort and filter choices are saved to `localStorage`, scoped to their
+account, so they survive page refreshes and signing out and back in. When the
+user comes back, the table reopens exactly as they left it.
+
+---
+
+## Architecture
+
+Three files collaborate:
+
+| File | Responsibility |
+|---|---|
+| `useViewState.ts` | What the user is looking at (sort column, filter values). Persists to `localStorage`. Converts UI state into GraphQL variables. |
+| `useDataGridSource.tsx` | Orchestrator. Calls the two sub-hooks, handles sort/filter change events, and assembles the final props for `<DataGrid>`. |
+| `useGridFilteredRowCount.ts` | Reactively reads how many rows pass the grid's current client-side filter, used for the "Total Rows" counter. |
+
+```
+useDataGridSource
+├── useViewState          ← "what are we looking at?"
+│   ├── localStorage      ← persist sort + filter across refreshes
+│   └── GraphQL input     ← sort/filter → { sort, order, filter } for the query
+├── useCachedList         ← "fetch it and keep it"
+│   ├── allPages query    ← cache-only read of the accumulated full list
+│   ├── firstPage query   ← live query for page 1 (current sort/filter)
+│   ├── onFetchRows       ← triggered by scroll; fetches pages 2, 3, …
+│   └── row stability     ← prevents blank flash during loading transitions
+└── useGridFilteredRowCount ← reactive client-side row count
+```
+
+---
+
+## useViewState
+
+**What it owns:** sort model, filter model, localStorage persistence, and the
+conversion of those UI values into the `{ sort, order, filter }` input the
+GraphQL query expects.
+
+### Storage key
+
+The key is `<userId>:<operationName>-data-grid-view`, scoped to both the
+authenticated user and the query name so different grids don't collide and
+different users sharing a browser don't see each other's filters.
+Example: `abc123:ProjectList-data-grid-view`.
+
+### What is (and isn't) persisted
+
+Only column types that make sense across sessions are saved:
+
+- `singleSelect` columns (dropdown choices) — **persisted**
+- `boolean` columns (yes/no toggles) — **persisted**
+- Free-text columns — **not persisted** (partial strings often aren't useful
+  after a break, and they can expose sensitive search terms in browser storage)
+
+Sort state is always persisted.
+
+### The `apiFilterModel` field
+
+The stored object keeps a pre-computed `apiFilterModel` alongside the MUI
+`filterModel`. This exists because on the very first render the DataGrid
+hasn't mounted yet, so its API object isn't available to compute the filter
+on the fly. The pre-computed version is used until the grid is ready.
+
+### `apiSortModel` vs `sortModel`
+
+The view tracks two sort models:
+
+- `sortModel` — what the grid column headers show (always up to date).
+- `apiSortModel` — what the first-page API query uses.
+
+When the cache is complete and sorting is done client-side, `apiSortModel`
+can be stale without issue — the server doesn't need to be asked again.
+When the cache is not yet complete, `apiSortModel` is updated alongside
+`sortModel` so the server query uses the current sort.
+
+---
+
+## useCachedList
+
+**What it owns:** all Apollo interaction, page accumulation, and ensuring the
+grid always has stable rows to display.
+
+### The two cache queries
+
+```
+allPages      = cache-only read at variables (no filter)
+allFilteredPages = cache-only read at variablesWithFilter (with filter, skipped when no filter)
+```
+
+Both are `fetchPolicy: 'cache-only'` — they never hit the network. They just
+watch what's already in the Apollo cache.
+
+### How pages accumulate
+
+Every time a page arrives from the network (either the auto-fetched page 1, or
+a scroll-triggered page), `addToAllPagesCache` writes it into the Apollo cache
+under the `queryForItemRef` key. That key is a trimmed version of the query
+that only requests `keyArgs` fields (e.g. `__typename` and `id`), keeping the
+accumulated entry small.
+
+The write merges the new items with any that were previously accumulated,
+de-duplicating by Apollo cache identity. The `total` field is preserved from
+whichever snapshot is authoritative (`updateTotal` flag).
+
+### isCacheComplete
+
+```ts
+isCacheComplete = allPages.isComplete || allFilteredPages.isComplete
+```
+
+`isComplete` is true when `items.length === total`. Once either the unfiltered
+or filtered full list is in cache, the grid switches to client modes for
+`rowsLoadingMode`, `sortingMode`, and `filterMode`.
+
+### Row stability (preventing blank flashes)
+
+Loading transitions can leave the grid temporarily with no data. The fallback
+chain resolves this:
+
+```
+freshList                           // prefer: current data if not mid-load
+  ?? listFrom(prevFirstPage)        // Apollo's previousData during refetch
+  ?? (loading ? prevListRef : null) // skip→active transition (no prevFirstPage)
+  ?? { items: [], total: undefined } // last resort empty state
+```
+
+`prevListRef` is updated whenever a fresh list is available, covering the case
+where switching from a fully-cached filter to an uncached one means Apollo's
+`previousData` is undefined.
+
+### Virtual scroll fetching
+
+`onFetchRows` is called by DataGrid when the user scrolls near unloaded rows.
+It is debounced (500 ms) to coalesce rapid scrolling. It:
+
+1. Calculates which pages cover the visible row range.
+2. Skips page 1 (always fetched by `useQuery`).
+3. Fires `client.query()` for each page in parallel.
+4. On success: calls `unstable_replaceRows` to swap in real data for the
+   skeleton rows, and calls `addToAllPagesCache` to accumulate toward
+   `isCacheComplete`.
+5. Checks `isCurrent` before replacing rows — if sort or filter changed while
+   the request was in flight, the rows are discarded (but the cache is still
+   updated).
+
+---
+
+## Mode switching
+
+The grid operates in one of two modes for filtering, sorting, and row loading:
+
+| Mode | When | Behavior |
+|---|---|---|
+| `server` | `isCacheComplete = false` | DataGrid defers to the app; changes trigger new API queries |
+| `client` | `isCacheComplete = true` | DataGrid handles everything in-browser with the full row set |
+
+`paginationMode` is fixed to `server` when a total is known (preventing an
+MUI warning) and `client` otherwise. It is intentionally not switched on
+`isCacheComplete` — changing `paginationMode` dynamically causes DataGrid to
+reset internally, which produces a visible flash.
+
+### Applying client-side sort after cache completion
+
+When `isCacheComplete` flips to `true`, the rows identity changes (switching
+from the first-page slice to the full list). DataGrid doesn't automatically
+re-sort when both `rows` and mode change at once, so there is an explicit
+`useEffect` that calls `apiRef.current.applySorting()` when `isCacheComplete`
+becomes true.
+
+---
+
+## Row count
+
+```ts
+rowCount = isCacheComplete
+  ? filteredRowCount ?? rows.length
+  : total
+```
+
+- In server mode, `total` comes from the API response.
+- In client mode, `filteredRowCount` comes from `useGridFilteredRowCount`,
+  which subscribes to the DataGrid's internal `stateChange` event via
+  `useSyncExternalStore` and reads `gridFilteredTopLevelRowCountSelector`.
+  This gives a live count that updates as filter values change, without any
+  extra props or state coordination.
+
+---
+
+## Usage example
+
+```tsx
+const [dataGridProps] = useDataGridSource({
+  query: ProjectListDocument,
+  variables: { input: { filter: { status: ['Active'] } } },
+  listAt: 'projects',
+  initialInput: { sort: 'name', order: 'ASC', count: 50 },
+});
+
+return <DataGrid {...dataGridProps} columns={columns} />;
+```
+
+`listAt` is a dot-separated path into the query result where the
+`{ items, total }` object lives. TypeScript enforces that the path resolves
+to a valid `PaginatedListOutput` shape, so typos are caught at compile time.
+

--- a/src/components/Grid/Toolbar.tsx
+++ b/src/components/Grid/Toolbar.tsx
@@ -24,7 +24,7 @@ export const Toolbar = (props: ChildrenProp & StyleProps) => {
       ]}
     >
       {props.children}
-      {rootProps.rowCount && (
+      {rootProps.rowCount != null && (
         <Typography>
           Total Rows: <FormattedNumber value={rootProps.rowCount} />
         </Typography>

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -8,6 +8,7 @@ export * from './ColumnTypes/booleanNullableColumn';
 export * from './ColumnTypes/enumColumn';
 export * from './ColumnTypes/textColumn';
 export * from './useDataGridSource';
+export * from './useViewState';
 export * from './Toolbar';
 export * from './QuickFilters';
 export * from './ColumnTypes/multiEnumColumn';

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -36,12 +36,13 @@ import {
   type SelectionSetNode,
 } from 'graphql';
 import { get, merge, pick, set, uniqBy } from 'lodash';
-import { MutableRefObject, useEffect, useMemo, useState } from 'react';
+import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
 import type { Get, Paths, SetNonNullable } from 'type-fest';
 import { type PaginatedListInput, type SortableListInput } from '~/api';
 import type { Order } from '~/api/schema/schema.graphql';
 import { lowerCase, upperCase } from '~/common';
 import { convertMuiFiltersToApi, FilterShape } from './convertMuiFiltersToApi';
+import { useGridFilteredRowCount } from './useGridFilteredRowCount';
 
 type ListInput = SetNonNullable<
   Required<
@@ -82,6 +83,9 @@ type ViewState = Omit<StoredViewState, 'apiFilterModel'> & {
   apiSortModel: DataGridProps['sortModel'];
 };
 
+// The built-in NoInfer<T> (TS 5.4+) is an intrinsic that TypeScript doesn't
+// resolve through when accessing properties on constrained generics.
+// This identity-type variant works correctly in that context.
 type NoInfer<T> = [T][T extends any ? 0 : never];
 
 export const useDataGridSource = <
@@ -113,6 +117,8 @@ export const useDataGridSource = <
   // eslint-disable-next-line react-hooks/rules-of-hooks -- we'll assume this doesn't change between renders
   const apiRef = apiRefInput ?? useGridApiRef();
 
+  const filteredRowCount = useGridFilteredRowCount(apiRef);
+
   const opName = useMemo(
     () =>
       query.definitions.find(
@@ -120,19 +126,23 @@ export const useDataGridSource = <
       )!.name!.value,
     [query]
   );
-  const queryForItemRef = useMemo(() => {
-    const queryForItemRef = structuredClone(query);
-    const listNode = getFieldPath(
-      getOperationAST(queryForItemRef)!.selectionSet,
-      [...listAt.split('.'), 'items']
-    );
-    listNode.selections = keyArgs.map((field) => ({
-      kind: Kind.FIELD,
-      name: { kind: Kind.NAME, value: field },
-    }));
-    return queryForItemRef;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- these deps should not be changing between renders
-  }, []);
+
+  // Computed once: strip the query down to only keyArgs fields so the
+  // cache-accumulation entries written by updateAllPagesQuery stay small.
+  const queryForItemRef = useRef(
+    (() => {
+      const q = structuredClone(query);
+      const listNode = getFieldPath(
+        getOperationAST(q)!.selectionSet,
+        [...listAt.split('.'), 'items']
+      );
+      listNode.selections = keyArgs.map((field) => ({
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: field },
+      }));
+      return q;
+    })()
+  );
 
   function listFrom(data: Unmasked<Output> | MaybeMasked<Output>): List;
   function listFrom(
@@ -170,7 +180,7 @@ export const useDataGridSource = <
   ) => {
     client.cache.updateQuery(
       {
-        query: queryForItemRef,
+        query: queryForItemRef.current,
         variables,
       },
       (prev) => {
@@ -283,12 +293,12 @@ export const useDataGridSource = <
     return merge({}, variables, { input: rest });
   }, [variables, input]);
 
-  const addToAllPagesCache = (next: MaybeMasked<Output>) => {
+  const addToAllPagesCache = useMemoizedFn((next: MaybeMasked<Output>) => {
     updateAllPagesQuery(variables, next as Unmasked<Output>, !hasFilter);
     if (hasFilter) {
       updateAllPagesQuery(variablesWithFilter, next as Unmasked<Output>, true);
     }
-  };
+  });
 
   const { data: allFilteredPagesData } = useQuery(query, {
     variables: variablesWithFilter,
@@ -301,7 +311,11 @@ export const useDataGridSource = <
     allPages?.isComplete || allFilteredPages?.isComplete || false;
 
   // Grab the first page from cache/network on mount and when view changes
-  const { data: firstPage, loading } = useQuery(query, {
+  const {
+    data: firstPage,
+    loading,
+    previousData: prevFirstPage,
+  } = useQuery(query, {
     skip: isCacheComplete,
     variables: useMemo(
       () => merge({}, variables, { input: { ...input, page: 1 } }),
@@ -310,16 +324,29 @@ export const useDataGridSource = <
   });
   useEffect(() => {
     firstPage && addToAllPagesCache(firstPage);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [firstPage]);
+  }, [firstPage, addToAllPagesCache]);
 
-  const list = loading
-    ? { items: emptyList, total: undefined }
+  const freshList = loading
+    ? undefined
     : allPages?.isComplete
     ? allPages
     : allFilteredPages?.isComplete
     ? allFilteredPages
     : listFrom(firstPage);
+
+  // While loading (filter change, sort change, etc.) fall back to the most
+  // recently known list so the grid stays populated instead of going blank.
+  // prevFirstPage covers the normal Apollo refetch case; prevListRef covers
+  // the skip→active transition where prevFirstPage is unavailable (e.g.
+  // switching from a fully-cached filter to an uncached one).
+  const prevListRef = useRef<typeof freshList>(undefined);
+  const list =
+    freshList ??
+    listFrom(prevFirstPage) ??
+    (loading ? prevListRef.current : undefined) ??
+    { items: emptyList, total: undefined };
+  if (freshList != null) prevListRef.current = freshList;
+
   const rows = list?.items ?? emptyList;
   const total = list?.total && list.total >= 0 ? list.total : undefined;
 
@@ -334,11 +361,11 @@ export const useDataGridSource = <
       }
 
       const { firstRowToRender, lastRowToRender } = params;
-      const firstPage = Math.ceil((firstRowToRender + 1) / input.count);
-      const lastPage = Math.ceil((lastRowToRender + 1) / input.count);
+      const startPage = Math.ceil((firstRowToRender + 1) / input.count);
+      const endPage = Math.ceil((lastRowToRender + 1) / input.count);
       const pages = Array.from(
-        { length: lastPage - firstPage + 1 },
-        (_, i) => firstPage + i
+        { length: endPage - startPage + 1 },
+        (_, i) => startPage + i
       )
         // skip the first page always loaded first by useQuery hook
         .filter((page) => page > 1);
@@ -429,11 +456,13 @@ export const useDataGridSource = <
     }
   }, [apiRef, isCacheComplete]);
 
+  const mode = isCacheComplete ? 'client' : 'server';
+
   const dataGridProps = {
     apiRef,
     rows,
     loading,
-    rowCount: total,
+    rowCount: isCacheComplete ? (filteredRowCount ?? rows.length) : total,
     sortModel: view.sortModel,
     filterModel: view.filterModel,
     hideFooterPagination: true,
@@ -441,9 +470,9 @@ export const useDataGridSource = <
     onSortModelChange,
     onFilterModelChange,
     paginationMode: total != null ? 'server' : 'client', // Not used, but prevents row count warning.
-    rowsLoadingMode: isCacheComplete ? 'client' : 'server',
-    sortingMode: isCacheComplete ? 'client' : 'server',
-    filterMode: isCacheComplete ? 'client' : 'server',
+    rowsLoadingMode: mode,
+    sortingMode: mode,
+    filterMode: mode,
     slots: apiSlots,
     slotProps: apiSlotProps,
   } satisfies Partial<DataGridProps>;

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -132,10 +132,10 @@ export const useDataGridSource = <
   const queryForItemRef = useRef(
     (() => {
       const q = structuredClone(query);
-      const listNode = getFieldPath(
-        getOperationAST(q)!.selectionSet,
-        [...listAt.split('.'), 'items']
-      );
+      const listNode = getFieldPath(getOperationAST(q)!.selectionSet, [
+        ...listAt.split('.'),
+        'items',
+      ]);
       listNode.selections = keyArgs.map((field) => ({
         kind: Kind.FIELD,
         name: { kind: Kind.NAME, value: field },
@@ -340,15 +340,16 @@ export const useDataGridSource = <
   // the skip→active transition where prevFirstPage is unavailable (e.g.
   // switching from a fully-cached filter to an uncached one).
   const prevListRef = useRef<typeof freshList>(undefined);
-  const list =
-    freshList ??
+  const list = freshList ??
     listFrom(prevFirstPage) ??
-    (loading ? prevListRef.current : undefined) ??
-    { items: emptyList, total: undefined };
+    (loading ? prevListRef.current : undefined) ?? {
+      items: emptyList,
+      total: undefined,
+    };
   if (freshList != null) prevListRef.current = freshList;
 
-  const rows = list?.items ?? emptyList;
-  const total = list?.total && list.total >= 0 ? list.total : undefined;
+  const rows = list.items ?? emptyList;
+  const total = list.total && list.total >= 0 ? list.total : undefined;
 
   // Load additional pages imperatively as needed based on scrolling
   // This is debounced to mostly to reduce the client side load.
@@ -462,7 +463,7 @@ export const useDataGridSource = <
     apiRef,
     rows,
     loading,
-    rowCount: isCacheComplete ? (filteredRowCount ?? rows.length) : total,
+    rowCount: isCacheComplete ? filteredRowCount ?? rows.length : total,
     sortModel: view.sortModel,
     filterModel: view.filterModel,
     hideFooterPagination: true,

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -116,9 +116,8 @@ function useCachedList<
     })()
   );
 
-  // Try to pull the complete list from the cache.
-  // This exists after all pages have been queried with the useQuery hook below.
-  // This allows us to do client-side filtering & sorting once we have the complete list.
+  // Two cache-only queries accumulate all pages without hitting the network.
+  // See: docs/data-grid-source.md#the-two-cache-queries
   const { data: allPagesData, client } = useQuery(query, {
     variables,
     fetchPolicy: 'cache-only',
@@ -176,6 +175,7 @@ function useCachedList<
   });
   const allFilteredPages = cacheInfo(allFilteredPagesData);
 
+  // See: docs/data-grid-source.md#iscachecomplete
   const isCacheComplete =
     allPages?.isComplete || allFilteredPages?.isComplete || false;
 
@@ -208,6 +208,7 @@ function useCachedList<
   // prevFirstPage covers the normal Apollo refetch case; prevListRef covers
   // the skip→active transition where prevFirstPage is unavailable (e.g.
   // switching from a fully-cached filter to an uncached one).
+  // See: docs/data-grid-source.md#row-stability-preventing-blank-flashes
   const prevListRef = useRef<typeof freshList>(undefined);
   const list = freshList ??
     listFrom(prevFirstPage) ??
@@ -245,7 +246,9 @@ function useCachedList<
             },
           })
           .then((res) => {
-            // Only apply to rows if the view hasn't changed
+            // Only apply to rows if the view hasn't changed since the request
+            // was fired — stale pages are discarded but still cached.
+            // See: docs/data-grid-source.md#virtual-scroll-fetching
             const isCurrent =
               params.sortModel === viewRef.current.sortModel &&
               params.filterModel === viewRef.current.filterModel;
@@ -372,6 +375,7 @@ export const useDataGridSource = <
   // sorting responsibility ('client').
   // Help it out by asking it to sort (again?) when we give it a different,
   // fully cached, unsorted list.
+  // See: docs/data-grid-source.md#applying-client-side-sort-after-cache-completion
   useEffect(() => {
     if (isCacheComplete) {
       apiRef.current.applySorting();
@@ -384,6 +388,7 @@ export const useDataGridSource = <
     apiRef,
     rows,
     loading,
+    // See: docs/data-grid-source.md#row-count
     rowCount: isCacheComplete ? filteredRowCount ?? rows.length : total,
     sortModel: view.sortModel,
     filterModel: view.filterModel,
@@ -391,7 +396,10 @@ export const useDataGridSource = <
     onFetchRows: onFetchRows.run,
     onSortModelChange,
     onFilterModelChange,
-    paginationMode: total != null ? 'server' : 'client', // Not used, but prevents row count warning.
+    // Not used for pagination; fixed to avoid MUI warning. Intentionally NOT
+    // switched on isCacheComplete — doing so causes an internal DataGrid reset.
+    // See: docs/data-grid-source.md#mode-switching
+    paginationMode: total != null ? 'server' : 'client',
     rowsLoadingMode: mode,
     sortingMode: mode,
     filterMode: mode,

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -7,10 +7,8 @@ import {
 import {
   FilterColumnsArgs,
   GetColumnForNewFilterArgs,
-  GridColType,
   GridLogicOperator,
   GridSlotProps,
-  GridSortItem,
 } from '@mui/x-data-grid';
 import {
   DataGridProProps as DataGridProps,
@@ -20,14 +18,8 @@ import {
   useGridApiContext,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import { groupBy, Nil, setOf } from '@seedcompany/common';
-import {
-  useDebounceFn,
-  useLatest,
-  useLocalStorageState,
-  useMemoizedFn,
-  useTimeout,
-} from 'ahooks';
+import { groupBy, Nil } from '@seedcompany/common';
+import { useDebounceFn, useMemoizedFn, useTimeout } from 'ahooks';
 import {
   type FieldNode,
   getOperationAST,
@@ -37,18 +29,9 @@ import {
 } from 'graphql';
 import { get, merge, pick, set, uniqBy } from 'lodash';
 import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react';
-import type { Get, Paths, SetNonNullable } from 'type-fest';
-import { type PaginatedListInput, type SortableListInput } from '~/api';
-import type { Order } from '~/api/schema/schema.graphql';
-import { lowerCase, upperCase } from '~/common';
-import { convertMuiFiltersToApi, FilterShape } from './convertMuiFiltersToApi';
+import type { Get, Paths } from 'type-fest';
 import { useGridFilteredRowCount } from './useGridFilteredRowCount';
-
-type ListInput = SetNonNullable<
-  Required<
-    SortableListInput & PaginatedListInput & { filter?: Record<string, any> }
-  >
->;
+import { ListInput, useViewState, ViewState } from './useViewState';
 
 interface PaginatedListOutput<T> {
   items: readonly T[];
@@ -63,69 +46,58 @@ type PathsMatching<T, List> = {
     : never;
 }[Paths<T>];
 
-const defaultInitialInput = {
-  count: 25,
-  sort: 'id',
-  order: 'ASC' as Order,
-};
 const defaultKeyArgs = ['__typename', 'id'];
-
-const persistColumnTypes = setOf<GridColType>(['singleSelect', 'boolean']);
-
-type StoredViewState = Pick<DataGridProps, 'filterModel'> & {
-  sortModel: [GridSortItem];
-  apiFilterModel?: FilterShape;
-};
-type ViewState = Omit<StoredViewState, 'apiFilterModel'> & {
-  // The sorting state for the first page API query.
-  // It could be the live sorting state, or a stale one,
-  // based on pagination needs.
-  apiSortModel: DataGridProps['sortModel'];
-};
 
 // The built-in NoInfer<T> (TS 5.4+) is an intrinsic that TypeScript doesn't
 // resolve through when accessing properties on constrained generics.
 // This identity-type variant works correctly in that context.
 type NoInfer<T> = [T][T extends any ? 0 : never];
 
-export const useDataGridSource = <
+const emptyList = [] as const;
+
+// ─── useCachedList ──────────────────────────────────────────────────────────
+// Manages all Apollo cache accumulation, page fetching, and row stability.
+// Returns stable rows/total and an imperative onFetchRows for virtual scrolling.
+
+function useCachedList<
   Output extends Record<string, any>,
-  Vars,
-  Input extends Partial<ListInput>,
-  const Path extends PathsMatching<Output, PaginatedListOutput<any>> & string,
-  List extends PaginatedListOutput<any> = Get<Output, Path> extends infer U
-    ? U extends PaginatedListOutput<any>
-      ? U
-      : never
-    : never
+  Vars extends Record<string, any>
 >({
   query,
   variables,
+  variablesWithFilter,
   listAt,
-  initialInput,
-  keyArgs = defaultKeyArgs,
-  apiRef: apiRefInput,
+  keyArgs,
+  hasFilter,
+  input,
+  viewRef,
+  apiRef,
 }: {
   query: DocumentNode<Output, Vars>;
-  variables: NoInfer<Vars & { input?: Input }>;
-  listAt: Path;
-  initialInput?: Partial<Omit<NoInfer<Input>, 'page'>>;
-  keyArgs?: string[];
-  apiRef?: MutableRefObject<GridApiPro>;
-}) => {
-  const initialInputRef = useLatest(initialInput);
-  // eslint-disable-next-line react-hooks/rules-of-hooks -- we'll assume this doesn't change between renders
-  const apiRef = apiRefInput ?? useGridApiRef();
-
-  const filteredRowCount = useGridFilteredRowCount(apiRef);
-
-  const opName = useMemo(
-    () =>
-      query.definitions.find(
-        (d): d is OperationDefinitionNode => d.kind === 'OperationDefinition'
-      )!.name!.value,
-    [query]
-  );
+  variables: Vars;
+  variablesWithFilter: Vars;
+  listAt: string;
+  keyArgs: string[];
+  hasFilter: boolean;
+  input: { count: number } & Record<string, any>;
+  viewRef: MutableRefObject<ViewState>;
+  apiRef: MutableRefObject<GridApiPro>;
+}) {
+  // Helper: extract the list from a query result
+  function listFrom(
+    data: Unmasked<Output> | MaybeMasked<Output>
+  ): PaginatedListOutput<any>;
+  function listFrom(
+    data: Unmasked<Output> | MaybeMasked<Output> | Nil
+  ): PaginatedListOutput<any> | undefined;
+  function listFrom(data: Unmasked<Output> | MaybeMasked<Output> | Nil) {
+    return data ? (get(data, listAt) as PaginatedListOutput<any>) : undefined;
+  }
+  function cacheInfo(data: MaybeMasked<Output> | Nil) {
+    if (!data) return undefined;
+    const list = listFrom(data);
+    return { ...list, isComplete: list.total === list.items.length };
+  }
 
   // Computed once: strip the query down to only keyArgs fields so the
   // cache-accumulation entries written by updateAllPagesQuery stay small.
@@ -144,25 +116,7 @@ export const useDataGridSource = <
     })()
   );
 
-  function listFrom(data: Unmasked<Output> | MaybeMasked<Output>): List;
-  function listFrom(
-    data: Unmasked<Output> | MaybeMasked<Output> | Nil
-  ): List | undefined;
-  function listFrom(data: Unmasked<Output> | MaybeMasked<Output> | Nil) {
-    return data ? (get(data, listAt) as List) : undefined;
-  }
-  function cacheInfo(data: MaybeMasked<Output> | Nil) {
-    if (!data) {
-      return undefined;
-    }
-    const list = listFrom(data);
-    return {
-      ...list,
-      isComplete: list.total === list.items.length,
-    };
-  }
-
-  // Try to pull the complete list from the cache
+  // Try to pull the complete list from the cache.
   // This exists after all pages have been queried with the useQuery hook below.
   // This allows us to do client-side filtering & sorting once we have the complete list.
   const { data: allPagesData, client } = useQuery(query, {
@@ -172,17 +126,13 @@ export const useDataGridSource = <
   const allPages = cacheInfo(allPagesData);
 
   // Add a page to the "all pages" cache entry
-  // This is read back in the first useQuery hook, above.
   const updateAllPagesQuery = (
-    variables: Vars,
+    vars: Vars,
     next: Unmasked<Output>,
     updateTotal: boolean
   ) => {
     client.cache.updateQuery(
-      {
-        query: queryForItemRef.current,
-        variables,
-      },
+      { query: queryForItemRef.current, variables: vars },
       (prev) => {
         const prevList = listFrom(prev);
         const nextList = listFrom(next);
@@ -211,87 +161,6 @@ export const useDataGridSource = <
       }
     );
   };
-
-  // State for current sorting & filtering
-  const [initialSort] = useState((): ViewState['sortModel'] => [
-    {
-      field: initialInput?.sort ?? defaultInitialInput.sort,
-      sort: lowerCase(initialInput?.order ?? defaultInitialInput.order),
-    },
-  ]);
-  const [storedView, setStoredView] = useLocalStorageState<StoredViewState>(
-    `${opName}-data-grid-view`,
-    {
-      defaultValue: () => ({
-        filterModel: { items: [] },
-        apiFilterModel: {},
-        sortModel: initialSort,
-      }),
-    }
-  );
-  const persist = useDebounceFn((next: ViewState) => {
-    const filterModel = {
-      // Strip out filters for columns that shouldn't be persisted
-      items:
-        next.filterModel?.items.filter((item) =>
-          persistColumnTypes.has(apiRef.current.getColumn(item.field).type!)
-        ) ?? [],
-    };
-    setStoredView({
-      sortModel: next.sortModel,
-      filterModel,
-      apiFilterModel: convertMuiFiltersToApi(
-        apiRef.current,
-        filterModel,
-        initialInputRef.current?.filter
-      ),
-    });
-  });
-  const [view, reallySetView] = useState((): ViewState => {
-    const { apiFilterModel: _, ...rest } = storedView!; // not null because we give a default value
-    return {
-      ...rest,
-      apiSortModel: rest.sortModel,
-    };
-  });
-  const setView = (setter: (prev: ViewState) => ViewState) => {
-    reallySetView((prev) => {
-      const next = setter(prev);
-      persist.run(next);
-      return next;
-    });
-  };
-
-  const viewRef = useLatest(view);
-  const hasFilter = !!view.filterModel && view.filterModel.items.length > 0;
-
-  // Convert the view state to the input for the GQL query
-  const input = useMemo(
-    () => ({
-      ...defaultInitialInput,
-      ...initialInputRef.current,
-      count: initialInputRef.current?.count ?? defaultInitialInput.count,
-      ...(view.apiSortModel?.[0] && {
-        sort: view.apiSortModel[0].field,
-        order: upperCase(view.apiSortModel[0].sort!),
-      }),
-      // eslint-disable-next-line no-extra-boolean-cast
-      filter: Boolean(apiRef.current.instanceId)
-        ? convertMuiFiltersToApi(
-            apiRef.current,
-            view.filterModel,
-            initialInputRef.current?.filter
-          )
-        : storedView?.apiFilterModel,
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [apiRef, initialInputRef, view.apiSortModel, view.filterModel]
-  );
-  const variablesWithFilter = useMemo(() => {
-    const { count, sort, order, ...rest } = input;
-
-    return merge({}, variables, { input: rest });
-  }, [variables, input]);
 
   const addToAllPagesCache = useMemoizedFn((next: MaybeMasked<Output>) => {
     updateAllPagesQuery(variables, next as Unmasked<Output>, !hasFilter);
@@ -348,18 +217,14 @@ export const useDataGridSource = <
     };
   if (freshList != null) prevListRef.current = freshList;
 
-  const rows = list.items ?? emptyList;
+  const rows = list.items;
   const total = list.total && list.total >= 0 ? list.total : undefined;
 
-  // Load additional pages imperatively as needed based on scrolling
-  // This is debounced to mostly to reduce the client side load.
-  // It is theoretical as well that some pages could be scrolled past,
-  // and the debouncing would skip those page requests.
+  // Load additional pages imperatively as needed based on scrolling.
+  // Debounced to reduce client-side load and skip fast-scrolled pages.
   const onFetchRows = useDebounceFn(
     (params: GridFetchRowsParams) => {
-      if (isCacheComplete) {
-        return;
-      }
+      if (isCacheComplete) return;
 
       const { firstRowToRender, lastRowToRender } = params;
       const startPage = Math.ceil((firstRowToRender + 1) / input.count);
@@ -368,7 +233,7 @@ export const useDataGridSource = <
         { length: endPage - startPage + 1 },
         (_, i) => startPage + i
       )
-        // skip the first page always loaded first by useQuery hook
+        // skip the first page always loaded by useQuery above
         .filter((page) => page > 1);
 
       for (const page of pages) {
@@ -385,21 +250,76 @@ export const useDataGridSource = <
               params.sortModel === viewRef.current.sortModel &&
               params.filterModel === viewRef.current.filterModel;
             if (isCurrent) {
-              // Swap in real rows via the recommended process.
               const firstRowToReplace = (page - 1) * input.count;
               const list = listFrom(res.data).items.slice();
               apiRef.current.unstable_replaceRows(firstRowToReplace, list);
             }
-
             // Always try to complete the list in cache.
             addToAllPagesCache(res.data);
           });
       }
     },
-    {
-      wait: 500,
-    }
+    { wait: 500 }
   );
+
+  return { rows, total, loading, isCacheComplete, onFetchRows };
+}
+
+// ─── useDataGridSource ───────────────────────────────────────────────────────
+
+export const useDataGridSource = <
+  Output extends Record<string, any>,
+  Vars,
+  Input extends Partial<ListInput>,
+  const Path extends PathsMatching<Output, PaginatedListOutput<any>> & string
+>({
+  query,
+  variables,
+  listAt,
+  initialInput,
+  keyArgs = defaultKeyArgs,
+  apiRef: apiRefInput,
+}: {
+  query: DocumentNode<Output, Vars>;
+  variables: NoInfer<Vars & { input?: Input }>;
+  listAt: Path;
+  initialInput?: Partial<Omit<NoInfer<Input>, 'page'>>;
+  keyArgs?: string[];
+  apiRef?: MutableRefObject<GridApiPro>;
+}) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- we'll assume this doesn't change between renders
+  const apiRef = apiRefInput ?? useGridApiRef();
+  const filteredRowCount = useGridFilteredRowCount(apiRef);
+
+  const opName = useMemo(
+    () =>
+      query.definitions.find(
+        (d): d is OperationDefinitionNode => d.kind === 'OperationDefinition'
+      )!.name!.value,
+    [query]
+  );
+
+  const {
+    view,
+    setView,
+    viewRef,
+    hasFilter,
+    input,
+    variablesWithFilter,
+    initialSort,
+  } = useViewState({ opName, initialInput, apiRef, variables });
+
+  const { rows, total, loading, isCacheComplete, onFetchRows } = useCachedList({
+    query,
+    variables,
+    variablesWithFilter,
+    listAt,
+    keyArgs,
+    hasFilter,
+    input,
+    viewRef,
+    apiRef,
+  });
 
   const onSortModelChange: DataGridProps['onSortModelChange'] & {} =
     useMemoizedFn((next) => {
@@ -427,6 +347,7 @@ export const useDataGridSource = <
 
       apiRef.current.scrollToIndexes({ rowIndex: 0 });
     });
+
   const onFilterModelChange: DataGridProps['onFilterModelChange'] & {} =
     useMemoizedFn((filterModel) => {
       const next = {
@@ -481,7 +402,7 @@ export const useDataGridSource = <
   return [dataGridProps] as const;
 };
 
-const emptyList = [] as const;
+// ─── Utilities ───────────────────────────────────────────────────────────────
 
 const getFieldPath = (
   x: SelectionSetNode,

--- a/src/components/Grid/useGridFilteredRowCount.ts
+++ b/src/components/Grid/useGridFilteredRowCount.ts
@@ -6,6 +6,8 @@ import { MutableRefObject, useSyncExternalStore } from 'react';
  * Reactively reads the number of top-level rows that pass the DataGrid's
  * current client-side filter. Safe to call before the grid has mounted —
  * returns undefined until the grid initialises.
+ *
+ * See: docs/data-grid-source.md#row-count
  */
 export function useGridFilteredRowCount(apiRef: MutableRefObject<GridApiPro>) {
   return useSyncExternalStore(

--- a/src/components/Grid/useGridFilteredRowCount.ts
+++ b/src/components/Grid/useGridFilteredRowCount.ts
@@ -1,0 +1,26 @@
+import { gridFilteredTopLevelRowCountSelector } from '@mui/x-data-grid';
+import { GridApiPro } from '@mui/x-data-grid-pro';
+import { MutableRefObject, useSyncExternalStore } from 'react';
+
+/**
+ * Reactively reads the number of top-level rows that pass the DataGrid's
+ * current client-side filter. Safe to call before the grid has mounted —
+ * returns undefined until the grid initialises.
+ */
+export function useGridFilteredRowCount(apiRef: MutableRefObject<GridApiPro>) {
+  return useSyncExternalStore(
+    (callback) =>
+      apiRef.current.subscribeEvent
+        ? apiRef.current.subscribeEvent('stateChange', callback)
+        : () => {},
+    () => {
+      try {
+        if (!apiRef.current.instanceId) return undefined;
+        return gridFilteredTopLevelRowCountSelector(apiRef);
+      } catch {
+        return undefined;
+      }
+    },
+    () => undefined as number | undefined,
+  );
+}

--- a/src/components/Grid/useGridFilteredRowCount.ts
+++ b/src/components/Grid/useGridFilteredRowCount.ts
@@ -9,18 +9,14 @@ import { MutableRefObject, useSyncExternalStore } from 'react';
  */
 export function useGridFilteredRowCount(apiRef: MutableRefObject<GridApiPro>) {
   return useSyncExternalStore(
-    (callback) =>
-      apiRef.current.subscribeEvent
-        ? apiRef.current.subscribeEvent('stateChange', callback)
-        : () => {},
+    (callback) => apiRef.current.subscribeEvent('stateChange', callback),
     () => {
       try {
-        if (!apiRef.current.instanceId) return undefined;
         return gridFilteredTopLevelRowCountSelector(apiRef);
       } catch {
         return undefined;
       }
     },
-    () => undefined as number | undefined,
+    () => undefined as number | undefined
   );
 }

--- a/src/components/Grid/useViewState.ts
+++ b/src/components/Grid/useViewState.ts
@@ -1,0 +1,148 @@
+import { GridColType, GridSortItem } from '@mui/x-data-grid';
+import {
+  DataGridProProps as DataGridProps,
+  GridApiPro,
+} from '@mui/x-data-grid-pro';
+import { setOf } from '@seedcompany/common';
+import { useDebounceFn, useLatest, useLocalStorageState } from 'ahooks';
+import { merge } from 'lodash';
+import { MutableRefObject, useMemo, useState } from 'react';
+import type { SetNonNullable } from 'type-fest';
+import type { PaginatedListInput, SortableListInput } from '~/api';
+import type { Order } from '~/api/schema/schema.graphql';
+import { lowerCase, upperCase } from '~/common';
+import { useSession } from '../Session/Session';
+import { convertMuiFiltersToApi, FilterShape } from './convertMuiFiltersToApi';
+
+export type ListInput = SetNonNullable<
+  Required<
+    SortableListInput & PaginatedListInput & { filter?: Record<string, any> }
+  >
+>;
+
+export const defaultInitialInput = {
+  count: 25,
+  sort: 'id',
+  order: 'ASC' as Order,
+};
+
+const persistColumnTypes = setOf<GridColType>(['singleSelect', 'boolean']);
+
+export type StoredViewState = Pick<DataGridProps, 'filterModel'> & {
+  sortModel: [GridSortItem];
+  apiFilterModel?: FilterShape;
+};
+
+export type ViewState = Omit<StoredViewState, 'apiFilterModel'> & {
+  // The sorting state for the first page API query.
+  // It could be the live sorting state, or a stale one,
+  // based on pagination needs.
+  apiSortModel: DataGridProps['sortModel'];
+};
+
+export function useViewState<Vars extends { input?: any }>({
+  opName,
+  initialInput,
+  apiRef,
+  variables,
+}: {
+  opName: string;
+  initialInput: Partial<Omit<ListInput, 'page'>> | undefined;
+  apiRef: MutableRefObject<GridApiPro>;
+  variables: Vars;
+}) {
+  const initialInputRef = useLatest(initialInput);
+
+  const [initialSort] = useState((): ViewState['sortModel'] => [
+    {
+      field: initialInput?.sort ?? defaultInitialInput.sort,
+      sort: lowerCase(initialInput?.order ?? defaultInitialInput.order),
+    },
+  ]);
+
+  const { session } = useSession();
+
+  const [storedView, setStoredView] = useLocalStorageState<StoredViewState>(
+    `${session?.id}:${opName}-data-grid-view`,
+    {
+      defaultValue: () => ({
+        filterModel: { items: [] },
+        apiFilterModel: {},
+        sortModel: initialSort,
+      }),
+    }
+  );
+
+  const persist = useDebounceFn((next: ViewState) => {
+    const filterModel = {
+      // Strip out filters for columns that shouldn't be persisted
+      items:
+        next.filterModel?.items.filter((item) =>
+          persistColumnTypes.has(apiRef.current.getColumn(item.field).type!)
+        ) ?? [],
+    };
+    setStoredView({
+      sortModel: next.sortModel,
+      filterModel,
+      apiFilterModel: convertMuiFiltersToApi(
+        apiRef.current,
+        filterModel,
+        initialInputRef.current?.filter
+      ),
+    });
+  });
+
+  const [view, reallySetView] = useState((): ViewState => {
+    const { apiFilterModel: _, ...rest } = storedView!; // not null: defaultValue is always provided
+    return { ...rest, apiSortModel: rest.sortModel };
+  });
+
+  const setView = (setter: (prev: ViewState) => ViewState) => {
+    reallySetView((prev) => {
+      const next = setter(prev);
+      persist.run(next);
+      return next;
+    });
+  };
+
+  const viewRef = useLatest(view);
+  const hasFilter = !!view.filterModel && view.filterModel.items.length > 0;
+
+  // Convert the view state to the input for the GQL query
+  const input = useMemo(
+    () => ({
+      ...defaultInitialInput,
+      ...initialInputRef.current,
+      count: initialInputRef.current?.count ?? defaultInitialInput.count,
+      ...(view.apiSortModel?.[0] && {
+        sort: view.apiSortModel[0].field,
+        order: upperCase(view.apiSortModel[0].sort!),
+      }),
+      // eslint-disable-next-line no-extra-boolean-cast
+      filter: Boolean(apiRef.current.instanceId)
+        ? convertMuiFiltersToApi(
+            apiRef.current,
+            view.filterModel,
+            initialInputRef.current?.filter
+          )
+        : storedView?.apiFilterModel,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [apiRef, initialInputRef, view.apiSortModel, view.filterModel]
+  );
+
+  const variablesWithFilter = useMemo(() => {
+    const { count, sort, order, ...rest } = input;
+    return merge({}, variables, { input: rest }) as Vars;
+  }, [variables, input]);
+
+  return {
+    view,
+    setView,
+    viewRef,
+    hasFilter,
+    input,
+    variablesWithFilter,
+    initialSort,
+  };
+}

--- a/src/components/Grid/useViewState.ts
+++ b/src/components/Grid/useViewState.ts
@@ -26,10 +26,14 @@ export const defaultInitialInput = {
   order: 'ASC' as Order,
 };
 
+// Only singleSelect and boolean columns are persisted across sessions.
+// See: docs/data-grid-source.md#what-is-and-isnt-persisted
 const persistColumnTypes = setOf<GridColType>(['singleSelect', 'boolean']);
 
 export type StoredViewState = Pick<DataGridProps, 'filterModel'> & {
   sortModel: [GridSortItem];
+  // Pre-computed so it's available before the grid mounts on first render.
+  // See: docs/data-grid-source.md#the-apifiltermodel-field
   apiFilterModel?: FilterShape;
 };
 
@@ -37,6 +41,7 @@ export type ViewState = Omit<StoredViewState, 'apiFilterModel'> & {
   // The sorting state for the first page API query.
   // It could be the live sorting state, or a stale one,
   // based on pagination needs.
+  // See: docs/data-grid-source.md#apisortmodel-vs-sortmodel
   apiSortModel: DataGridProps['sortModel'];
 };
 
@@ -62,6 +67,8 @@ export function useViewState<Vars extends { input?: any }>({
 
   const { session } = useSession();
 
+  // Key format: `<userId>:<operationName>-data-grid-view`
+  // See: docs/data-grid-source.md#storage-key
   const [storedView, setStoredView] = useLocalStorageState<StoredViewState>(
     `${session?.id}:${opName}-data-grid-view`,
     {


### PR DESCRIPTION
### **Row count not updating on client-side filter**

When all pages were cached (isCacheComplete), the grid switched to client-side filtering but rowCount still reflected the server total. The fix subscribes to the grid's internal state via useSyncExternalStore + gridFilteredTopLevelRowCountSelector so the toolbar's "Total Rows" count updates reactively as filters are applied. The subscription is extracted into a reusable useGridFilteredRowCount hook. Also fixes Toolbar.tsx using && on rowCount, which suppressed the label when the count was 0.

### **Grid flashing blank on filter change**

**Two causes:**
paginationMode was made dynamic based on isCacheComplete. When switching from a fully-cached filter to an uncached one, isCacheComplete flips and MUI DataGrid received paginationMode, filterMode, sortingMode, and rowsLoadingMode all changing in the same render — triggering an internal grid reset. paginationMode is now stable again.
While a filter refetch was in flight, rows was cleared to [], blanking the grid. Now it falls back through Apollo's previousData → a prevListRef (last known list), keeping the grid populated under the loading indicator. The prevListRef covers the skip→active transition case where previousData is unavailable (e.g. switching from a fully-cached filter to a new one).

### Refactors in useDataGridSource

queryForItemRef: useMemo(…, []) + eslint-disable → useRef with IIFE (one-time init, not derived state)
addToAllPagesCache: wrapped in useMemoizedFn for a stable reference; useEffect dep list is now correct and its eslint-disable is removed
const mode: collapsed three repeated isCacheComplete ? 'client' : 'server' ternaries
Renamed firstPage/lastPage inside onFetchRows to startPage/endPage (shadowed the outer firstPage data variable)
Restored and documented local NoInfer<T> — the TS 5.4 built-in doesn't resolve through property access on constrained generics in this pattern