### PR TITLE
Upload Multiplication Project Progress Reports

### DIFF
--- a/src/components/PeriodicReports/OverviewCard/PeriodicReportCard.tsx
+++ b/src/components/PeriodicReports/OverviewCard/PeriodicReportCard.tsx
@@ -1,4 +1,4 @@
-import { AssignmentOutlined, BarChart, ShowChart } from '@mui/icons-material';
+import { AssignmentOutlined, ShowChart } from '@mui/icons-material';
 import {
   Box,
   Button,
@@ -60,6 +60,7 @@ const PeriodicReportCardInContext = (props: PeriodicReportCardProps) => {
     isDragActive,
     open: openFileBrowser,
   } = useDropzone({
+    accept: type === 'Progress' ? { 'application/pdf': ['.pdf'] } : undefined,
     onDrop: (files) => {
       if (!currentFile?.canEdit) {
         return;
@@ -79,20 +80,19 @@ const PeriodicReportCardInContext = (props: PeriodicReportCardProps) => {
         className={props.className}
         sx={props.sx}
       >
-        <PeriodicReportCardContent to={link} icon={!disableIcon}>
-          {!disableIcon && (
+        <PeriodicReportCardContent to={link} icon={!disableIcon} type={type}>
+          {!disableIcon && type !== 'Progress' && (
             <HugeIcon
               icon={simpleSwitch(type, {
                 Narrative: AssignmentOutlined,
                 Financial: ShowChart,
-                Progress: BarChart,
               })}
               sx={{ gridArea: 'icon' }}
             />
           )}
 
-          <Typography variant="h4" sx={{ gridArea: 'title' }}>
-            {`${type} Reports`}
+          <Typography variant="h4" paragraph sx={{ gridArea: 'title' }}>
+            {`${type === 'Progress' ? 'Quarterly' : type} Reports`}
           </Typography>
           <ReportInfoContainer
             horizontalAt={260}
@@ -175,40 +175,49 @@ const PeriodicReportCardRoot = styled(Card)({
 
 const PeriodicReportCardContent = ({
   icon,
+  type,
   ...props
-}: CardActionAreaLinkProps & { icon: boolean }) => (
-  <CardActionAreaLink
-    {...props}
-    sx={[
-      {
-        flex: 1,
-        py: 3,
-        px: 4,
-        display: 'grid',
-        gap: 3,
-        gridTemplateColumns: 'min-content 1fr',
+}: CardActionAreaLinkProps & { icon: boolean; type: ReportType }) => {
+  const multiplicationProgressReportCardSx = {
+    p: 2,
+  };
+  const narrativeOrFinancialReportCardSx = {
+    flex: 1,
+    py: 3,
+    px: 4,
+    display: 'grid',
+    gap: 3,
+    gridTemplateColumns: 'min-content 1fr',
+    ...gridTemplateAreas`
+                title title
+                info info
+              `,
+    ...(icon && {
+      ...gridTemplateAreas`
+                icon title
+                info info
+              `,
+      [`@container (min-width: 430px)`]: {
         ...gridTemplateAreas`
-          title title
-          info info
-        `,
-        ...(icon && {
-          ...gridTemplateAreas`
-            icon title
-            info info
-          `,
-          [`@container (min-width: 430px)`]: {
-            ...gridTemplateAreas`
-              icon title
-              icon info
-            `,
-            '.MuiAvatar-root': { alignSelf: 'start' },
-          },
-        }),
+                  icon title
+                  icon info
+                `,
+        '.MuiAvatar-root': { alignSelf: 'start' },
       },
-      ...extendSx(props.sx),
-    ]}
-  />
-);
+    }),
+  };
+  return (
+    <CardActionAreaLink
+      {...props}
+      sx={[
+        type === 'Progress'
+          ? multiplicationProgressReportCardSx
+          : narrativeOrFinancialReportCardSx,
+        ...extendSx(props.sx),
+      ]}
+    />
+  );
+};
 
 export const PeriodicReportCard = (props: PeriodicReportCardProps) => (
   <FileActionsContextProvider>

--- a/src/components/ProgressReportsOverviewCard/ProgressReportOverview.graphql
+++ b/src/components/ProgressReportsOverviewCard/ProgressReportOverview.graphql
@@ -3,11 +3,26 @@ fragment ProgressReportOverviewItem on ProgressReport {
   start
   end
   due
+  type
+  reportFile {
+    canEdit
+    canRead
+    value {
+      ...FileNodeInfo
+    }
+  }
+  receivedDate {
+    canRead
+    canEdit
+    value
+  }
   status {
     value
   }
   skippedReason {
     value
+    canEdit
+    canRead
   }
 }
 

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -1,6 +1,7 @@
 import { Add } from '@mui/icons-material';
 import { Card, Grid, Tooltip, Typography } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
+import { PeriodicReportCard } from '~/components/PeriodicReports';
 import { ProgressReportsOverviewCard } from '../../../components/ProgressReportsOverviewCard/ProgressReportsOverviewCard';
 import { ResponsiveDivider } from '../../../components/ResponsiveDivider';
 import { FabLink } from '../../../components/Routing';
@@ -49,6 +50,9 @@ export const LanguageEngagementDetail = ({ engagement }: EngagementQuery) => {
     return null; // easiest for typescript
   }
 
+  const isMultiplication =
+    engagement.project.__typename === 'MultiplicationTranslationProject';
+
   return (
     <div className={classes.root}>
       <Grid
@@ -63,10 +67,18 @@ export const LanguageEngagementDetail = ({ engagement }: EngagementQuery) => {
           <Grid item lg={5} container direction="column" spacing={3}>
             <Grid item container spacing={3}>
               <Grid item container className={classes.details}>
-                <ProgressReportsOverviewCard
-                  dueCurrently={engagement.currentProgressReportDue}
-                  dueNext={engagement.nextProgressReportDue}
-                />
+                {isMultiplication ? (
+                  <PeriodicReportCard
+                    type="Progress"
+                    dueCurrently={engagement.currentProgressReportDue}
+                    dueNext={engagement.nextProgressReportDue}
+                  />
+                ) : (
+                  <ProgressReportsOverviewCard
+                    dueCurrently={engagement.currentProgressReportDue}
+                    dueNext={engagement.nextProgressReportDue}
+                  />
+                )}
               </Grid>
               <Grid item container className={classes.details}>
                 <PlanningSpreadsheet engagement={engagement} />

--- a/src/scenes/ProgressReports/List/ProgressReportListItem.graphql
+++ b/src/scenes/ProgressReports/List/ProgressReportListItem.graphql
@@ -1,5 +1,6 @@
 fragment ProgressReportListItem on ProgressReport {
   ...Id
+  type
   start
   end
   due
@@ -7,6 +8,18 @@ fragment ProgressReportListItem on ProgressReport {
     value
     canEdit
     canRead
+  }
+  reportFile {
+    canEdit
+    canRead
+    value {
+      ...FileNodeInfo
+    }
+  }
+  receivedDate {
+    canRead
+    canEdit
+    value
   }
   status {
     value

--- a/src/scenes/ProgressReports/List/ProgressReportListPage.tsx
+++ b/src/scenes/ProgressReports/List/ProgressReportListPage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/client';
+import { PeriodicReportsTable } from '~/components/PeriodicReports/PeriodicReportsTable';
 import { useChangesetAwareIdFromUrl } from '../../../components/Changeset';
 import { EngagementBreadcrumb } from '../../../components/EngagementBreadcrumb';
 import { Error } from '../../../components/Error';
@@ -33,6 +34,9 @@ export const ProgressReportListPage = () => {
       ? data.engagement
       : undefined;
 
+  const isMultiplication =
+    engagement?.project.__typename === 'MultiplicationTranslationProject';
+
   return (
     <PeriodicReportListLayout
       type="Progress"
@@ -42,13 +46,19 @@ export const ProgressReportListPage = () => {
         <EngagementBreadcrumb key="engagement" data={engagement} />,
       ]}
       TableCardProps={{
-        sx: { maxWidth: 400 },
+        sx: {
+          maxWidth: !isMultiplication ? 400 : undefined,
+        },
       }}
     >
-      <ProgressReportsTable
-        loading={!engagement}
-        rows={engagement?.progressReports.items ?? []}
-      />
+      {isMultiplication ? (
+        <PeriodicReportsTable data={engagement.progressReports.items} />
+      ) : (
+        <ProgressReportsTable
+          loading={!engagement}
+          rows={engagement?.progressReports.items ?? []}
+        />
+      )}
     </PeriodicReportListLayout>
   );
 };


### PR DESCRIPTION
This allows for users to upload their multiplication project quarterly reports.  Changes are found in both the overview card and the report list, with similar styling to the Financial or Narrative reports found directly on the Project page.