### PR TITLE
Fix MUI Calendar Picker bug

### DIFF
--- a/src/common/CalenderDate.ts
+++ b/src/common/CalenderDate.ts
@@ -260,7 +260,32 @@ export class CalendarDate<IsValid extends boolean = DefaultValidity>
       : undefined;
 
   endOf(unit: DateTimeUnit): this {
-    return CalendarDate.fromDateTime(super.endOf(unit)) as this;
+    // We must NOT call super.endOf() here. Luxon's endOf() internally calls
+    // this.startOf(), this.plus(), this.minus() — and since `this` is a
+    // CalendarDate, those dispatch to our overridden versions which all strip
+    // time back to midnight via fromDateTime/startOf('day'). This causes
+    // super.endOf() to return midnight instead of 23:59:59.999.
+    //
+    // The @date-io/luxon getWeekArray computes grid size with:
+    //   Math.round(endOf('week').diff(startOf('week'), 'days'))
+    // When the month's last day is a Sunday (end of ISO week), endOf('week')
+    // lands on the same day as endOf('month'). With midnight timestamps the diff
+    // is an exact integer (e.g. 34), which Math.round doesn't round up — so the
+    // last day of the month is dropped from the calendar grid entirely.
+    //
+    // By using a plain DateTime (not CalendarDate), endOf() returns 23:59:59.999,
+    // making the diff fractional (34.9999...) so Math.round correctly gives 35.
+    const inst = DateTime.fromMillis(this.valueOf(), { zone: this.zone }).endOf(
+      unit
+    ) as any;
+    return new CalendarDate({
+      ts: inst.ts,
+      zone: inst.zone,
+      c: inst.c,
+      o: inst.o,
+      loc: inst.loc,
+      invalid: inst.invalid,
+    }) as this;
   }
 
   minus(duration: DurationLike): this {


### PR DESCRIPTION
The MUI calendar builds its grid by counting how many days to show. It does this by computing:

"How many days are between the start of the first week and the end of the last week?"

Then it rounds that number and generates that many day cells.

### The trap: 
CalendarDate is a custom class that wraps Luxon's DateTime but strips out the time component — every date is always stored at midnight (00:00:00). That's intentional, since this app only cares about calendar dates, not times.

The problem: When the calendar asks "what's the end of this week?" it expects to get back something like Aug 31 at 11:59 PM. But because CalendarDate always strips time to midnight, it gets back Aug 31 at 12:00 AM instead.

So the count looks like:

Aug 31 midnight − Jul 28 midnight = exactly 34 days

Math.round(34) = 34 → 34 cells generated → the grid goes from Jul 28 to Aug 30 and Aug 31 never gets a cell.

If time had been preserved, the count would be:

Aug 31 11:59 PM − Jul 28 midnight = 34.9999… days

Math.round(34.9999) = 35 → 35 cells → Aug 31 is included ✓

### Why only some months? 
The bug only triggers when the last day of the month falls on a Sunday (the last day of the ISO week). When the last day is any other day, the "end of week" lands on a later Sunday, so there's already enough room in the count to include the last day. But when the last day IS the Sunday, the end-of-week lands on the same day, and midnight vs. 11:59 PM is the only thing separating "right count" from "one short."

In 2025 that's August 31 and November 30 — both Sundays.

Fixes #1806 