### PR TITLE
Use context for Session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { LuxonCalenderDateUtils } from './common/LuxonCalenderDateUtils';
 import { CommentsProvider } from './components/Comments/CommentsContext';
 import { ConfettiProvider } from './components/Confetti';
 import { Nest } from './components/Nest';
+import { SessionProvider } from './components/Session';
 import { SnackbarProvider } from './components/Snackbar';
 import { UploadProvider as FileUploadProvider } from './components/Upload';
 import { Root } from './scenes/Root';
@@ -52,6 +53,7 @@ export const appProviders = [
   <LocalizationProvider key="i10n" dateAdapter={LuxonCalenderDateUtils} />,
   <SnackbarProvider key="snackbar" />, // needed by apollo
   <ApolloProvider key="apollo" />,
+  <SessionProvider key="session" />,
   <FileUploadProvider key="files" />,
   <ConfettiProvider key="confetti" />,
   <CommentsProvider key="comments" />,

--- a/src/components/Session/Session.tsx
+++ b/src/components/Session/Session.tsx
@@ -3,7 +3,9 @@ import { useAsyncEffect } from 'ahooks';
 import { pickBy } from 'lodash';
 import { PostHog } from 'posthog-js';
 import { usePostHog } from 'posthog-js/react';
+import { createContext, useContext } from 'react';
 import { SessionOutput } from '~/api/schema.graphql';
+import { ChildrenProp } from '~/common';
 import { LoginMutation } from '../../scenes/Authentication/Login/Login.graphql';
 import { RegisterMutation } from '../../scenes/Authentication/Register/register.graphql';
 import {
@@ -12,10 +14,24 @@ import {
   SessionDocument,
 } from './session.graphql';
 
-export const useSession = () => {
-  const { data, loading: sessionLoading } = useQuery(SessionDocument, {
+const useSessionQuery = () =>
+  useQuery(SessionDocument, {
     ssr: true,
   });
+
+const SessionContext = createContext<
+  ReturnType<typeof useSessionQuery> | undefined
+>(undefined);
+
+export const SessionProvider = ({ children }: ChildrenProp) => {
+  const result = useSessionQuery();
+  return (
+    <SessionContext.Provider value={result}>{children}</SessionContext.Provider>
+  );
+};
+
+export const useSession = () => {
+  const { data, loading: sessionLoading } = useContext(SessionContext)!;
   const session = data?.session.user;
   const impersonator = data?.session.impersonator;
   const powers = data?.session.powers;


### PR DESCRIPTION
Mainly so this doesn't duplicate active queries in apollo dev tools.
Idk if this will help performance at all..maybe a little better?