### PR TITLE
Update Language Detail Page with Tab Layout

### DIFF
--- a/src/api/schema/typePolicies/typePolicies.base.ts
+++ b/src/api/schema/typePolicies/typePolicies.base.ts
@@ -37,6 +37,7 @@ export const typePolicies: TypePolicies = {
     fields: {
       ethnologue: { merge: true },
       locations: {},
+      projects: {},
     },
   },
   EthnologueLanguage: { keyFields: false },

--- a/src/api/schema/typePolicies/typePolicies.base.ts
+++ b/src/api/schema/typePolicies/typePolicies.base.ts
@@ -36,6 +36,7 @@ export const typePolicies: TypePolicies = {
   Language: {
     fields: {
       ethnologue: { merge: true },
+      locations: {},
     },
   },
   EthnologueLanguage: { keyFields: false },

--- a/src/components/Grid/createAddItemFooter.tsx
+++ b/src/components/Grid/createAddItemFooter.tsx
@@ -1,0 +1,62 @@
+import { Add } from '@mui/icons-material';
+import { Button, Stack, Tooltip } from '@mui/material';
+
+export interface AddItemFooterOptions {
+  addItem: () => void;
+  label?: string;
+  tooltipTitle?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Factory function that creates a footer component for DataGrid with an add button.
+ * Use this to create a footer slot for MUI DataGrid that allows adding new items.
+ *
+ * @example
+ * ```tsx
+ * const slots = useMemo(
+ *   () => ({
+ *     footer: createAddItemFooter({
+ *       addItem: handleAdd,
+ *       label: 'Add Location',
+ *     }),
+ *   }),
+ *   [handleAdd]
+ * );
+ * ```
+ */
+export const createAddItemFooter = ({
+  addItem,
+  label,
+  tooltipTitle,
+  disabled = false,
+}: AddItemFooterOptions) => {
+  return () => {
+    return (
+      <Stack
+        sx={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          background: 'var(--DataGrid-containerBackground)',
+          p: 1,
+          borderTop: 'thin solid var(--DataGrid-rowBorderColor)',
+          borderBottomLeftRadius: 'inherit',
+          borderBottomRightRadius: 'inherit',
+        }}
+      >
+        <Tooltip title={tooltipTitle || label}>
+          <Button
+            onClick={addItem}
+            disabled={disabled}
+            variant="outlined"
+            color="primary"
+            size="small"
+            sx={{ minWidth: 'auto', px: 1 }}
+          >
+            <Add />
+          </Button>
+        </Tooltip>
+      </Stack>
+    );
+  };
+};

--- a/src/components/Grid/createAddItemFooter.tsx
+++ b/src/components/Grid/createAddItemFooter.tsx
@@ -31,35 +31,39 @@ export const createAddItemFooter = ({
   tooltipTitle,
   disabled = false,
 }: AddItemFooterOptions) => {
-  const Footer = () => (
-    <Stack
-      sx={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        background: 'var(--DataGrid-containerBackground)',
-        p: 1,
-        borderTop: 'thin solid var(--DataGrid-rowBorderColor)',
-        borderBottomLeftRadius: 'inherit',
-        borderBottomRightRadius: 'inherit',
-      }}
-    >
-      <Tooltip title={tooltipTitle || label}>
-        <span>
-          {/* span is needed to wrap disabled button for tooltip to work */}
-          <Button
-            onClick={addItem}
-            disabled={disabled}
-            variant="outlined"
-            color="primary"
-            size="small"
-            sx={{ minWidth: 'auto', px: 1 }}
-          >
-            <Add />
-          </Button>
-        </span>
-      </Tooltip>
-    </Stack>
-  );
+  const Footer = () => {
+    const title = tooltipTitle ?? label;
+    const button = (
+      <span>
+        {/* span is needed to wrap disabled button for tooltip to work */}
+        <Button
+          onClick={addItem}
+          disabled={disabled}
+          variant="outlined"
+          color="primary"
+          size="small"
+          sx={{ minWidth: 'auto', px: 1 }}
+        >
+          <Add />
+        </Button>
+      </span>
+    );
+    return (
+      <Stack
+        sx={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          background: 'var(--DataGrid-containerBackground)',
+          p: 1,
+          borderTop: 'thin solid var(--DataGrid-rowBorderColor)',
+          borderBottomLeftRadius: 'inherit',
+          borderBottomRightRadius: 'inherit',
+        }}
+      >
+        {title ? <Tooltip title={title}>{button}</Tooltip> : button}
+      </Stack>
+    );
+  };
   Footer.displayName = 'AddItemFooter';
   return Footer;
 };

--- a/src/components/Grid/createAddItemFooter.tsx
+++ b/src/components/Grid/createAddItemFooter.tsx
@@ -31,20 +31,21 @@ export const createAddItemFooter = ({
   tooltipTitle,
   disabled = false,
 }: AddItemFooterOptions) => {
-  return () => {
-    return (
-      <Stack
-        sx={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          background: 'var(--DataGrid-containerBackground)',
-          p: 1,
-          borderTop: 'thin solid var(--DataGrid-rowBorderColor)',
-          borderBottomLeftRadius: 'inherit',
-          borderBottomRightRadius: 'inherit',
-        }}
-      >
-        <Tooltip title={tooltipTitle || label}>
+  const Footer = () => (
+    <Stack
+      sx={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        background: 'var(--DataGrid-containerBackground)',
+        p: 1,
+        borderTop: 'thin solid var(--DataGrid-rowBorderColor)',
+        borderBottomLeftRadius: 'inherit',
+        borderBottomRightRadius: 'inherit',
+      }}
+    >
+      <Tooltip title={tooltipTitle || label}>
+        <span>
+          {/* span is needed to wrap disabled button for tooltip to work */}
           <Button
             onClick={addItem}
             disabled={disabled}
@@ -55,8 +56,10 @@ export const createAddItemFooter = ({
           >
             <Add />
           </Button>
-        </Tooltip>
-      </Stack>
-    );
-  };
+        </span>
+      </Tooltip>
+    </Stack>
+  );
+  Footer.displayName = 'AddItemFooter';
+  return Footer;
 };

--- a/src/components/Grid/createIconActionColumn.tsx
+++ b/src/components/Grid/createIconActionColumn.tsx
@@ -1,0 +1,63 @@
+import { IconButton, Tooltip } from '@mui/material';
+import type { GridColDef, GridValidRowModel } from '@mui/x-data-grid-pro';
+import type { ReactNode } from 'react';
+
+type ValueOrFactory<Row extends GridValidRowModel, T> = T | ((row: Row) => T);
+
+export interface CreateIconActionColumnOptions<Row extends GridValidRowModel> {
+  field?: string;
+  headerName?: string;
+  width?: number;
+  align?: 'left' | 'center' | 'right';
+  tooltip: ValueOrFactory<Row, string>;
+  icon: ValueOrFactory<Row, ReactNode>;
+  onClick: (row: Row) => void;
+  disabled?: (row: Row) => boolean;
+}
+
+const resolveValue = <Row extends GridValidRowModel, T>(
+  value: ValueOrFactory<Row, T>,
+  row: Row
+): T => {
+  if (typeof value === 'function') {
+    return (value as (row: Row) => T)(row);
+  }
+  return value;
+};
+
+export const createIconActionColumn = <Row extends GridValidRowModel>({
+  field,
+  headerName,
+  width,
+  align,
+  onClick,
+  icon,
+  tooltip,
+  disabled,
+}: CreateIconActionColumnOptions<Row>): GridColDef<Row> => ({
+  field: field ?? 'actions',
+  headerName: headerName ?? '',
+  width: width ?? 60,
+  align: align ?? 'center',
+  sortable: false,
+  filterable: false,
+  disableColumnMenu: true,
+  hideable: false,
+  renderCell: ({ row }) => {
+    const isDisabled = disabled?.(row) ?? false;
+    return (
+      <Tooltip title={resolveValue(tooltip, row)}>
+        <span>
+          <IconButton
+            size="small"
+            aria-label={resolveValue(tooltip, row)}
+            disabled={isDisabled}
+            onClick={() => onClick(row)}
+          >
+            {resolveValue(icon, row)}
+          </IconButton>
+        </span>
+      </Tooltip>
+    );
+  },
+});

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -14,3 +14,4 @@ export * from './ColumnTypes/multiEnumColumn';
 export * from './ColumnTypes/dateColumn';
 export * from './isCellEditable';
 export * from './useGridMutation';
+export * from './createAddItemFooter';

--- a/src/components/LocationDataGrid/LocationColumns.tsx
+++ b/src/components/LocationDataGrid/LocationColumns.tsx
@@ -1,0 +1,61 @@
+import { Box } from '@mui/material';
+import {
+  DataGridProProps as DataGridProps,
+  GridColDef,
+  GridToolbarColumnsButton,
+  GridToolbarFilterButton,
+} from '@mui/x-data-grid-pro';
+import { LocationTypeLabels, LocationTypeList } from '~/api/schema.graphql';
+import { enumColumn, getInitialVisibility, textColumn, Toolbar } from '../Grid';
+import { Link } from '../Routing';
+import { LocationDataGridRowFragment as Location } from './locationDataGridRow.graphql';
+
+export const LocationColumns: Array<GridColDef<Location>> = [
+  {
+    field: 'name',
+    ...textColumn(),
+    headerName: 'Name',
+    width: 200,
+    valueGetter: (_, row) => row.name.value || '',
+    renderCell: ({ value, row }) => {
+      return <Link to={`/locations/${row.id}`}>{value}</Link>;
+    },
+  },
+  {
+    field: 'type',
+    ...enumColumn(LocationTypeList, LocationTypeLabels),
+    headerName: 'Type',
+    width: 150,
+    valueGetter: (_, row) => row.type.value || '',
+  },
+  {
+    field: 'defaultFieldRegion',
+    ...textColumn(),
+    headerName: 'Field Region',
+    width: 200,
+    valueGetter: (_, row) => row.defaultFieldRegion.value?.name.value || '',
+    renderCell: ({ value, row }) => {
+      const fieldRegion = row.defaultFieldRegion.value;
+      return fieldRegion ? (
+        <Link to={`/field-regions/${fieldRegion.id}`}>{value}</Link>
+      ) : null;
+    },
+  },
+];
+
+export const LocationInitialState = {
+  columns: {
+    columnVisibilityModel: {
+      ...getInitialVisibility(LocationColumns),
+    },
+  },
+} satisfies DataGridProps['initialState'];
+
+export const LocationToolbar = () => (
+  <Toolbar sx={{ justifyContent: 'flex-start', gap: 2 }}>
+    <Box flex={1}>
+      <GridToolbarColumnsButton />
+      <GridToolbarFilterButton />
+    </Box>
+  </Toolbar>
+);

--- a/src/components/LocationDataGrid/index.ts
+++ b/src/components/LocationDataGrid/index.ts
@@ -1,0 +1,2 @@
+export * from './LocationColumns';
+export * from './locationDataGridRow.graphql';

--- a/src/components/LocationDataGrid/locationDataGridRow.graphql
+++ b/src/components/LocationDataGrid/locationDataGridRow.graphql
@@ -1,0 +1,20 @@
+fragment locationDataGridRow on Location {
+  id
+  name {
+    canRead
+    value
+  }
+  type {
+    canRead
+    value
+  }
+  defaultFieldRegion {
+    canRead
+    value {
+      id
+      name {
+        value
+      }
+    }
+  }
+}

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -23,10 +23,12 @@ interface PostListProps
   > {
   parent: PostableIdFragment;
   includeMembership?: boolean;
+  headless?: boolean; // hides title and right-aligns the add button, used when rendered inside a tab
 }
 
 export const PostList = ({
   includeMembership = false,
+  headless = false,
   parent,
   ...rest
 }: PostListProps) => {
@@ -36,11 +38,20 @@ export const PostList = ({
 
   return (
     <div>
-      <Grid container spacing={2} alignItems="center">
-        <Grid item>
-          <Typography variant="h3">Posts</Typography>
-        </Grid>
-        <Grid item>
+      <Grid container spacing={2} alignItems="center" sx={{ maxWidth: 600 }}>
+        {!headless && (
+          <Grid item>
+            <Typography variant="h3">Posts</Typography>
+          </Grid>
+        )}
+        <Grid
+          item
+          sx={{
+            display: 'flex',
+            justifyContent: headless ? 'flex-end' : 'inherit',
+            flex: 1,
+          }}
+        >
           <Tooltip title="Add Post">
             <Fab
               sx={{

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -1,7 +1,7 @@
 import { Add } from '@mui/icons-material';
 import { Grid, Tooltip, Typography } from '@mui/material';
-import { makeStyles } from 'tss-react/mui';
 import { Except } from 'type-fest';
+import { extendSx } from '~/common';
 import { useDialog } from '../Dialog';
 import { Fab } from '../Fab';
 import { List, ListProps } from '../List';
@@ -9,12 +9,6 @@ import { CreatePost } from './CreatePost';
 import { PostableIdFragment } from './PostableId.graphql';
 import { PostListItemCard } from './PostListItemCard';
 import { PostListItemCardFragment } from './PostListItemCard/PostListItemCard.graphql';
-
-const useStyles = makeStyles()(() => ({
-  postListItems: {
-    maxWidth: 600,
-  },
-}));
 
 interface PostListProps
   extends Except<
@@ -30,9 +24,9 @@ export const PostList = ({
   includeMembership = false,
   headless = false,
   parent,
+  ContainerProps,
   ...rest
 }: PostListProps) => {
-  const { classes } = useStyles();
   const [createPostState, createPost] = useDialog();
   const canCreate = rest.data?.canCreate;
 
@@ -67,7 +61,10 @@ export const PostList = ({
       </Grid>
       <List
         {...rest}
-        classes={{ container: classes.postListItems }}
+        ContainerProps={{
+          ...ContainerProps,
+          sx: [{ maxWidth: 600 }, ...extendSx(ContainerProps?.sx)],
+        }}
         spacing={3}
         renderItem={(post) => (
           <PostListItemCard

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -28,8 +28,6 @@ export const PostList = ({
   ...rest
 }: PostListProps) => {
   const [createPostState, createPost] = useDialog();
-  const canCreate = rest.data?.canCreate;
-
   return (
     <div>
       <Grid container spacing={2} alignItems="center" sx={{ maxWidth: 600 }}>
@@ -47,13 +45,7 @@ export const PostList = ({
           }}
         >
           <Tooltip title="Add Post">
-            <Fab
-              sx={{
-                visibility: canCreate ? 'visible' : 'hidden',
-              }}
-              color="error"
-              onClick={createPost}
-            >
+            <Fab color="error" onClick={createPost} aria-label="Add post">
               <Add />
             </Fab>
           </Tooltip>

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -68,6 +68,10 @@ fragment LanguageDetail on Language {
     canEdit
     value
   }
+  locations {
+    canRead
+    canCreate
+  }
   ...FirstScripture
   ...TogglePin
 }

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -72,6 +72,12 @@ fragment LanguageDetail on Language {
     canRead
     canCreate
   }
+  projects {
+    canRead
+  }
+  posts {
+    canRead
+  }
   ...FirstScripture
   ...TogglePin
 }

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -1,75 +1,40 @@
-import { useMutation, useQuery } from '@apollo/client';
-import { Add, Edit } from '@mui/icons-material';
-import { Grid, Skeleton, Tooltip, Typography } from '@mui/material';
+import { useQuery } from '@apollo/client';
+import { Edit } from '@mui/icons-material';
+import { TabContext } from '@mui/lab';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
+import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
-import { makeStyles } from 'tss-react/mui';
 import { PartialDeep } from 'type-fest';
-import { removeItemFromList } from '~/api';
-import { asDate, canEditAny, listOrPlaceholders } from '~/common';
+import { canEditAny } from '~/common';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
-import { BooleanProperty } from '../../../components/BooleanProperty';
+import { Tab, TabsContainer } from '~/components/Tabs';
+import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
 import { useDialog } from '../../../components/Dialog';
-import {
-  DisplaySimpleProperty,
-  DisplaySimplePropertyProps,
-} from '../../../components/DisplaySimpleProperty';
 import { Error } from '../../../components/Error';
-import { Fab } from '../../../components/Fab';
-import {
-  FormattedDate,
-  useNumberFormatter,
-} from '../../../components/Formatters';
 import { IconButton } from '../../../components/IconButton';
-import { LocationCard } from '../../../components/LocationCard';
-import { ProjectListItemCard } from '../../../components/ProjectListItemCard';
-import { ProjectListItemFragment } from '../../../components/ProjectListItemCard/ProjectListItem.graphql';
 import { Redacted } from '../../../components/Redacted';
-import { Sensitivity } from '../../../components/Sensitivity';
 import { TogglePinButton } from '../../../components/TogglePinButton';
 import { EditLanguage } from '../Edit';
-import { AddLocationToLanguageForm } from '../Edit/AddLocationToLanguageForm';
 import { LanguagesQueryVariables } from '../List/languages.graphql';
-import { FirstScripture } from './FirstScripture';
-import {
-  LanguageDocument,
-  RemoveLocationFromLanguageDocument,
-} from './LanguageDetail.graphql';
-import { LanguagePostList } from './LanguagePostList';
-import { LeastOfThese } from './LeastOfThese';
+import { LanguageDocument } from './LanguageDetail.graphql';
+import { LanguageDetailLocations } from './Tabs/Locations/LanguageDetailLocations';
+import { LanguageDetailPosts } from './Tabs/Posts/LanguageDetailPosts';
+import { LanguageDetailProfile } from './Tabs/Profile/LanguageDetailProfile';
+import { LanguageDetailProjects } from './Tabs/Projects/LanguageDetailProjects';
 
-const useStyles = makeStyles()(({ spacing }) => ({
-  root: {
-    overflowY: 'auto',
-    padding: spacing(4),
-    '& > *:not(:last-child)': {
-      marginBottom: spacing(3),
-    },
-  },
-  header: {
-    flex: 1,
-    display: 'flex',
-    gap: spacing(1),
-  },
-  name: {
-    marginRight: spacing(2), // a little extra between text and buttons
-    lineHeight: 'inherit', // centers text with buttons better
-  },
-  listHeader: {
-    marginBottom: spacing(1),
-  },
-  listItem: {
-    marginBottom: spacing(2),
-  },
-  hidden: {
-    visibility: 'hidden',
-  },
-}));
+const useLanguageDetailsFilters = makeQueryHandler({
+  tab: withDefault(
+    EnumParam(['profile', 'locations', 'projects', 'posts']),
+    'profile'
+  ),
+});
 
 export const LanguageDetail = () => {
-  const { classes } = useStyles();
   const { languageId = '' } = useParams();
+  const [filters, setFilters] = useLanguageDetailsFilters();
   const { data, error } = useQuery(LanguageDocument, {
     variables: { languageId },
     fetchPolicy: 'cache-and-network',
@@ -77,38 +42,25 @@ export const LanguageDetail = () => {
   useComments(languageId);
 
   const [editState, edit] = useDialog();
-  const [locationFormState, addLocation] = useDialog();
 
   const language = data?.language;
-  const {
-    id,
-    ethnologue,
-    locations,
-    projects,
-    signLanguageCode,
-    isSignLanguage,
-    sensitivity,
-    isDialect,
-    displayNamePronunciation,
-    registryOfLanguageVarietiesCode,
-    population,
-    sponsorStartDate,
-    sponsorEstimatedEndDate,
-    displayName,
-    usesAIAssistance,
-    name,
-  } = language ?? {};
+  const { ethnologue, displayName, name } = language ?? {};
 
   const canEditAnyFields = canEditAny(language) || canEditAny(ethnologue);
 
-  const formatNumber = useNumberFormatter();
-
-  const [removeLocation, { loading: removing }] = useMutation(
-    RemoveLocationFromLanguageDocument
-  );
-
   return (
-    <main className={classes.root}>
+    <Box
+      component="main"
+      sx={(theme) => ({
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        overflowY: 'auto',
+        padding: 4,
+        gap: 3,
+        maxWidth: theme.breakpoints.values.xl,
+      })}
+    >
       <Helmet title={name?.value ?? displayName?.value ?? undefined} />
       <Error error={error}>
         {{
@@ -118,8 +70,8 @@ export const LanguageDetail = () => {
       </Error>
       {!error && (
         <>
-          <div className={classes.header}>
-            <Typography variant="h2" className={classes.name}>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Typography variant="h2" sx={{ mr: 2, lineHeight: 'inherit' }}>
               {!language ? (
                 <Skeleton width="16ch" />
               ) : (
@@ -148,222 +100,35 @@ export const LanguageDetail = () => {
               }
             />
             <ToggleCommentsButton loading={!language} />
-          </div>
-          <Grid container spacing={2} alignItems="center">
-            <Grid item>
-              <Sensitivity value={sensitivity} loading={!language} />
-            </Grid>
-            <BooleanProperty
-              label="Dialect"
-              redacted="You do not have permission to view whether the language is a dialect"
-              data={isDialect}
-              wrap={(node) => <Grid item>{node}</Grid>}
-            />
-            <LeastOfThese language={language} />
-            <BooleanProperty
-              label="Sign Language"
-              redacted="You do not have permission to view whether the language is a sign language"
-              data={isSignLanguage}
-              wrap={(node) => <Grid item>{node}</Grid>}
-            />
-          </Grid>
-          <DisplayProperty label="ID" value={id} loading={!language} />
-          <DisplayProperty
-            label="Pronunciation Guide"
-            value={displayNamePronunciation?.value}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Ethnologue Name"
-            value={ethnologue?.name.value}
-            loading={!language}
-          />
-          {isSignLanguage?.value && signLanguageCode?.value ? (
-            <DisplayProperty
-              label="Sign Language Code"
-              value={signLanguageCode.value}
-              loading={!language}
-            />
-          ) : (
-            <DisplayProperty
-              label="Ethnologue Code"
-              value={ethnologue?.code.value}
-              loading={!language}
-            />
-          )}
-          <DisplayProperty
-            label="Provisional Code"
-            value={ethnologue?.provisionalCode.value}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Registry of Language Varieties (ROLV) Code"
-            value={registryOfLanguageVarietiesCode?.value}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Population"
-            value={formatNumber(population?.value)}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Ethnologue Population"
-            value={formatNumber(ethnologue?.population.value)}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Sponsor Start Date"
-            value={<FormattedDate date={sponsorStartDate?.value} />}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Sponsor Estimated End Fiscal Year"
-            value={asDate(sponsorEstimatedEndDate?.value)?.fiscalYear}
-            loading={!language}
-          />
-          <DisplayProperty
-            label="Does this language use AI assistance?"
-            value={usesAIAssistance?.value ? 'Yes' : 'No'}
-            loading={!language}
-          />
-          <Grid item>
-            <FirstScripture data={data?.language} />
-          </Grid>
-
-          <Grid container spacing={3}>
-            <Grid item xs={12}>
-              <Grid
-                container
-                spacing={2}
-                alignItems="center"
-                className={classes.listHeader}
-              >
-                <Grid item>
-                  <Typography variant="h3">Locations</Typography>
-                </Grid>
-                <Grid item>
-                  <Tooltip title="Add location">
-                    <Fab
-                      color="error"
-                      aria-label="add location"
-                      className={
-                        locations?.canCreate === true
-                          ? undefined
-                          : classes.hidden
-                      }
-                      onClick={addLocation}
-                    >
-                      <Add />
-                    </Fab>
-                  </Tooltip>
-                </Grid>
-              </Grid>
-              {listOrPlaceholders(locations?.items, 3).map(
-                (location, index) => (
-                  <LocationCard
-                    key={location?.id ?? index}
-                    location={location}
-                    className={classes.listItem}
-                    loading={!location}
-                    removing={removing}
-                    onRemove={() =>
-                      language &&
-                      location &&
-                      void removeLocation({
-                        variables: {
-                          language: language.id,
-                          location: location.id,
-                        },
-                        update: removeItemFromList({
-                          listId: [language, 'locations'],
-                          item: location,
-                        }),
-                      })
-                    }
-                  />
-                )
-              )}
-              {locations?.items.length === 0 ? (
-                <Typography color="textSecondary">
-                  This language does not have any locations yet
-                </Typography>
-              ) : locations?.canRead === false ? (
-                <Typography color="textSecondary">
-                  You don't have permission to see this language's locations
-                </Typography>
-              ) : null}
-            </Grid>
-            <Grid item xs={12}>
-              <Typography variant="h3" paragraph>
-                Projects
-              </Typography>
-              {listOrPlaceholders(
-                projects?.items as ProjectListItemFragment[] | undefined,
-                3
-              ).map((project, index) => (
-                <ProjectListItemCard
-                  key={project?.id ?? index}
-                  project={project}
-                  className={classes.listItem}
-                />
-              ))}
-              {projects?.canRead === false ? (
-                <Typography color="textSecondary">
-                  You don't have permission to see the projects this language is
-                  engaged in
-                </Typography>
-              ) : projects?.items.length === 0 ? (
-                <Typography color="textSecondary">
-                  This language is not engaged in any projects
-                </Typography>
-              ) : null}
-            </Grid>
-            <Grid item xs={12}>
-              {!!language && <LanguagePostList language={language} />}
-            </Grid>
-          </Grid>
+          </Box>
+          <TabsContainer>
+            <TabContext value={filters.tab}>
+              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+                <Tab label="Profile" value="profile" />
+                <Tab label="Locations" value="locations" />
+                <Tab label="Projects" value="projects" />
+                <Tab label="Posts" value="posts" />
+              </TabList>
+              <TabPanel value="profile">
+                {language && <LanguageDetailProfile language={language} />}
+              </TabPanel>
+              <TabPanel value="locations">
+                <LanguageDetailLocations />
+              </TabPanel>
+              <TabPanel value="projects">
+                <LanguageDetailProjects />
+              </TabPanel>
+              <TabPanel value="posts">
+                {language && <LanguageDetailPosts language={language} />}
+              </TabPanel>
+            </TabContext>
+          </TabsContainer>
 
           {language ? (
             <EditLanguage language={language} {...editState} />
           ) : null}
-          {language ? (
-            <AddLocationToLanguageForm
-              languageId={language.id}
-              {...locationFormState}
-            />
-          ) : null}
         </>
       )}
-    </main>
+    </Box>
   );
 };
-
-const DisplayProperty = (props: DisplaySimplePropertyProps) =>
-  !props.value && !props.loading ? null : (
-    <DisplaySimpleProperty
-      variant="body1"
-      {...{ component: 'div' }}
-      {...props}
-      loading={
-        props.loading ? (
-          <>
-            <Typography variant="body2">
-              <Skeleton width="10%" />
-            </Typography>
-            <Typography variant="body1">
-              <Skeleton width="40%" />
-            </Typography>
-          </>
-        ) : null
-      }
-      LabelProps={{
-        color: 'textSecondary',
-        variant: 'body2',
-        ...props.LabelProps,
-      }}
-      ValueProps={{
-        color: 'textPrimary',
-        ...props.ValueProps,
-      }}
-    />
-  );

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { PartialDeep } from 'type-fest';
@@ -60,12 +60,15 @@ export const LanguageDetail = () => {
   const canReadProjects = language?.projects.canRead !== false;
   const canReadPosts = language?.posts.canRead !== false;
 
-  const readableTabs = [
-    'profile',
-    ...(canReadLocations ? ['locations'] : []),
-    ...(canReadProjects ? ['projects'] : []),
-    ...(canReadPosts ? ['posts'] : []),
-  ];
+  const readableTabs = useMemo(
+    () => [
+      'profile',
+      ...(canReadLocations ? ['locations'] : []),
+      ...(canReadProjects ? ['projects'] : []),
+      ...(canReadPosts ? ['posts'] : []),
+    ],
+    [canReadLocations, canReadProjects, canReadPosts]
+  );
 
   useEffect(() => {
     if (!readableTabs.includes(filters.tab)) {

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { PartialDeep } from 'type-fest';
@@ -55,6 +56,22 @@ export const LanguageDetail = () => {
   } = language ?? {};
 
   const canEditAnyFields = canEditAny(language) || canEditAny(ethnologue);
+  const canReadLocations = language?.locations.canRead !== false;
+  const canReadProjects = language?.projects.canRead !== false;
+  const canReadPosts = language?.posts.canRead !== false;
+
+  const readableTabs = [
+    'profile',
+    ...(canReadLocations ? ['locations'] : []),
+    ...(canReadProjects ? ['projects'] : []),
+    ...(canReadPosts ? ['posts'] : []),
+  ];
+
+  useEffect(() => {
+    if (!readableTabs.includes(filters.tab)) {
+      setFilters({ tab: 'profile' });
+    }
+  }, [filters.tab, readableTabs, setFilters]);
 
   return (
     <Box
@@ -128,25 +145,37 @@ export const LanguageDetail = () => {
             />
           </Grid>
           <TabsContainer>
-            <TabContext value={filters.tab}>
+            <TabContext
+              value={
+                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
+              }
+            >
               <TabList onChange={(_, next) => setFilters({ tab: next })}>
                 <Tab label="Profile" value="profile" />
-                <Tab label="Locations" value="locations" />
-                <Tab label="Projects" value="projects" />
-                <Tab label="Posts" value="posts" />
+                {canReadLocations && (
+                  <Tab label="Locations" value="locations" />
+                )}
+                {canReadProjects && <Tab label="Projects" value="projects" />}
+                {canReadPosts && <Tab label="Posts" value="posts" />}
               </TabList>
               <TabPanel value="profile">
                 <LanguageDetailProfile language={language} />
               </TabPanel>
-              <TabPanel value="locations">
-                {language && <LanguageDetailLocations language={language} />}
-              </TabPanel>
-              <TabPanel value="projects">
-                <LanguageDetailProjects />
-              </TabPanel>
-              <TabPanel value="posts">
-                {language && <LanguageDetailPosts language={language} />}
-              </TabPanel>
+              {canReadLocations && (
+                <TabPanel value="locations">
+                  {language && <LanguageDetailLocations language={language} />}
+                </TabPanel>
+              )}
+              {canReadProjects && (
+                <TabPanel value="projects">
+                  <LanguageDetailProjects />
+                </TabPanel>
+              )}
+              {canReadPosts && (
+                <TabPanel value="posts">
+                  {language && <LanguageDetailPosts language={language} />}
+                </TabPanel>
+              )}
             </TabContext>
           </TabsContainer>
 

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -1,14 +1,14 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { TabContext } from '@mui/lab';
-import TabList from '@mui/lab/TabList';
-import TabPanel from '@mui/lab/TabPanel';
-import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { PartialDeep } from 'type-fest';
 import { canEditAny } from '~/common';
+import { BooleanProperty } from '~/components/BooleanProperty';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
+import { Sensitivity } from '~/components/Sensitivity';
 import { Tab, TabsContainer } from '~/components/Tabs';
 import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
@@ -20,6 +20,7 @@ import { TogglePinButton } from '../../../components/TogglePinButton';
 import { EditLanguage } from '../Edit';
 import { LanguagesQueryVariables } from '../List/languages.graphql';
 import { LanguageDocument } from './LanguageDetail.graphql';
+import { LeastOfThese } from './LeastOfThese';
 import { LanguageDetailLocations } from './Tabs/Locations/LanguageDetailLocations';
 import { LanguageDetailPosts } from './Tabs/Posts/LanguageDetailPosts';
 import { LanguageDetailProfile } from './Tabs/Profile/LanguageDetailProfile';
@@ -44,7 +45,14 @@ export const LanguageDetail = () => {
   const [editState, edit] = useDialog();
 
   const language = data?.language;
-  const { ethnologue, displayName, name } = language ?? {};
+  const {
+    ethnologue,
+    displayName,
+    name,
+    sensitivity,
+    isDialect,
+    isSignLanguage,
+  } = language ?? {};
 
   const canEditAnyFields = canEditAny(language) || canEditAny(ethnologue);
 
@@ -101,6 +109,24 @@ export const LanguageDetail = () => {
             />
             <ToggleCommentsButton loading={!language} />
           </Box>
+          <Grid container spacing={2} alignItems="center">
+            <Grid item>
+              <Sensitivity value={sensitivity} loading={!language} />
+            </Grid>
+            <BooleanProperty
+              label="Dialect"
+              redacted="You do not have permission to view whether the language is a dialect"
+              data={isDialect}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+            <LeastOfThese language={language} />
+            <BooleanProperty
+              label="Sign Language"
+              redacted="You do not have permission to view whether the language is a sign language"
+              data={isSignLanguage}
+              wrap={(node) => <Grid item>{node}</Grid>}
+            />
+          </Grid>
           <TabsContainer>
             <TabContext value={filters.tab}>
               <TabList onChange={(_, next) => setFilters({ tab: next })}>
@@ -110,7 +136,7 @@ export const LanguageDetail = () => {
                 <Tab label="Posts" value="posts" />
               </TabList>
               <TabPanel value="profile">
-                {language && <LanguageDetailProfile language={language} />}
+                <LanguageDetailProfile language={language} />
               </TabPanel>
               <TabPanel value="locations">
                 <LanguageDetailLocations />

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -139,7 +139,7 @@ export const LanguageDetail = () => {
                 <LanguageDetailProfile language={language} />
               </TabPanel>
               <TabPanel value="locations">
-                <LanguageDetailLocations />
+                {language && <LanguageDetailLocations language={language} />}
               </TabPanel>
               <TabPanel value="projects">
                 <LanguageDetailProjects />

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -8,11 +8,11 @@ import {
 } from '@mui/x-data-grid-pro';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import { useDialog } from '~/components/Dialog';
 import {
   DefaultDataGridStyles,
   flexLayout,
+  noFooter,
   noHeaderFilterButtons,
   useDataGridSource,
 } from '~/components/Grid';
@@ -24,59 +24,65 @@ import {
 } from '~/components/LocationDataGrid';
 import { TabPanelContent } from '~/components/Tabs';
 import { AddLocationToLanguageForm } from '../../../../Languages/Edit/AddLocationToLanguageForm';
+import { LanguageDetailFragment } from '../../LanguageDetail.graphql';
 import {
   LanguageLocationDataGridRowFragment as LanguageLocation,
   LanguageLocationsDocument,
   RemoveLocationFromLanguageDocument,
 } from './LanguageLocations.graphql';
 
-export const LanguageDetailLocations = () => {
-  const { languageId = '' } = useParams();
-  const [locationFormState, addLocation] = useDialog();
-  const [removeLocation] = useMutation(RemoveLocationFromLanguageDocument);
+interface LanguageDetailLocationProps {
+  language: LanguageDetailFragment;
+}
 
+export const LanguageDetailLocations = ({
+  language,
+}: LanguageDetailLocationProps) => {
+  const { id, locations } = language;
+  const [locationFormState, addLocation] = useDialog();
+
+  const [removeLocation] = useMutation(RemoveLocationFromLanguageDocument);
   const [props] = useDataGridSource({
     query: LanguageLocationsDocument,
-    variables: { languageId },
+    variables: { languageId: id },
     listAt: 'language.locations',
     initialInput: {
       sort: 'name',
     },
   });
 
-  const columns = useMemo<Array<GridColDef<LanguageLocation>>>(
-    () => [
-      ...LocationColumns,
-      {
-        field: 'Remove Location',
-        headerName: '',
-        width: 60,
-        align: 'center',
-        sortable: false,
-        filterable: false,
-        disableColumnMenu: true,
-        hideable: false,
-        renderCell: ({ row: location }) => (
-          <Tooltip title="Remove Location">
-            <IconButton
-              size="small"
-              onClick={() => {
-                void removeLocation({
-                  variables: {
-                    language: languageId,
-                    location: location.id,
-                  },
-                  refetchQueries: [LanguageLocationsDocument],
-                });
-              }}
-            >
-              <DeleteIcon fontSize="small" color="error" />
-            </IconButton>
-          </Tooltip>
-        ),
-      },
-    ],
-    [removeLocation, languageId]
+  const actionsCol: GridColDef<LanguageLocation> = {
+    field: 'actions',
+    headerName: '',
+    width: 60,
+    align: 'center',
+    sortable: false,
+    filterable: false,
+    disableColumnMenu: true,
+    hideable: false,
+    renderCell: ({ row: location }) => (
+      <Tooltip title="Remove Location">
+        <IconButton
+          size="small"
+          onClick={() =>
+            void removeLocation({
+              variables: {
+                language: id,
+                location: location.id,
+              },
+              refetchQueries: [LanguageLocationsDocument],
+            })
+          }
+        >
+          <DeleteIcon fontSize="small" color="error" />
+        </IconButton>
+      </Tooltip>
+    ),
+  };
+
+  const columns = useMemo(
+    () => [...LocationColumns, ...(locations.canCreate ? [actionsCol] : [])],
+    [locations.canCreate, removeLocation, language]
   );
 
   const LocationFooter = useMemo(
@@ -112,12 +118,12 @@ export const LanguageDetailLocations = () => {
         columns={columns}
         initialState={LocationInitialState}
         headerFilters
-        sx={[flexLayout, noHeaderFilterButtons]}
+        hideFooter={!locations.canCreate}
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
       />
-      <AddLocationToLanguageForm
-        languageId={languageId}
-        {...locationFormState}
-      />
+      {locations.canCreate && (
+        <AddLocationToLanguageForm languageId={id} {...locationFormState} />
+      )}
     </TabPanelContent>
   );
 };

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -1,34 +1,34 @@
+import { useMutation } from '@apollo/client';
+import { Delete as DeleteIcon } from '@mui/icons-material';
+import { IconButton, Tooltip } from '@mui/material';
 import {
   DataGridPro as DataGrid,
   DataGridProProps as DataGridProps,
   GridColDef,
 } from '@mui/x-data-grid-pro';
-import { IconButton, Tooltip } from '@mui/material';
-import { Delete as DeleteIcon } from '@mui/icons-material';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { useMutation } from '@apollo/client';
+import { useDialog } from '~/components/Dialog';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noHeaderFilterButtons,
   useDataGridSource,
 } from '~/components/Grid';
+import { createAddItemFooter } from '~/components/Grid/createAddItemFooter';
 import {
   LocationColumns,
   LocationInitialState,
   LocationToolbar,
 } from '~/components/LocationDataGrid';
 import { TabPanelContent } from '~/components/Tabs';
+import { AddLocationToLanguageForm } from '../../../../Languages/Edit/AddLocationToLanguageForm';
 import {
   LanguageLocationDataGridRowFragment as LanguageLocation,
   LanguageLocationsDocument,
   RemoveLocationFromLanguageDocument,
 } from './LanguageLocations.graphql';
-import { useDialog } from '~/components/Dialog';
-import { AddLocationToLanguageForm } from '~/scenes/Languages/Edit/AddLocationToLanguageForm';
-import { createAddItemFooter } from '~/components/Grid/createAddItemFooter';
 
 export const LanguageDetailLocations = () => {
   const { languageId = '' } = useParams();
@@ -60,20 +60,15 @@ export const LanguageDetailLocations = () => {
           <Tooltip title="Remove Location">
             <IconButton
               size="small"
-              onClick={() =>
-                removeLocation({
+              onClick={() => {
+                void removeLocation({
                   variables: {
                     language: languageId,
                     location: location.id,
                   },
-                  refetchQueries: [
-                    {
-                      query: LanguageLocationsDocument,
-                      variables: { languageId },
-                    },
-                  ],
-                })
-              }
+                  refetchQueries: [LanguageLocationsDocument],
+                });
+              }}
             >
               <DeleteIcon fontSize="small" color="error" />
             </IconButton>
@@ -81,7 +76,7 @@ export const LanguageDetailLocations = () => {
         ),
       },
     ],
-    []
+    [removeLocation, languageId]
   );
 
   const LocationFooter = useMemo(

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -1,0 +1,66 @@
+import {
+  DataGridPro as DataGrid,
+  DataGridProProps as DataGridProps,
+} from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  LocationColumns,
+  LocationInitialState,
+  LocationToolbar,
+} from '~/components/LocationDataGrid';
+import { TabPanelContent } from '~/components/Tabs';
+import {
+  LanguageLocationDataGridRowFragment as LanguageLocation,
+  LanguageLocationsDocument,
+} from './LanguageLocations.graphql';
+
+export const LanguageDetailLocations = () => {
+  const { languageId = '' } = useParams();
+
+  const [props] = useDataGridSource({
+    query: LanguageLocationsDocument,
+    variables: { languageId },
+    listAt: 'language.locations',
+    initialInput: {
+      sort: 'name',
+    },
+  });
+
+  const slots = useMemo(
+    () =>
+      merge({}, DefaultDataGridStyles.slots, props.slots, {
+        toolbar: LocationToolbar,
+      } satisfies DataGridProps['slots']),
+    [props.slots]
+  );
+
+  const slotProps = useMemo(
+    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
+    [props.slotProps]
+  );
+
+  return (
+    <TabPanelContent>
+      <DataGrid<LanguageLocation>
+        {...DefaultDataGridStyles}
+        {...props}
+        slots={slots}
+        slotProps={slotProps}
+        columns={LocationColumns}
+        initialState={LocationInitialState}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
+  );
+};

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -82,7 +82,7 @@ export const LanguageDetailLocations = ({
 
   const columns = useMemo(
     () => [...LocationColumns, ...(locations.canCreate ? [actionsCol] : [])],
-    [locations.canCreate, removeLocation, language]
+    [locations.canCreate, removeLocation, language, actionsCol]
   );
 
   const LocationFooter = useMemo(

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -51,39 +51,37 @@ export const LanguageDetailLocations = ({
     },
   });
 
-  const actionsCol: GridColDef<LanguageLocation> = {
-    field: 'actions',
-    headerName: '',
-    width: 60,
-    align: 'center',
-    sortable: false,
-    filterable: false,
-    disableColumnMenu: true,
-    hideable: false,
-    renderCell: ({ row: location }) => (
-      <Tooltip title="Remove Location">
-        <IconButton
-          size="small"
-          onClick={() =>
-            void removeLocation({
-              variables: {
-                language: id,
-                location: location.id,
-              },
-              refetchQueries: [LanguageLocationsDocument],
-            })
-          }
-        >
-          <DeleteIcon fontSize="small" color="error" />
-        </IconButton>
-      </Tooltip>
-    ),
-  };
-
-  const columns = useMemo(
-    () => [...LocationColumns, ...(locations.canCreate ? [actionsCol] : [])],
-    [locations.canCreate, removeLocation, language, actionsCol]
-  );
+  const columns = useMemo(() => {
+    const actionsCol: GridColDef<LanguageLocation> = {
+      field: 'actions',
+      headerName: '',
+      width: 60,
+      align: 'center',
+      sortable: false,
+      filterable: false,
+      disableColumnMenu: true,
+      hideable: false,
+      renderCell: ({ row: location }) => (
+        <Tooltip title="Remove Location">
+          <IconButton
+            size="small"
+            onClick={() =>
+              void removeLocation({
+                variables: {
+                  language: id,
+                  location: location.id,
+                },
+                refetchQueries: [LanguageLocationsDocument],
+              })
+            }
+          >
+            <DeleteIcon fontSize="small" color="error" />
+          </IconButton>
+        </Tooltip>
+      ),
+    };
+    return [...LocationColumns, ...(locations.canCreate ? [actionsCol] : [])];
+  }, [locations.canCreate, id, removeLocation]);
 
   const LocationFooter = useMemo(
     () =>

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -1,14 +1,17 @@
 import {
   DataGridPro as DataGrid,
   DataGridProProps as DataGridProps,
+  GridColDef,
 } from '@mui/x-data-grid-pro';
+import { IconButton, Tooltip } from '@mui/material';
+import { Delete as DeleteIcon } from '@mui/icons-material';
 import { merge } from 'lodash';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { useMutation } from '@apollo/client';
 import {
   DefaultDataGridStyles,
   flexLayout,
-  noFooter,
   noHeaderFilterButtons,
   useDataGridSource,
 } from '~/components/Grid';
@@ -21,10 +24,16 @@ import { TabPanelContent } from '~/components/Tabs';
 import {
   LanguageLocationDataGridRowFragment as LanguageLocation,
   LanguageLocationsDocument,
+  RemoveLocationFromLanguageDocument,
 } from './LanguageLocations.graphql';
+import { useDialog } from '~/components/Dialog';
+import { AddLocationToLanguageForm } from '~/scenes/Languages/Edit/AddLocationToLanguageForm';
+import { createAddItemFooter } from '~/components/Grid/createAddItemFooter';
 
 export const LanguageDetailLocations = () => {
   const { languageId = '' } = useParams();
+  const [locationFormState, addLocation] = useDialog();
+  const [removeLocation] = useMutation(RemoveLocationFromLanguageDocument);
 
   const [props] = useDataGridSource({
     query: LanguageLocationsDocument,
@@ -35,12 +44,62 @@ export const LanguageDetailLocations = () => {
     },
   });
 
+  const columns = useMemo<Array<GridColDef<LanguageLocation>>>(
+    () => [
+      ...LocationColumns,
+      {
+        field: 'Remove Location',
+        headerName: '',
+        width: 60,
+        align: 'center',
+        sortable: false,
+        filterable: false,
+        disableColumnMenu: true,
+        hideable: false,
+        renderCell: ({ row: location }) => (
+          <Tooltip title="Remove Location">
+            <IconButton
+              size="small"
+              onClick={() =>
+                removeLocation({
+                  variables: {
+                    language: languageId,
+                    location: location.id,
+                  },
+                  refetchQueries: [
+                    {
+                      query: LanguageLocationsDocument,
+                      variables: { languageId },
+                    },
+                  ],
+                })
+              }
+            >
+              <DeleteIcon fontSize="small" color="error" />
+            </IconButton>
+          </Tooltip>
+        ),
+      },
+    ],
+    []
+  );
+
+  const LocationFooter = useMemo(
+    () =>
+      createAddItemFooter({
+        addItem: addLocation,
+        tooltipTitle: 'Add Location to Language',
+      }),
+    [addLocation]
+  );
+
   const slots = useMemo(
     () =>
       merge({}, DefaultDataGridStyles.slots, props.slots, {
         toolbar: LocationToolbar,
+        footer: LocationFooter,
       } satisfies DataGridProps['slots']),
-    [props.slots]
+    [props.slots, LocationFooter]
   );
 
   const slotProps = useMemo(
@@ -55,11 +114,14 @@ export const LanguageDetailLocations = () => {
         {...props}
         slots={slots}
         slotProps={slotProps}
-        columns={LocationColumns}
+        columns={columns}
         initialState={LocationInitialState}
         headerFilters
-        hideFooter
-        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+        sx={[flexLayout, noHeaderFilterButtons]}
+      />
+      <AddLocationToLanguageForm
+        languageId={languageId}
+        {...locationFormState}
       />
     </TabPanelContent>
   );

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageLocations.graphql
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageLocations.graphql
@@ -1,0 +1,24 @@
+query LanguageLocations($languageId: ID!, $input: LocationListInput) {
+  language(id: $languageId) {
+    id
+    locations(input: $input) {
+      canRead
+      hasMore
+      total
+      items {
+        ...languageLocationDataGridRow
+      }
+    }
+  }
+}
+
+fragment languageLocationDataGridRow on Location {
+  ...locationDataGridRow
+}
+
+mutation RemoveLocationFromLanguage($language: ID!, $location: ID!) {
+  removeLocationFromLanguage(language: $language, location: $location) {
+    ...LanguageDetail
+    ...LanguageForm
+  }
+}

--- a/src/scenes/Languages/Detail/Tabs/Posts/LanguageDetailPosts.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Posts/LanguageDetailPosts.tsx
@@ -1,0 +1,19 @@
+import { useListQuery } from '~/components/List';
+import { PostableIdFragment } from '~/components/posts/PostableId.graphql';
+import { PostList } from '~/components/posts/PostList';
+import { LanguagePostListDocument as LanguagePosts } from '../../LanguagePostList.graphql';
+
+interface LanguageDetailPostsProps {
+  language: PostableIdFragment;
+}
+
+export const LanguageDetailPosts = ({ language }: LanguageDetailPostsProps) => {
+  const posts = useListQuery(LanguagePosts, {
+    listAt: (data) => data.language.posts,
+    variables: {
+      language: language.id,
+    },
+  });
+
+  return <PostList parent={language} headless {...posts} />;
+};

--- a/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.graphql
+++ b/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.graphql
@@ -1,11 +1,10 @@
-query Language($languageId: ID!) @live {
-  language(id: $languageId) {
-    ...LanguageDetail
-    ...LanguageForm
-  }
+fragment LanguageProfile on Language {
+  ...DisplayLanguage
+  ...LanguageForm
+  ...FirstScripture
 }
 
-fragment LanguageDetail on Language {
+fragment DisplayLanguage on Language {
   id
   createdAt
   name {
@@ -28,7 +27,6 @@ fragment LanguageDetail on Language {
     canEdit
     value
   }
-  ...LeastOfThese
   ethnologue {
     code {
       canRead
@@ -56,11 +54,6 @@ fragment LanguageDetail on Language {
     canEdit
     value
   }
-  usesAIAssistance {
-    canRead
-    canEdit
-    value
-  }
   sensitivity
   avatarLetters
   population {
@@ -68,6 +61,4 @@ fragment LanguageDetail on Language {
     canEdit
     value
   }
-  ...FirstScripture
-  ...TogglePin
 }

--- a/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
@@ -1,21 +1,11 @@
-import { Edit } from '@mui/icons-material';
-import {
-  Box,
-  IconButton,
-  Skeleton,
-  Stack,
-  Tooltip,
-  Typography,
-} from '@mui/material';
-import { asDate, canEditAny } from '~/common';
-import { useDialog } from '~/components/Dialog';
+import { Skeleton, Stack, Typography } from '@mui/material';
+import { asDate } from '~/common';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
 import { FormattedDate, useNumberFormatter } from '~/components/Formatters';
 import { TabPanelContent } from '~/components/Tabs';
-import { EditLanguage } from '../../../Edit';
 import { FirstScripture } from '../../FirstScripture';
 import { LanguageProfileFragment } from './LanguageDetailProfile.graphql';
 
@@ -26,10 +16,8 @@ interface LanguageDetailProfileProps {
 export const LanguageDetailProfile = ({
   language,
 }: LanguageDetailProfileProps) => {
-  const [editLanguageState, editLanguage] = useDialog();
   const formatNumber = useNumberFormatter();
 
-  const canEditAnyFields = canEditAny(language);
   const {
     ethnologue,
     signLanguageCode,
@@ -110,16 +98,6 @@ export const LanguageDetailProfile = ({
         />
         {language && <FirstScripture data={language} />}
       </Stack>
-      <Box sx={{ p: 1 }}>
-        {canEditAnyFields ? (
-          <Tooltip title="Edit Language">
-            <IconButton aria-label="edit language" onClick={editLanguage}>
-              <Edit />
-            </IconButton>
-          </Tooltip>
-        ) : null}
-      </Box>
-      <EditLanguage language={language} {...editLanguageState} />
     </TabPanelContent>
   );
 };

--- a/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
@@ -15,12 +15,12 @@ import {
 } from '~/components/DisplaySimpleProperty';
 import { FormattedDate, useNumberFormatter } from '~/components/Formatters';
 import { TabPanelContent } from '~/components/Tabs';
-import { EditLanguage } from '~/scenes/Languages/Edit';
+import { EditLanguage } from '../../../Edit';
 import { FirstScripture } from '../../FirstScripture';
 import { LanguageProfileFragment } from './LanguageDetailProfile.graphql';
 
 interface LanguageDetailProfileProps {
-  language: LanguageProfileFragment;
+  language?: LanguageProfileFragment;
 }
 
 export const LanguageDetailProfile = ({

--- a/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
@@ -34,7 +34,8 @@ export const LanguageDetailProfile = ({
       sx={(theme) => ({
         display: 'flex',
         justifyContent: 'space-between',
-        width: theme.breakpoints.values.md,
+        maxWidth: theme.breakpoints.values.md,
+        width: '100%',
       })}
     >
       <Stack

--- a/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
@@ -1,0 +1,155 @@
+import { Edit } from '@mui/icons-material';
+import {
+  Box,
+  IconButton,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { asDate, canEditAny } from '~/common';
+import { useDialog } from '~/components/Dialog';
+import {
+  DisplaySimpleProperty,
+  DisplaySimplePropertyProps,
+} from '~/components/DisplaySimpleProperty';
+import { FormattedDate, useNumberFormatter } from '~/components/Formatters';
+import { TabPanelContent } from '~/components/Tabs';
+import { EditLanguage } from '~/scenes/Languages/Edit';
+import { FirstScripture } from '../../FirstScripture';
+import { LanguageProfileFragment } from './LanguageDetailProfile.graphql';
+
+interface LanguageDetailProfileProps {
+  language: LanguageProfileFragment;
+}
+
+export const LanguageDetailProfile = ({
+  language,
+}: LanguageDetailProfileProps) => {
+  const [editLanguageState, editLanguage] = useDialog();
+  const formatNumber = useNumberFormatter();
+
+  const canEditAnyFields = canEditAny(language);
+  const {
+    ethnologue,
+    signLanguageCode,
+    isSignLanguage,
+    displayNamePronunciation,
+    registryOfLanguageVarietiesCode,
+    population,
+    sponsorStartDate,
+    sponsorEstimatedEndDate,
+  } = language ?? {};
+
+  return (
+    <TabPanelContent
+      sx={(theme) => ({
+        display: 'flex',
+        justifyContent: 'space-between',
+        width: theme.breakpoints.values.md,
+      })}
+    >
+      <Stack
+        sx={{
+          p: 2,
+          gap: 2,
+        }}
+      >
+        <DisplayProperty
+          label="Pronunciation Guide"
+          value={displayNamePronunciation?.value}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Ethnologue Name"
+          value={ethnologue?.name.value}
+          loading={!language}
+        />
+        {isSignLanguage?.value && signLanguageCode?.value ? (
+          <DisplayProperty
+            label="Sign Language Code"
+            value={signLanguageCode.value}
+            loading={!language}
+          />
+        ) : (
+          <DisplayProperty
+            label="Ethnologue Code"
+            value={ethnologue?.code.value}
+            loading={!language}
+          />
+        )}
+        <DisplayProperty
+          label="Provisional Code"
+          value={ethnologue?.provisionalCode.value}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Registry of Language Varieties (ROLV) Code"
+          value={registryOfLanguageVarietiesCode?.value}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Population"
+          value={formatNumber(population?.value)}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Ethnologue Population"
+          value={formatNumber(ethnologue?.population.value)}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Sponsor Start Date"
+          value={<FormattedDate date={sponsorStartDate?.value} />}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Sponsor Estimated End Fiscal Year"
+          value={asDate(sponsorEstimatedEndDate?.value)?.fiscalYear}
+          loading={!language}
+        />
+        {language && <FirstScripture data={language} />}
+      </Stack>
+      <Box sx={{ p: 1 }}>
+        {canEditAnyFields ? (
+          <Tooltip title="Edit Language">
+            <IconButton aria-label="edit language" onClick={editLanguage}>
+              <Edit />
+            </IconButton>
+          </Tooltip>
+        ) : null}
+      </Box>
+      <EditLanguage language={language} {...editLanguageState} />
+    </TabPanelContent>
+  );
+};
+
+const DisplayProperty = (props: DisplaySimplePropertyProps) =>
+  !props.value && !props.loading ? null : (
+    <DisplaySimpleProperty
+      variant="body1"
+      {...{ component: 'div' }}
+      {...props}
+      loading={
+        props.loading ? (
+          <>
+            <Typography variant="body2">
+              <Skeleton width="10%" />
+            </Typography>
+            <Typography variant="body1">
+              <Skeleton width="40%" />
+            </Typography>
+          </>
+        ) : null
+      }
+      LabelProps={{
+        color: 'textSecondary',
+        variant: 'body2',
+        ...props.LabelProps,
+      }}
+      ValueProps={{
+        color: 'textPrimary',
+        ...props.ValueProps,
+      }}
+    />
+  );

--- a/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
@@ -1,0 +1,66 @@
+import {
+  DataGridPro as DataGrid,
+  DataGridProProps as DataGridProps,
+} from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  ProjectColumns,
+  ProjectInitialState,
+  ProjectToolbar,
+} from '~/components/ProjectDataGrid';
+import { TabPanelContent } from '~/components/Tabs';
+import {
+  LanguageProjectDataGridRowFragment as LanguageProject,
+  LanguageProjectsDocument,
+} from './LanguageProjects.graphql';
+
+export const LanguageDetailProjects = () => {
+  const { languageId = '' } = useParams();
+
+  const [props] = useDataGridSource({
+    query: LanguageProjectsDocument,
+    variables: { languageId },
+    listAt: 'language.projects',
+    initialInput: {
+      sort: 'name',
+    },
+  });
+
+  const slots = useMemo(
+    () =>
+      merge({}, DefaultDataGridStyles.slots, props.slots, {
+        toolbar: ProjectToolbar,
+      } satisfies DataGridProps['slots']),
+    [props.slots]
+  );
+
+  const slotProps = useMemo(
+    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
+    [props.slotProps]
+  );
+
+  return (
+    <TabPanelContent>
+      <DataGrid<LanguageProject>
+        {...DefaultDataGridStyles}
+        {...props}
+        slots={slots}
+        slotProps={slotProps}
+        columns={ProjectColumns}
+        initialState={ProjectInitialState}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
+  );
+};

--- a/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
@@ -19,7 +19,7 @@ import {
 } from '~/components/ProjectDataGrid';
 import { TabPanelContent } from '~/components/Tabs';
 import {
-  LanguageProjectDataGridRowFragment as LanguageProject,
+  type LanguageProjectDataGridRowFragment as LanguageProject,
   LanguageProjectsDocument,
 } from './LanguageProjects.graphql';
 

--- a/src/scenes/Languages/Detail/Tabs/Projects/LanguageProjects.graphql
+++ b/src/scenes/Languages/Detail/Tabs/Projects/LanguageProjects.graphql
@@ -1,0 +1,17 @@
+query LanguageProjects($languageId: ID!, $input: ProjectListInput) {
+  language(id: $languageId) {
+    id
+    projects(input: $input) {
+      canRead
+      hasMore
+      total
+      items {
+        ...languageProjectDataGridRow
+      }
+    }
+  }
+}
+
+fragment languageProjectDataGridRow on Project {
+  ...projectDataGridRow
+}

--- a/src/scenes/Languages/Edit/AddLocationToLanguageForm.tsx
+++ b/src/scenes/Languages/Edit/AddLocationToLanguageForm.tsx
@@ -7,8 +7,8 @@ import {
 } from '../../../components/Dialog/DialogForm';
 import { SubmitError } from '../../../components/form';
 import { LocationField } from '../../../components/form/Lookup';
-import { AddLocationToLanguageDocument } from './EditLanguage.graphql';
 import { LanguageLocationsDocument } from '../Detail/Tabs/Locations/LanguageLocations.graphql';
+import { AddLocationToLanguageDocument } from './EditLanguage.graphql';
 
 interface FormValues {
   location: DisplayLocationFragment;
@@ -37,12 +37,7 @@ export const AddLocationToLanguageForm = ({
             language: languageId,
             location: location.id,
           },
-          refetchQueries: [
-            {
-              query: LanguageLocationsDocument,
-              variables: { languageId },
-            },
-          ],
+          refetchQueries: [LanguageLocationsDocument],
         });
       }}
     >

--- a/src/scenes/Languages/Edit/AddLocationToLanguageForm.tsx
+++ b/src/scenes/Languages/Edit/AddLocationToLanguageForm.tsx
@@ -8,6 +8,7 @@ import {
 import { SubmitError } from '../../../components/form';
 import { LocationField } from '../../../components/form/Lookup';
 import { AddLocationToLanguageDocument } from './EditLanguage.graphql';
+import { LanguageLocationsDocument } from '../Detail/Tabs/Locations/LanguageLocations.graphql';
 
 interface FormValues {
   location: DisplayLocationFragment;
@@ -36,6 +37,12 @@ export const AddLocationToLanguageForm = ({
             language: languageId,
             location: location.id,
           },
+          refetchQueries: [
+            {
+              query: LanguageLocationsDocument,
+              variables: { languageId },
+            },
+          ],
         });
       }}
     >


### PR DESCRIPTION
## Description
- Convert `LanguageDetail` into a tabbed UI with **Profile / Locations / Projects / Posts**.
- Add a **Locations** tab using MUI DataGrid with:
  - inline remove column per row
  - reusable add-footer via `createAddItemFooter`
  - `refetchQueries` after mutations to refresh the grid
- Extract shared location DataGrid pieces: `LocationColumns` and `locationDataGridRow` fragment.
- Simplify `AddLocationToLanguageForm` to accept `languageId` and refetch locations on submit.
- Add `Language.locations` typePolicy to improve cache merging.
- Add `headless` prop to `PostList` for embedding in tabs (hides title and right-aligns add button).
