### PR TITLE
Fix/workflow dark mode styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The API is [here](https://github.com/SeedCompany/cord-api-v3).
 
 You can see the complete setup guide for your local environment in the [cord-docs wiki](https://github.com/SeedCompany/cord-docs/wiki#new-hire-on-boarding).
 
-*Note*: Current version of nodejs or at least the LTS version is recommended. If you run in to a compilation with the node server error where the Buffer object does not have a 'blob' property, this is likely the issue. You can check your node version by running `node -v`
+_Note_: Current version of nodejs or at least the LTS version is recommended. If you run in to a compilation with the node server error where the Buffer object does not have a 'blob' property, this is likely the issue. You can check your node version by running `node -v`
 
 ## Local Development
 
@@ -21,6 +21,7 @@ You can see the complete setup guide for your local environment in the [cord-doc
 By default, this project will attempt to access the [cord api project](https://github.com/SeedCompany/cord-api-v3) that's running locally on your machine on port `3000`.
 
 If you'd like to change the API server that you're connected to, create an `.env.local` file with the following contents:
+
 ```dotenv
 RAZZLE_API_BASE_URL=http://your-api-server-host.com:3000
 ```

--- a/src/components/Workflow/Controls.tsx
+++ b/src/components/Workflow/Controls.tsx
@@ -58,7 +58,7 @@ export const Controls = (props: ControlsProps) => {
     <Panel position="bottom-left">
       <ButtonGroup
         orientation="vertical"
-        color="secondary"
+        color="inherit"
         variant="text"
         sx={(theme) => ({
           x: theme.transitions.duration.complex,

--- a/src/components/Workflow/Controls.tsx
+++ b/src/components/Workflow/Controls.tsx
@@ -61,8 +61,8 @@ export const Controls = (props: ControlsProps) => {
         color="inherit"
         variant="text"
         sx={(theme) => ({
-          x: theme.transitions.duration.complex,
           backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
           boxShadow: theme.shadows[4],
           '.MuiButton-root': {
             minWidth: 'initial',

--- a/src/components/Workflow/nodes.tsx
+++ b/src/components/Workflow/nodes.tsx
@@ -117,17 +117,23 @@ const NodeCard = forwardRef<
       ref={ref}
       elevation={selected ? 4 : 1}
       sx={[
-        (theme) => ({
-          transition: theme.transitions.create(['box-shadow', 'border-color'], {
-            duration: theme.transitions.duration.shorter,
-          }),
-          borderColor: selected ? `${color}.dark` : 'transparent',
-          borderWidth: 1,
-          borderStyle: 'solid',
-          p: 2,
-          bgcolor: `${color}.main`,
-          color: `${color}.contrastText`,
-        }),
+        (theme) => {
+          const pal = color ? (theme.palette as any)[color] : null;
+          return {
+            transition: theme.transitions.create(
+              ['box-shadow', 'border-color'],
+              {
+                duration: theme.transitions.duration.shorter,
+              }
+            ),
+            borderColor: selected ? pal?.dark ?? 'transparent' : 'transparent',
+            borderWidth: 1,
+            borderStyle: 'solid',
+            p: 2,
+            backgroundColor: pal?.main,
+            color: pal?.contrastText,
+          };
+        },
         ...extendSx(sx),
       ]}
     >

--- a/src/components/Workflow/nodes.tsx
+++ b/src/components/Workflow/nodes.tsx
@@ -31,6 +31,11 @@ type Node = N<State | Transition, NodeTypes>;
 export const FlowchartStyles = styled(Box)(({ theme }) => ({
   height: '100%',
   '& .react-flow': {
+    // Override reactflow's own color defaults so MUI theme colors win
+    // regardless of CSS import order on page load
+    '.react-flow__node, .react-flow__panel': {
+      color: theme.palette.text.primary,
+    },
     '.react-flow__edge-textbg': {
       fill: theme.palette.background.paper,
     },
@@ -119,6 +124,17 @@ const NodeCard = forwardRef<
       sx={[
         (theme) => {
           const pal = color ? (theme.palette as any)[color] : null;
+          // secondary.main is light in dark mode (for text button visibility),
+          // but node card backgrounds need a darker neutral color on the canvas.
+          const isDark = theme.palette.mode === 'dark';
+          const cardBg =
+            isDark && color === 'secondary' ? '#3c444e' : pal?.main;
+          // Derive text color from the actual background rather than relying on
+          // contrastText, which may mismatch when cardBg diverges from pal.main.
+          const cardText =
+            cardBg != null
+              ? theme.palette.getContrastText(cardBg)
+              : pal?.contrastText;
           return {
             transition: theme.transitions.create(
               ['box-shadow', 'border-color'],
@@ -130,8 +146,8 @@ const NodeCard = forwardRef<
             borderWidth: 1,
             borderStyle: 'solid',
             p: 2,
-            backgroundColor: pal?.main,
-            color: pal?.contrastText,
+            backgroundColor: cardBg,
+            color: cardText,
           };
         },
         ...extendSx(sx),
@@ -225,6 +241,7 @@ const LabelContainer = ({
       sx={{
         position: 'absolute',
         bgcolor: 'background.paper',
+        color: 'text.primary',
         p: 1,
         borderRadius: 1,
         fontSize: 12,

--- a/src/components/Workflow/nodes.tsx
+++ b/src/components/Workflow/nodes.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardProps } from '@mui/material';
+import { Box, Card, CardProps, PaletteColor } from '@mui/material';
 import { yellow } from '@mui/material/colors';
 import { styled } from '@mui/material/styles';
 import { forwardRef, useCallback } from 'react';
@@ -123,31 +123,25 @@ const NodeCard = forwardRef<
       elevation={selected ? 4 : 1}
       sx={[
         (theme) => {
-          const pal = color ? (theme.palette as any)[color] : null;
-          // secondary.main is light in dark mode (for text button visibility),
-          // but node card backgrounds need a darker neutral color on the canvas.
-          const isDark = theme.palette.mode === 'dark';
-          const cardBg =
-            isDark && color === 'secondary' ? '#3c444e' : pal?.main;
-          // Derive text color from the actual background rather than relying on
-          // contrastText, which may mismatch when cardBg diverges from pal.main.
-          const cardText =
-            cardBg != null
-              ? theme.palette.getContrastText(cardBg)
-              : pal?.contrastText;
+          const pal = color
+            ? (theme.palette[
+                color as keyof typeof theme.palette
+              ] as PaletteColor)
+            : null;
+          // In dark mode use .dark so node cards get the stable navy background.
+          // (.main is grey[50] in dark mode to keep text/icon buttons readable.)
+          const bg = theme.palette.mode === 'dark' ? pal?.dark : pal?.main;
           return {
             transition: theme.transitions.create(
               ['box-shadow', 'border-color'],
-              {
-                duration: theme.transitions.duration.shorter,
-              }
+              { duration: theme.transitions.duration.shorter }
             ),
-            borderColor: selected ? pal?.dark ?? 'transparent' : 'transparent',
+            borderColor: selected ? `${color}.dark` : 'transparent',
             borderWidth: 1,
             borderStyle: 'solid',
             p: 2,
-            backgroundColor: cardBg,
-            color: cardText,
+            backgroundColor: bg,
+            color: bg ? theme.palette.getContrastText(bg) : undefined,
           };
         },
         ...extendSx(sx),

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useMemo } from 'react';
 import { createTheme } from './createTheme';
 
 export const ThemeProvider = ({ children }: { children?: ReactNode }) => {
-  const isDark = useMediaQuery('(prefers-color-scheme: dark)');
+  const isDark = useMediaQuery('(prefers-color-scheme: dark)', { noSsr: true });
 
   const theme = useMemo(() => createTheme({ dark: isDark }), [isDark]);
 

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -16,7 +16,8 @@ export const createPalette = ({ dark }: { dark?: boolean }) => {
       contrastText: '#ffffff',
     },
     secondary: {
-      main: dark ? grey[50] : '#3c444e',
+      main: dark ? '#3c444e' : grey[50],
+      contrastText: dark ? '#ffffff' : 'rgba(0, 0, 0, 0.87)',
     },
     error: {
       main: '#ff5a5f',

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -10,14 +10,15 @@ export const createPalette = ({ dark }: { dark?: boolean }) => {
     mode: dark ? 'dark' : 'light',
     background: {
       default: dark ? '#303030' : grey[50],
+      paper: dark ? '#424242' : '#ffffff',
     },
     primary: {
       main: mainGreen,
       contrastText: '#ffffff',
     },
     secondary: {
-      main: dark ? '#3c444e' : grey[50],
-      contrastText: dark ? '#ffffff' : 'rgba(0, 0, 0, 0.87)',
+      main: dark ? grey[50] : '#3c444e',
+      contrastText: dark ? 'rgba(0, 0, 0, 0.87)' : '#ffffff',
     },
     error: {
       main: '#ff5a5f',

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -18,6 +18,10 @@ export const createPalette = ({ dark }: { dark?: boolean }) => {
     },
     secondary: {
       main: dark ? grey[50] : '#3c444e',
+      // Pinned so node card backgrounds always get the dark navy regardless of mode.
+      // secondary.main is grey[50] in dark mode for text/icon button readability,
+      // but that's unusable as a canvas background color.
+      dark: '#3c444e',
       contrastText: dark ? 'rgba(0, 0, 0, 0.87)' : '#ffffff',
     },
     error: {


### PR DESCRIPTION
This PR fixes visibility and contrast issues in the Workflow UI when Dark Mode is active. It replaces hardcoded styling with dynamic, theme-aware logic.

### Changes

- **Theme Refinement**: Added paper background and `contrastText` to the dark mode palette in `src/theme/palette.ts`.

- **Dynamic Nodes**: Refactored `NodeCard` to calculate colors using `getContrastText()` and added a custom dark background ([#3c444e](url)) for secondary nodes.

- **UI Cleanup**: Fixed button visibility by setting `ButtonGroup` to `color="inherit"` and added `noSsr: true` to the theme provider to prevent hydration flickering.