### PR TITLE
New Parter Profile Languages Section

### DIFF
--- a/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Profile/LanguageDetailProfile.tsx
@@ -28,6 +28,7 @@ export const LanguageDetailProfile = ({
     sponsorStartDate,
     sponsorEstimatedEndDate,
     usesAIAssistance,
+    isAvailableForReporting,
   } = language ?? {};
 
   return (
@@ -101,6 +102,11 @@ export const LanguageDetailProfile = ({
         <DisplayProperty
           label="Uses AI assistance"
           value={usesAIAssistance?.value ? 'Yes' : 'No'}
+          loading={!language}
+        />
+        <DisplayProperty
+          label="Available for Reporting"
+          value={isAvailableForReporting?.value ? 'Yes' : 'No'}
           loading={!language}
         />
         {language && <FirstScripture data={language} />}

--- a/src/scenes/Languages/LanguageForm/LanguageForm.tsx
+++ b/src/scenes/Languages/LanguageForm/LanguageForm.tsx
@@ -225,6 +225,17 @@ export const LanguageForm = <Mutation extends LanguageMutation>({
                       </Grid>
                     )}
                   </SecuredField>
+                  <SecuredField obj={language} name="isAvailableForReporting">
+                    {(props) => (
+                      <Grid item xs={12} sm={6}>
+                        <CheckboxField
+                          label="Is this language available for reporting?"
+                          margin="none"
+                          {...props}
+                        />
+                      </Grid>
+                    )}
+                  </SecuredField>
                   <Grid item xs={12} sm={6}>
                     <SelectField
                       label="Sensitivity"

--- a/src/scenes/Languages/LanguageForm/LangugeForm.graphql
+++ b/src/scenes/Languages/LanguageForm/LangugeForm.graphql
@@ -88,4 +88,9 @@ fragment LanguageForm on Language {
     canEdit
     value
   }
+  isAvailableForReporting {
+    canRead
+    canEdit
+    value
+  }
 }

--- a/src/scenes/Partners/Detail/PartnerDetail.graphql
+++ b/src/scenes/Partners/Detail/PartnerDetail.graphql
@@ -85,6 +85,27 @@ fragment partnerOwnDetails on Partner {
       ...DisplayLocation
     }
   }
+  languageOfReporting {
+    canRead
+    canEdit
+    value {
+      ...LanguageLookupItem
+    }
+  }
+  languageOfWiderCommunication {
+    canRead
+    canEdit
+    value {
+      ...LanguageLookupItem
+    }
+  }
+  languagesOfConsulting {
+    canRead
+    canEdit
+    value {
+      ...LanguageLookupItem
+    }
+  }
   ...TogglePin
 }
 

--- a/src/scenes/Partners/Detail/Tabs/Profile/PartnerDetailProfile.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Profile/PartnerDetailProfile.tsx
@@ -5,6 +5,7 @@ import { TabPanelContent } from '~/components/Tabs';
 import { EditablePartnerField } from '../../../Edit';
 import { PartnerDetailsFragment } from '../../PartnerDetail.graphql';
 import { PartnerContactSection } from './PartnerContactSection';
+import { PartnerLanguagesSection } from './PartnerLanguagesSection';
 import { PartnerLocationSection } from './PartnerLocationSection';
 import { PartnerOrgReachAndTypeSection } from './PartnerOrgReachAndTypeSection';
 import { PartnerTypesSection } from './PartnerTypesSection';
@@ -47,6 +48,18 @@ export const PartnerDetailProfile = ({ partner, editPartner: edit }: Props) => (
         <PartnerLocationSection
           partner={partner}
           onEdit={() => edit(['partner.fieldRegions', 'partner.countries'])}
+        />
+      </Grid>
+      <Grid xs={12}>
+        <PartnerLanguagesSection
+          partner={partner}
+          onEdit={() =>
+            edit([
+              'partner.languageOfReporting',
+              'partner.languageOfWiderCommunication',
+              'partner.languagesOfConsulting',
+            ])
+          }
         />
       </Grid>
     </Grid>

--- a/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.test.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PartnerDetailsFragment } from '../../PartnerDetail.graphql';
+import { PartnerLanguagesSection } from './PartnerLanguagesSection';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeLang = (name: string, displayName = name) => ({
+  __typename: 'Language' as const,
+  id: `lang-${name}`,
+  name: { __typename: 'SecuredString' as const, value: name },
+  displayName: { __typename: 'SecuredString' as const, value: displayName },
+  ethnologue: {
+    __typename: 'EthnologueLanguage' as const,
+    code: { __typename: 'SecuredStringNullable' as const, value: null },
+  },
+  registryOfLanguageVarietiesCode: {
+    __typename: 'SecuredStringNullable' as const,
+    value: null,
+  },
+});
+
+const makePartner = (
+  overrides: Partial<{
+    languageOfReporting: object;
+    languageOfWiderCommunication: object;
+    languagesOfConsulting: object;
+  }> = {}
+) =>
+  ({
+    languageOfReporting: { canRead: true, canEdit: true, value: null },
+    languageOfWiderCommunication: { canRead: true, canEdit: true, value: null },
+    languagesOfConsulting: { canRead: true, canEdit: true, value: [] },
+    ...overrides,
+  } as unknown as PartnerDetailsFragment);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PartnerLanguagesSection', () => {
+  it('renders the section title', () => {
+    render(
+      <PartnerLanguagesSection partner={makePartner()} onEdit={jest.fn()} />
+    );
+    expect(screen.getByText('Languages')).toBeInTheDocument();
+  });
+
+  it('renders all three field labels', () => {
+    render(
+      <PartnerLanguagesSection partner={makePartner()} onEdit={jest.fn()} />
+    );
+    expect(screen.getByText('Language of Reporting')).toBeInTheDocument();
+    expect(
+      screen.getByText('Language of Wider Communication')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Languages of Consulting')).toBeInTheDocument();
+  });
+
+  it('shows "None" for each empty field', () => {
+    render(
+      <PartnerLanguagesSection partner={makePartner()} onEdit={jest.fn()} />
+    );
+    expect(screen.getAllByText('None')).toHaveLength(3);
+  });
+
+  it('displays language of reporting by name', () => {
+    const partner = makePartner({
+      languageOfReporting: {
+        canRead: true,
+        canEdit: true,
+        value: makeLang('French'),
+      },
+    });
+    render(<PartnerLanguagesSection partner={partner} onEdit={jest.fn()} />);
+    expect(screen.getByText('French')).toBeInTheDocument();
+  });
+
+  it('displays language of wider communication by name', () => {
+    const partner = makePartner({
+      languageOfWiderCommunication: {
+        canRead: true,
+        canEdit: true,
+        value: makeLang('Spanish'),
+      },
+    });
+    render(<PartnerLanguagesSection partner={partner} onEdit={jest.fn()} />);
+    expect(screen.getByText('Spanish')).toBeInTheDocument();
+  });
+
+  it('displays languages of consulting as a list', () => {
+    const partner = makePartner({
+      languagesOfConsulting: {
+        canRead: true,
+        canEdit: true,
+        value: [makeLang('German'), makeLang('Arabic')],
+      },
+    });
+    render(<PartnerLanguagesSection partner={partner} onEdit={jest.fn()} />);
+    expect(screen.getByText('German')).toBeInTheDocument();
+    expect(screen.getByText('Arabic')).toBeInTheDocument();
+  });
+
+  it('falls back to displayName when language name value is null', () => {
+    const lang = {
+      ...makeLang('ignored', 'Display-Only Name'),
+      name: { __typename: 'SecuredString' as const, value: null },
+    };
+    const partner = makePartner({
+      languageOfReporting: { canRead: true, canEdit: true, value: lang },
+    });
+    render(<PartnerLanguagesSection partner={partner} onEdit={jest.fn()} />);
+    expect(screen.getByText('Display-Only Name')).toBeInTheDocument();
+  });
+
+  it('calls onEdit when the edit button is clicked', async () => {
+    const onEdit = jest.fn();
+    const partner = makePartner({
+      languageOfReporting: { canRead: true, canEdit: true, value: null },
+    });
+    render(<PartnerLanguagesSection partner={partner} onEdit={onEdit} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the edit button when no fields are editable', () => {
+    const partner = makePartner({
+      languageOfReporting: { canRead: true, canEdit: false, value: null },
+      languageOfWiderCommunication: {
+        canRead: true,
+        canEdit: false,
+        value: null,
+      },
+      languagesOfConsulting: { canRead: true, canEdit: false, value: [] },
+    });
+    render(<PartnerLanguagesSection partner={partner} onEdit={jest.fn()} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.tsx
@@ -1,0 +1,136 @@
+import { Edit } from '@mui/icons-material';
+import { Box, Skeleton, Stack, Tooltip, Typography } from '@mui/material';
+import { canEditAny } from '~/common';
+import { ActionableSection } from '~/components/ActionableSection';
+import { IconButton } from '~/components/IconButton';
+import { Redacted } from '~/components/Redacted';
+import { PartnerDetailsFragment } from '../../PartnerDetail.graphql';
+
+interface PartnerLanguagesSectionProps {
+  partner?: PartnerDetailsFragment;
+  onEdit: () => void;
+}
+
+export const PartnerLanguagesSection = ({
+  partner,
+  onEdit,
+}: PartnerLanguagesSectionProps) => {
+  const canEdit = canEditAny(
+    partner,
+    false,
+    'languageOfReporting',
+    'languageOfWiderCommunication',
+    'languagesOfConsulting'
+  );
+
+  return (
+    <ActionableSection
+      title="Languages"
+      loading={!partner}
+      action={
+        <Tooltip title="Edit">
+          <span>
+            <IconButton
+              disabled={!canEdit}
+              onClick={onEdit}
+              loading={!partner}
+              size="small"
+            >
+              <Edit />
+            </IconButton>
+          </span>
+        </Tooltip>
+      }
+    >
+      <Stack direction="row" columnGap={6} rowGap={3} flexWrap="wrap">
+        <Box>
+          <Typography
+            component="h4"
+            variant="body2"
+            color="textSecondary"
+            gutterBottom
+          >
+            Language of Reporting
+          </Typography>
+          {!partner ? (
+            <Skeleton width="120px" />
+          ) : partner.languageOfReporting.canRead ? (
+            <Typography component="p" variant="h4">
+              {partner.languageOfReporting.value
+                ? partner.languageOfReporting.value.name.value ??
+                  partner.languageOfReporting.value.displayName.value
+                : 'None'}
+            </Typography>
+          ) : (
+            <Redacted
+              info="You cannot view this partner's language of reporting"
+              width="120px"
+            />
+          )}
+        </Box>
+        <Box>
+          <Typography
+            component="h4"
+            variant="body2"
+            color="textSecondary"
+            gutterBottom
+          >
+            Language of Wider Communication
+          </Typography>
+          {!partner ? (
+            <Skeleton width="120px" />
+          ) : partner.languageOfWiderCommunication.canRead ? (
+            <Typography component="p" variant="h4">
+              {partner.languageOfWiderCommunication.value
+                ? partner.languageOfWiderCommunication.value.name.value ??
+                  partner.languageOfWiderCommunication.value.displayName.value
+                : 'None'}
+            </Typography>
+          ) : (
+            <Redacted
+              info="You cannot view this partner's language of wider communication"
+              width="120px"
+            />
+          )}
+        </Box>
+        <Box>
+          <Typography
+            component="h4"
+            variant="body2"
+            color="textSecondary"
+            gutterBottom
+          >
+            Languages of Consulting
+          </Typography>
+          {!partner ? (
+            <Skeleton width="120px" />
+          ) : partner.languagesOfConsulting.canRead ? (
+            partner.languagesOfConsulting.value.length > 0 ? (
+              <Stack component="ul" sx={{ m: 0, p: 0, gap: 1 }}>
+                {partner.languagesOfConsulting.value.map((language) => (
+                  <Typography
+                    component="li"
+                    variant="h4"
+                    sx={{ listStyleType: 'none' }}
+                    key={language.id}
+                  >
+                    {language.name.value ?? language.displayName.value}
+                  </Typography>
+                ))}
+              </Stack>
+            ) : (
+              <Typography component="p" variant="h4">
+                None
+              </Typography>
+            )
+          ) : (
+            <Redacted
+              info="You cannot view this partner's languages of consulting"
+              width="120px"
+            />
+          )}
+        </Box>
+      </Stack>
+    </ActionableSection>
+  );
+};

--- a/src/scenes/Partners/Edit/EditPartner.tsx
+++ b/src/scenes/Partners/Edit/EditPartner.tsx
@@ -36,10 +36,12 @@ import {
 } from '../../../components/form';
 import {
   FieldRegionField,
+  LanguageField,
   LocationField,
   UserField,
   UserLookupItem,
 } from '../../../components/form/Lookup';
+import { LanguageLookupItemFragment } from '../../../components/form/Lookup/Language/LanguageLookup.graphql';
 import { PartnerDetailsFragment } from '../Detail/PartnerDetail.graphql';
 import { UpdatePartnerDocument } from './UpdatePartner.graphql';
 
@@ -51,6 +53,9 @@ type PartnerFormValues = {
       pointOfContact: UserLookupItem | null;
       fieldRegions: readonly DisplayFieldRegionFragment[];
       countries: readonly DisplayLocationFragment[];
+      languageOfReporting: LanguageLookupItemFragment | null;
+      languageOfWiderCommunication: LanguageLookupItemFragment | null;
+      languagesOfConsulting: readonly LanguageLookupItemFragment[];
     }
   >;
   organization: UpdateOrganization;
@@ -128,6 +133,20 @@ const fieldMapping = {
   'partner.countries': ({ props }) => (
     <LocationField {...props} label="Countries" multiple variant="outlined" />
   ),
+  'partner.languageOfReporting': ({ props }) => (
+    <LanguageField {...props} label="Language of Reporting" />
+  ),
+  'partner.languageOfWiderCommunication': ({ props }) => (
+    <LanguageField {...props} label="Language of Wider Communication" />
+  ),
+  'partner.languagesOfConsulting': ({ props }) => (
+    <LanguageField
+      {...props}
+      label="Languages of Consulting"
+      multiple
+      variant="outlined"
+    />
+  ),
   'organization.name': ({ props }) => (
     <TextField {...props} required label="Name" />
   ),
@@ -194,6 +213,10 @@ export const EditPartner = ({
         pointOfContact: partner.pointOfContact.value ?? null,
         fieldRegions: partner.fieldRegions.value,
         countries: partner.countries.value,
+        languageOfReporting: partner.languageOfReporting.value ?? null,
+        languageOfWiderCommunication:
+          partner.languageOfWiderCommunication.value ?? null,
+        languagesOfConsulting: partner.languagesOfConsulting.value,
       },
       organization: {
         id: organization.id,
@@ -219,6 +242,12 @@ export const EditPartner = ({
               pointOfContact: partner.pointOfContact?.id ?? null,
               fieldRegions: partner.fieldRegions.map((region) => region.id),
               countries: partner.countries.map((country) => country.id),
+              languageOfReporting: partner.languageOfReporting?.id ?? null,
+              languageOfWiderCommunication:
+                partner.languageOfWiderCommunication?.id ?? null,
+              languagesOfConsulting: partner.languagesOfConsulting.map(
+                (l) => l.id
+              ),
             },
             organization,
           },


### PR DESCRIPTION
API PR: https://github.com/SeedCompany/cord-api-v3/pull/3686

Adds `languageOfReporting`, `languageOfWiderCommunication`, and `languagesOfConsulting` fields to the `Partner` detail profile and edit form, including GraphQL fragments and form value wiring

Introduces a new `PartnerLanguagesSection` component (with tests) that displays these three language fields with proper read/edit permission handling

Adds `isAvailableForReporting` checkbox to the Language form and displays it on the Language detail profile page