### PR TITLE
Fix tooltip font color

### DIFF
--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -257,6 +257,10 @@ export const appComponents = ({
         tooltip: {
           fontSize: typography.pxToRem(12),
           backgroundColor: fade(palette.grey[700], 0.94),
+          color: palette.common.white,
+          '& .MuiTypography-root': {
+            color: 'inherit',
+          },
         },
       },
     },


### PR DESCRIPTION
The font color was inheriting a black font so add an explicit override back to the palette white so it can sit on the tooltip background and not clash.