### PR TITLE
Add Apollo preflight header

### DIFF
--- a/src/api/client/links/http.link.ts
+++ b/src/api/client/links/http.link.ts
@@ -11,6 +11,7 @@ export const createHttpLink = () =>
     credentials: 'include',
     fetch,
     print: dedupeFragmentsPrinter,
+    headers: { 'apollo-require-preflight': '1' },
   });
 
 export const createSseLink = () =>


### PR DESCRIPTION
Adds apollo-require-preflight: 1 to the Apollo HttpLink headers.

This repo uses APQ, which sends an initial GET request — Apollo Server's csrfPrevention rejects these with a 400 before auth runs.

The apollo-require-preflight header is the recommended bypass with no semantic side effects
