### PR TITLE
Tool overview page

### DIFF
--- a/src/common/fragments/index.ts
+++ b/src/common/fragments/index.ts
@@ -11,6 +11,7 @@ export * from './lists.graphql';
 export * from './prompt.graphql';
 export * from './promptResponse.graphql';
 export * from './variant.graphql';
+export * from './tool.graphql';
 
 export type ProjectIdFragment =
   | MomentumProjectIdFragment

--- a/src/common/fragments/tool.graphql
+++ b/src/common/fragments/tool.graphql
@@ -1,0 +1,29 @@
+fragment ToolListItem on Tool {
+  ...Id
+  name {
+    value
+  }
+  description {
+    value
+  }
+  aiBased {
+    value
+  }
+}
+
+fragment ToolProfile on Tool {
+  ...Id
+  name {
+    value
+  }
+  description {
+    value
+  }
+  aiBased {
+    value
+  }
+  containerSummary {
+    containerType
+    total
+  }
+}

--- a/src/components/ToolListItemCard/ToolListItemCard.tsx
+++ b/src/components/ToolListItemCard/ToolListItemCard.tsx
@@ -20,8 +20,8 @@ export const ToolListItemCard = ({
   sx,
   className,
 }: ToolListItemCardProps) => {
-  const title = tool?.name.value;
-  const description = tool?.description.value;
+  const title = tool?.name?.value;
+  const description = tool?.description?.value;
   const isAiBased = tool?.aiBased?.value;
 
   return (

--- a/src/components/ToolListItemCard/ToolListItemCard.tsx
+++ b/src/components/ToolListItemCard/ToolListItemCard.tsx
@@ -1,0 +1,81 @@
+import {
+  Card,
+  CardContent,
+  Chip,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { PartialDeep } from 'type-fest';
+import { StyleProps } from '~/common';
+import type { ToolListItemFragment } from '~/common/fragments/tool.graphql';
+import { CardActionAreaLink } from '../Routing';
+
+export interface ToolListItemCardProps extends StyleProps {
+  tool?: PartialDeep<ToolListItemFragment>;
+}
+
+export const ToolListItemCard = ({
+  tool,
+  sx,
+  className,
+}: ToolListItemCardProps) => {
+  const title = tool?.name.value;
+  const description = tool?.description.value;
+  const isAiBased = tool?.aiBased?.value;
+
+  return (
+    <Card
+      sx={[
+        (theme) => ({
+          width: '100%',
+          maxWidth: theme.breakpoints.values.sm,
+        }),
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+      className={className}
+    >
+      <CardActionAreaLink to={`/tools/${tool?.id}`} disabled={!tool?.id}>
+        <CardContent sx={{ p: 2 }}>
+          <Stack
+            direction="row"
+            alignItems="flex-start"
+            spacing={1}
+            sx={{ mb: 1 }}
+          >
+            <Typography variant="h6" component="h3" noWrap sx={{ flex: 1 }}>
+              {title ?? <Skeleton width="60%" />}
+            </Typography>
+            {isAiBased && (
+              <Chip
+                label="AI-Based"
+                size="small"
+                variant="outlined"
+                sx={{ flexShrink: 0 }}
+              />
+            )}
+          </Stack>
+          {description ? (
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {description}
+            </Typography>
+          ) : (
+            <>
+              <Skeleton variant="text" width="95%" />
+              <Skeleton variant="text" width="85%" />
+            </>
+          )}
+        </CardContent>
+      </CardActionAreaLink>
+    </Card>
+  );
+};

--- a/src/components/ToolListItemCard/index.ts
+++ b/src/components/ToolListItemCard/index.ts
@@ -1,0 +1,2 @@
+export { ToolListItemCard } from './ToolListItemCard';
+export type { ToolListItemCardProps } from './ToolListItemCard';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useFirstMountState';
 export * from './useSet';
 export * from './useUserAgent';
+export * from './useDetailTabs';
 export * from './useQueryParams';
 export * from './useIsomorphicEffect';
 export * from './useRequest';

--- a/src/hooks/useDetailTabs.ts
+++ b/src/hooks/useDetailTabs.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { makeQueryHandler, StringParam, withDefault } from './useQueryParams';
+
+const useTabFilter = makeQueryHandler({
+  tab: withDefault(StringParam, 'profile'),
+});
+
+/**
+ * Manages URL-synced tab state for detail pages.
+ *
+ * Falls back to the default tab synchronously during render if the current
+ * URL value isn't in the available tab list, avoiding the one-frame flicker
+ * caused by the useEffect/reset pattern.
+ *
+ * @param availableTabs - The tab values that are currently accessible.
+ *   Tabs that aren't readable (e.g. due to permissions) should be excluded.
+ *   Always include 'profile' (or whatever your default is) in this list.
+ * @param defaultTab - The tab to fall back to. Defaults to 'profile'.
+ *
+ * @example
+ * const [tab, setTab] = useDetailTabs([
+ *   'profile',
+ *   ...(canReadProjects ? ['projects'] : []),
+ * ]);
+ */
+export const useDetailTabs = (
+  availableTabs: readonly string[],
+  defaultTab = 'profile'
+) => {
+  const [filters, setFilters] = useTabFilter();
+
+  const activeTab = useMemo(
+    () => (availableTabs.includes(filters.tab) ? filters.tab : defaultTab),
+    [availableTabs, filters.tab, defaultTab]
+  );
+
+  const setTab = (tab: string) => setFilters({ tab });
+
+  return [activeTab, setTab] as const;
+};

--- a/src/scenes/FieldRegions/Detail/FieldRegionDetail.tsx
+++ b/src/scenes/FieldRegions/Detail/FieldRegionDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { canEditAny } from '~/common';
@@ -14,20 +14,15 @@ import {
 import { EditFieldRegion } from '~/components/FieldRegion';
 import { Link } from '~/components/Routing';
 import { Tab, TabsContainer } from '~/components/Tabs';
-import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
+import { useDetailTabs } from '~/hooks';
 import { Error } from '../../../components/Error';
 import { IconButton } from '../../../components/IconButton';
 import { Redacted } from '../../../components/Redacted';
 import { FieldRegionDetailDocument } from './FieldRegionDetail.graphql';
 import { FieldRegionProjectsPanel } from './Tabs/Projects/FieldRegionProjectsPanel';
 
-const useFieldRegionDetailFilters = makeQueryHandler({
-  tab: withDefault(EnumParam(['profile', 'projects']), 'profile'),
-});
-
 export const FieldRegionDetail = () => {
   const { fieldRegionId = '' } = useParams();
-  const [filters, setFilters] = useFieldRegionDetailFilters();
 
   const [editRegionState, editRegion] = useDialog();
 
@@ -39,16 +34,12 @@ export const FieldRegionDetail = () => {
   const fieldRegion = data?.fieldRegion;
   const canReadProjects = fieldRegion?.projects.canRead !== false;
 
-  const readableTabs = useMemo(
-    () => ['profile', ...(canReadProjects ? ['projects'] : [])],
-    [canReadProjects]
+  const [activeTab, setTab] = useDetailTabs(
+    useMemo(
+      () => ['profile', ...(canReadProjects ? ['projects'] : [])],
+      [canReadProjects]
+    )
   );
-
-  useEffect(() => {
-    if (!readableTabs.includes(filters.tab)) {
-      setFilters({ tab: 'profile' });
-    }
-  }, [filters.tab, readableTabs, setFilters]);
 
   return (
     <Box
@@ -95,12 +86,8 @@ export const FieldRegionDetail = () => {
           </Box>
 
           <TabsContainer>
-            <TabContext
-              value={
-                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
-              }
-            >
-              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+            <TabContext value={activeTab}>
+              <TabList onChange={(_, next) => setTab(next)}>
                 <Tab label="Profile" value="profile" />
                 {canReadProjects && <Tab label="Projects" value="projects" />}
               </TabList>

--- a/src/scenes/FieldZones/Detail/FieldZoneDetail.tsx
+++ b/src/scenes/FieldZones/Detail/FieldZoneDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { canEditAny } from '~/common';
@@ -13,7 +13,7 @@ import {
 } from '~/components/DisplaySimpleProperty';
 import { Link } from '~/components/Routing';
 import { Tab, TabsContainer } from '~/components/Tabs';
-import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
+import { useDetailTabs } from '~/hooks';
 import { Error } from '../../../components/Error';
 import { EditFieldZone } from '../../../components/FieldZone';
 import { IconButton } from '../../../components/IconButton';
@@ -21,13 +21,8 @@ import { Redacted } from '../../../components/Redacted';
 import { FieldZoneDetailDocument } from './FieldZoneDetail.graphql';
 import { FieldZoneProjectsPanel } from './Tabs/Projects/FieldZoneProjectsPanel';
 
-const useFieldZoneDetailFilters = makeQueryHandler({
-  tab: withDefault(EnumParam(['profile', 'projects']), 'profile'),
-});
-
 export const FieldZoneDetail = () => {
   const { fieldZoneId = '' } = useParams();
-  const [filters, setFilters] = useFieldZoneDetailFilters();
 
   const [editZoneState, editZone] = useDialog();
 
@@ -39,16 +34,12 @@ export const FieldZoneDetail = () => {
   const fieldZone = data?.fieldZone;
   const canReadProjects = fieldZone?.projects.canRead !== false;
 
-  const readableTabs = useMemo(
-    () => ['profile', ...(canReadProjects ? ['projects'] : [])],
-    [canReadProjects]
+  const [activeTab, setTab] = useDetailTabs(
+    useMemo(
+      () => ['profile', ...(canReadProjects ? ['projects'] : [])],
+      [canReadProjects]
+    )
   );
-
-  useEffect(() => {
-    if (!readableTabs.includes(filters.tab)) {
-      setFilters({ tab: 'profile' });
-    }
-  }, [filters.tab, readableTabs, setFilters]);
 
   return (
     <Box
@@ -95,12 +86,8 @@ export const FieldZoneDetail = () => {
           </Box>
 
           <TabsContainer>
-            <TabContext
-              value={
-                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
-              }
-            >
-              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+            <TabContext value={activeTab}>
+              <TabList onChange={(_, next) => setTab(next)}>
                 <Tab label="Profile" value="profile" />
                 {canReadProjects && <Tab label="Projects" value="projects" />}
               </TabList>

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { PartialDeep } from 'type-fest';
@@ -11,7 +11,7 @@ import { BooleanProperty } from '~/components/BooleanProperty';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
 import { Sensitivity } from '~/components/Sensitivity';
 import { Tab, TabsContainer } from '~/components/Tabs';
-import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
+import { useDetailTabs } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
 import { useDialog } from '../../../components/Dialog';
 import { Error } from '../../../components/Error';
@@ -27,16 +27,8 @@ import { LanguageDetailPosts } from './Tabs/Posts/LanguageDetailPosts';
 import { LanguageDetailProfile } from './Tabs/Profile/LanguageDetailProfile';
 import { LanguageDetailProjects } from './Tabs/Projects/LanguageDetailProjects';
 
-const useLanguageDetailsFilters = makeQueryHandler({
-  tab: withDefault(
-    EnumParam(['profile', 'locations', 'projects', 'posts']),
-    'profile'
-  ),
-});
-
 export const LanguageDetail = () => {
   const { languageId = '' } = useParams();
-  const [filters, setFilters] = useLanguageDetailsFilters();
   const { data, error } = useQuery(LanguageDocument, {
     variables: { languageId },
     fetchPolicy: 'cache-and-network',
@@ -71,11 +63,7 @@ export const LanguageDetail = () => {
     [canReadLocations, canReadProjects, canReadPosts]
   );
 
-  useEffect(() => {
-    if (!readableTabs.includes(filters.tab)) {
-      setFilters({ tab: 'profile' });
-    }
-  }, [filters.tab, readableTabs, setFilters]);
+  const [activeTab, setTab] = useDetailTabs(readableTabs);
 
   return (
     <Box
@@ -149,12 +137,8 @@ export const LanguageDetail = () => {
             />
           </Grid>
           <TabsContainer>
-            <TabContext
-              value={
-                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
-              }
-            >
-              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+            <TabContext value={activeTab}>
+              <TabList onChange={(_, next) => setTab(next)}>
                 <Tab label="Profile" value="profile" />
                 {canReadLocations && (
                   <Tab label="Locations" value="locations" />

--- a/src/scenes/Partners/Detail/PartnerDetail.tsx
+++ b/src/scenes/Partners/Detail/PartnerDetail.tsx
@@ -19,7 +19,7 @@ import { IconButton } from '~/components/IconButton';
 import { InactiveStatusIcon } from '~/components/Icons/InactiveStatusIcon';
 import { Tab, TabsContainer } from '~/components/Tabs';
 import { TogglePinButton } from '~/components/TogglePinButton';
-import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
+import { useDetailTabs } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
 import { EditablePartnerField, EditPartner } from '../Edit';
 import { PartnersQueryVariables } from '../List/PartnerList.graphql';
@@ -188,27 +188,21 @@ const PartnerDataButtons = ({
   </Box>
 );
 
-const usePartnerDetailsFilters = makeQueryHandler({
-  tab: withDefault(
-    EnumParam([
-      'profile',
-      'people',
-      'projects',
-      'finance',
-      'notes',
-      'engagements',
-    ]),
-    'profile'
-  ),
-});
 const PartnerTabs = (props: PartnerViewEditProps) => {
-  const [filters, setFilters] = usePartnerDetailsFilters();
+  const [activeTab, setTab] = useDetailTabs([
+    'profile',
+    'finance',
+    'people',
+    'projects',
+    'engagements',
+    'notes',
+  ]);
 
   return (
     <TabsContainer>
-      <TabContext value={filters.tab}>
+      <TabContext value={activeTab}>
         <TabList
-          onChange={(_e, tab) => setFilters({ ...filters, tab })}
+          onChange={(_e, tab) => setTab(tab)}
           aria-label="partner navigation tabs"
           variant="scrollable"
         >

--- a/src/scenes/Root/Root.tsx
+++ b/src/scenes/Root/Root.tsx
@@ -54,6 +54,9 @@ const SearchResults = loadable(() => import('../SearchResults'), {
 const FieldZones = loadable(() => import('../FieldZones/FieldZones'), {
   resolveComponent: (m) => m.FieldZones,
 });
+const Tools = loadable(() => import('../Tools'), {
+  resolveComponent: (m) => m.Tools,
+});
 const Dashboard = loadable(() => import('../Dashboard'), {
   resolveComponent: (m) => m.DashboardRoutes,
 });
@@ -86,6 +89,7 @@ export const Root = () => {
         <Route path="field-regions/*" element={<FieldRegions />} />
         <Route path="locations/*" element={<Locations />} />
         <Route path="field-zones/*" element={<FieldZones />} />
+        <Route path="tools/*" element={<Tools />} />
         {NotFoundRoute}
       </Route>
       <Route key="auth" element={<AuthLayout />}>

--- a/src/scenes/SearchResults/Search.graphql
+++ b/src/scenes/SearchResults/Search.graphql
@@ -17,4 +17,5 @@ fragment SearchResultItem on SearchResult {
   ...PartnerListItem
   ...FieldRegionCard
   ...FieldZoneCard
+  ...ToolListItem
 }

--- a/src/scenes/SearchResults/SearchResults.tsx
+++ b/src/scenes/SearchResults/SearchResults.tsx
@@ -5,6 +5,7 @@ import { ReactElement } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { FieldRegionCard } from '~/components/FieldRegionCard';
 import { FieldZoneCard } from '~/components/FieldZoneCard';
+import { ToolListItemCard } from '~/components/ToolListItemCard';
 import { Error } from '../../components/Error';
 import { LanguageListItemCard } from '../../components/LanguageListItemCard';
 import { LocationCard } from '../../components/LocationCard';
@@ -35,6 +36,7 @@ export const SearchResults = () => {
           'Story',
           'FieldRegion',
           'FieldZone',
+          'Tool',
         ],
       },
     },
@@ -63,6 +65,7 @@ export const SearchResults = () => {
             <ProjectListItemCard />
             <UserListItemCardLandscape />
             <PartnerListItemCard />
+            <ToolListItemCard />
             <ProjectListItemCard />
             <PartnerListItemCard />
             <UserListItemCardLandscape />
@@ -127,6 +130,11 @@ const displayItem = (
       return [
         <Navigate replace to={`/field-zones/${item.id}`} />,
         <FieldZoneCard key={item.id} fieldZone={item} />,
+      ];
+    case 'Tool':
+      return [
+        <Navigate replace to={`/tools/${item.id}`} />,
+        <ToolListItemCard key={item.id} tool={item} />,
       ];
     case 'Film':
     case 'Story':

--- a/src/scenes/Tools/Detail/Tabs/Profile/ToolDetailProfile.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Profile/ToolDetailProfile.tsx
@@ -1,0 +1,53 @@
+import { Stack } from '@mui/material';
+import {
+  DisplaySimpleProperty,
+  DisplaySimplePropertyProps,
+} from '~/components/DisplaySimpleProperty';
+import { TabPanelContent } from '~/components/Tabs';
+import type { ToolProfileFragment } from '../../ToolDetail.graphql';
+
+interface ToolDetailProfileProps {
+  tool?: ToolProfileFragment;
+}
+
+export const ToolDetailProfile = ({ tool }: ToolDetailProfileProps) => {
+  const { description, aiBased } = tool ?? {};
+
+  return (
+    <TabPanelContent>
+      <Stack sx={{ p: 2, gap: 2 }}>
+        <DisplayProperty
+          label="Description"
+          value={description?.value}
+          loading={!tool}
+        />
+        <DisplayProperty
+          label="Is this AI based?"
+          value={
+            aiBased?.value != null ? (aiBased.value ? 'Yes' : 'No') : undefined
+          }
+          loading={!tool}
+        />
+      </Stack>
+    </TabPanelContent>
+  );
+};
+
+const DisplayProperty = (props: DisplaySimplePropertyProps) =>
+  !props.value && !props.loading ? null : (
+    <DisplaySimpleProperty
+      variant="body1"
+      {...{ component: 'div' }}
+      {...props}
+      loadingWidth="20ch"
+      LabelProps={{
+        color: 'textSecondary',
+        variant: 'body2',
+        ...props.LabelProps,
+      }}
+      ValueProps={{
+        color: 'textPrimary',
+        ...props.ValueProps,
+      }}
+    />
+  );

--- a/src/scenes/Tools/Detail/Tabs/Profile/ToolDetailProfile.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Profile/ToolDetailProfile.tsx
@@ -1,10 +1,10 @@
 import { Stack } from '@mui/material';
+import type { ToolProfileFragment } from '~/common/fragments/tool.graphql';
 import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
 import { TabPanelContent } from '~/components/Tabs';
-import type { ToolProfileFragment } from '../../ToolDetail.graphql';
 
 interface ToolDetailProfileProps {
   tool?: ToolProfileFragment;

--- a/src/scenes/Tools/Detail/Tabs/Profile/index.ts
+++ b/src/scenes/Tools/Detail/Tabs/Profile/index.ts
@@ -1,0 +1,1 @@
+export { ToolDetailProfile } from './ToolDetailProfile';

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/EngagementPanel.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/EngagementPanel.tsx
@@ -27,10 +27,9 @@ export const EngagementPanel = ({ toolId }: EngagementPanelProps) => {
     query: EngagementListDocument,
     variables: {
       input: {
-        // `tool` filter not yet in local schema types — cast until codegen catches up.
         filter: {
           tool: { id: toolId },
-        } as unknown as EngagementListInput['filter'],
+        },
       } satisfies EngagementListInput,
     },
     listAt: 'engagements',

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/EngagementPanel.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/EngagementPanel.tsx
@@ -1,0 +1,64 @@
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import { EngagementListInput } from '~/api/schema.graphql';
+import {
+  EngagementDataGridRowFragment as Engagement,
+  EngagementColumns,
+  EngagementInitialState,
+  EngagementToolbar,
+  useProcessEngagementUpdate,
+} from '~/components/EngagementDataGrid';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSlots,
+  useDataGridSource,
+} from '~/components/Grid';
+import { TabPanelContent } from '~/components/Tabs';
+import { EngagementListDocument } from '../../../../../Projects/List/EngagementList.graphql';
+
+interface EngagementPanelProps {
+  toolId: string;
+}
+
+export const EngagementPanel = ({ toolId }: EngagementPanelProps) => {
+  const [dataGridProps] = useDataGridSource({
+    query: EngagementListDocument,
+    variables: {
+      input: {
+        // `tool` filter not yet in local schema types — cast until codegen catches up.
+        filter: {
+          tool: { id: toolId },
+        } as unknown as EngagementListInput['filter'],
+      } satisfies EngagementListInput,
+    },
+    listAt: 'engagements',
+    initialInput: {
+      sort: EngagementColumns[0]!.field,
+    },
+  });
+
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: EngagementToolbar },
+  });
+
+  const processRowUpdate = useProcessEngagementUpdate();
+
+  return (
+    <TabPanelContent>
+      <DataGrid<Engagement>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={EngagementColumns}
+        initialState={EngagementInitialState}
+        processRowUpdate={processRowUpdate}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
+  );
+};

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/ProjectPanel.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/ProjectPanel.tsx
@@ -1,0 +1,60 @@
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import { ProjectListInput } from '~/api/schema.graphql';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSlots,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  ProjectDataGridRowFragment as Project,
+  ProjectColumns,
+  ProjectInitialState,
+  ProjectToolbar,
+} from '~/components/ProjectDataGrid';
+import { TabPanelContent } from '~/components/Tabs';
+import { ProjectListDocument } from '../../../../../Projects/List/ProjectList.graphql';
+
+interface ProjectPanelProps {
+  toolId: string;
+}
+
+export const ProjectPanel = ({ toolId }: ProjectPanelProps) => {
+  const [dataGridProps] = useDataGridSource({
+    query: ProjectListDocument,
+    variables: {
+      input: {
+        // `tool` filter not yet in local schema types — cast until codegen catches up.
+        filter: {
+          tool: { id: toolId },
+        } as unknown as ProjectListInput['filter'],
+      } satisfies ProjectListInput,
+    },
+    listAt: 'projects',
+    initialInput: {
+      sort: 'name',
+    },
+  });
+
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: ProjectToolbar },
+  });
+
+  return (
+    <TabPanelContent>
+      <DataGrid<Project>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={ProjectColumns}
+        initialState={ProjectInitialState}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
+  );
+};

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/ProjectPanel.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/ProjectPanel.tsx
@@ -26,10 +26,9 @@ export const ProjectPanel = ({ toolId }: ProjectPanelProps) => {
     query: ProjectListDocument,
     variables: {
       input: {
-        // `tool` filter not yet in local schema types — cast until codegen catches up.
         filter: {
           tool: { id: toolId },
-        } as unknown as ProjectListInput['filter'],
+        },
       } satisfies ProjectListInput,
     },
     listAt: 'projects',

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/index.ts
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/index.ts
@@ -1,0 +1,2 @@
+export { EngagementPanel } from './EngagementPanel';
+export { ProjectPanel } from './ProjectPanel';

--- a/src/scenes/Tools/Detail/Tabs/Usages/ToolDetailUsages.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/ToolDetailUsages.tsx
@@ -1,0 +1,19 @@
+import { EngagementPanel } from './Panels/EngagementPanel';
+import { ProjectPanel } from './Panels/ProjectPanel';
+
+const panels = {
+  Engagement: EngagementPanel,
+  Project: ProjectPanel,
+} satisfies Record<string, React.ComponentType<{ toolId: string }>>;
+
+export type UsageTab = keyof typeof panels;
+
+interface ToolDetailUsagesProps {
+  toolId: string;
+  tab: UsageTab;
+}
+
+export const ToolDetailUsages = ({ toolId, tab }: ToolDetailUsagesProps) => {
+  const Panel = panels[tab];
+  return <Panel toolId={toolId} />;
+};

--- a/src/scenes/Tools/Detail/Tabs/Usages/index.ts
+++ b/src/scenes/Tools/Detail/Tabs/Usages/index.ts
@@ -1,0 +1,1 @@
+export { ToolDetailUsages, type UsageTab } from './ToolDetailUsages';

--- a/src/scenes/Tools/Detail/ToolDetail.graphql
+++ b/src/scenes/Tools/Detail/ToolDetail.graphql
@@ -1,0 +1,6 @@
+query ToolDetail($id: ID!) {
+  tool(id: $id) {
+    ...ToolProfile
+    ...ToolForm
+  }
+}

--- a/src/scenes/Tools/Detail/ToolDetail.tsx
+++ b/src/scenes/Tools/Detail/ToolDetail.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import { canEditAny } from '~/common';
@@ -12,18 +12,13 @@ import { IconButton } from '~/components/IconButton';
 import { Redacted } from '~/components/Redacted';
 import { Tab, TabsContainer } from '~/components/Tabs';
 import { EditTool } from '~/components/Tool';
-import { makeQueryHandler, StringParam, withDefault } from '~/hooks';
+import { useDetailTabs } from '~/hooks';
 import { ToolDetailProfile } from './Tabs/Profile/ToolDetailProfile';
 import { ToolDetailUsages, UsageTab } from './Tabs/Usages';
 import { ToolDetailDocument } from './ToolDetail.graphql';
 
-const useToolDetailFilters = makeQueryHandler({
-  tab: withDefault(StringParam, 'profile'),
-});
-
 export const ToolDetail = () => {
   const { toolId = '' } = useParams();
-  const [filters, setFilters] = useToolDetailFilters();
   const [editState, edit] = useDialog();
 
   const { data, error } = useQuery(ToolDetailDocument, {
@@ -43,16 +38,7 @@ export const ToolDetail = () => {
     [tool?.containerSummary]
   );
 
-  const readableTabs = useMemo(
-    () => ['profile', ...tabs.map((t) => t.value)],
-    [tabs]
-  );
-
-  useEffect(() => {
-    if (!readableTabs.includes(filters.tab)) {
-      setFilters({ tab: 'profile' });
-    }
-  }, [filters.tab, readableTabs, setFilters]);
+  const [activeTab, setTab] = useDetailTabs(tabs.map((t) => t.value));
 
   return (
     <Box
@@ -93,12 +79,8 @@ export const ToolDetail = () => {
           </Box>
 
           <TabsContainer>
-            <TabContext
-              value={
-                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
-              }
-            >
-              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+            <TabContext value={activeTab}>
+              <TabList onChange={(_, next) => setTab(next)}>
                 <Tab label="Profile" value="profile" />
                 {tabs.map((tab) => (
                   <Tab key={tab.value} label={tab.label} value={tab.value} />

--- a/src/scenes/Tools/Detail/ToolDetail.tsx
+++ b/src/scenes/Tools/Detail/ToolDetail.tsx
@@ -1,0 +1,125 @@
+import { useQuery } from '@apollo/client';
+import { Edit } from '@mui/icons-material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
+import { useEffect, useMemo } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useParams } from 'react-router-dom';
+import { canEditAny } from '~/common';
+import { useDialog } from '~/components/Dialog';
+import { Error } from '~/components/Error';
+import { IconButton } from '~/components/IconButton';
+import { Redacted } from '~/components/Redacted';
+import { Tab, TabsContainer } from '~/components/Tabs';
+import { EditTool } from '~/components/Tool';
+import { makeQueryHandler, StringParam, withDefault } from '~/hooks';
+import { ToolDetailProfile } from './Tabs/Profile/ToolDetailProfile';
+import { ToolDetailUsages, UsageTab } from './Tabs/Usages';
+import { ToolDetailDocument } from './ToolDetail.graphql';
+
+const useToolDetailFilters = makeQueryHandler({
+  tab: withDefault(StringParam, 'profile'),
+});
+
+export const ToolDetail = () => {
+  const { toolId = '' } = useParams();
+  const [filters, setFilters] = useToolDetailFilters();
+  const [editState, edit] = useDialog();
+
+  const { data, error } = useQuery(ToolDetailDocument, {
+    variables: { id: toolId },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const tool = data?.tool;
+  const canEditTool = canEditAny(tool);
+
+  const tabs = useMemo(
+    () =>
+      (tool?.containerSummary ?? []).map((c) => ({
+        value: c.containerType as UsageTab,
+        label: c.containerType === 'Engagement' ? 'Engagements' : 'Projects',
+      })),
+    [tool?.containerSummary]
+  );
+
+  const readableTabs = useMemo(
+    () => ['profile', ...tabs.map((t) => t.value)],
+    [tabs]
+  );
+
+  useEffect(() => {
+    if (!readableTabs.includes(filters.tab)) {
+      setFilters({ tab: 'profile' });
+    }
+  }, [filters.tab, readableTabs, setFilters]);
+
+  return (
+    <Box
+      component="main"
+      sx={(theme) => ({
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        overflowY: 'auto',
+        padding: 4,
+        gap: 3,
+        maxWidth: theme.breakpoints.values.xl,
+      })}
+    >
+      <Helmet title={tool?.name.value || undefined} />
+      <Error error={error}>
+        {{ NotFound: 'Could not find tool', Default: 'Error loading tool' }}
+      </Error>
+      {!error && (
+        <>
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+            <Typography variant="h2" sx={{ mr: 2, lineHeight: 'inherit' }}>
+              {!tool ? (
+                <Skeleton width="20ch" />
+              ) : (
+                tool.name.value ?? (
+                  <Redacted info="You don't have permission to view this tool's name" />
+                )
+              )}
+            </Typography>
+            {canEditTool ? (
+              <Tooltip title="Edit Tool">
+                <IconButton aria-label="edit tool" onClick={edit}>
+                  <Edit />
+                </IconButton>
+              </Tooltip>
+            ) : null}
+          </Box>
+
+          <TabsContainer>
+            <TabContext
+              value={
+                readableTabs.includes(filters.tab) ? filters.tab : 'profile'
+              }
+            >
+              <TabList onChange={(_, next) => setFilters({ tab: next })}>
+                <Tab label="Profile" value="profile" />
+                {tabs.map((tab) => (
+                  <Tab key={tab.value} label={tab.label} value={tab.value} />
+                ))}
+              </TabList>
+
+              <TabPanel value="profile">
+                {tool && <ToolDetailProfile tool={tool} />}
+              </TabPanel>
+
+              {tabs.map((tab) => (
+                <TabPanel key={tab.value} value={tab.value}>
+                  <ToolDetailUsages toolId={toolId} tab={tab.value} />
+                </TabPanel>
+              ))}
+            </TabContext>
+          </TabsContainer>
+
+          {tool ? <EditTool tool={tool} {...editState} /> : null}
+        </>
+      )}
+    </Box>
+  );
+};

--- a/src/scenes/Tools/Detail/index.ts
+++ b/src/scenes/Tools/Detail/index.ts
@@ -1,0 +1,1 @@
+export { ToolDetail } from './ToolDetail';

--- a/src/scenes/Tools/Tools.tsx
+++ b/src/scenes/Tools/Tools.tsx
@@ -1,0 +1,10 @@
+import { Route, Routes } from 'react-router-dom';
+import { NotFoundRoute } from '../../components/Error';
+import { ToolDetail } from './Detail';
+
+export const Tools = () => (
+  <Routes>
+    <Route path=":toolId" element={<ToolDetail />} />
+    {NotFoundRoute}
+  </Routes>
+);

--- a/src/scenes/Tools/Tools.tsx
+++ b/src/scenes/Tools/Tools.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
-import { NotFoundRoute } from '../../components/Error';
+import { NotFoundRoute } from '~/components/Error';
 import { ToolDetail } from './Detail';
 
 export const Tools = () => (

--- a/src/scenes/Tools/index.ts
+++ b/src/scenes/Tools/index.ts
@@ -1,0 +1,1 @@
+export { Tools } from './Tools';

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -14,7 +14,7 @@ import { Redacted } from '~/components/Redacted';
 import { Tab, TabsContainer } from '~/components/Tabs';
 import { TogglePinButton } from '~/components/TogglePinButton';
 import { UserPhoto } from '~/components/UserPhoto';
-import { EnumParam, makeQueryHandler, withDefault } from '~/hooks';
+import { useDetailTabs } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
 import { EditUser } from '../Edit';
 import { UsersQueryVariables } from '../List/users.graphql';
@@ -23,10 +23,6 @@ import { UserDetailProfile } from './Tabs/Profile/UserDetailProfile';
 import { UserDetailProjects } from './Tabs/Projects/UserDetailProjects';
 import { UserDocument } from './UserDetail.graphql';
 
-const useUserDetailsFilters = makeQueryHandler({
-  tab: withDefault(EnumParam(['profile', 'projects']), 'profile'),
-});
-
 export const UserDetail = () => {
   const { userId = '' } = useParams();
   const { data, error } = useQuery(UserDocument, {
@@ -34,7 +30,7 @@ export const UserDetail = () => {
     fetchPolicy: 'cache-and-network',
   });
   useComments(userId);
-  const [filters, setFilters] = useUserDetailsFilters();
+  const [activeTab, setTab] = useDetailTabs(['profile', 'projects']);
   const [editUserState, editUser] = useDialog();
   const user = data?.user;
 
@@ -105,9 +101,9 @@ export const UserDetail = () => {
           {user && <UserPhoto user={user} sx={{ alignSelf: 'start' }} />}
 
           <TabsContainer>
-            <TabContext value={filters.tab}>
+            <TabContext value={activeTab}>
               <TabList
-                onChange={(_e, tab) => setFilters({ ...filters, tab })}
+                onChange={(_e, tab) => setTab(tab)}
                 aria-label="user navigation tabs"
                 variant="scrollable"
               >


### PR DESCRIPTION
API PR: https://github.com/SeedCompany/cord-api-v3/pull/3764

### Summary
Two related changes that extend the Tools feature and improve tab state management across detail pages.

### Tool Detail Page
Adds a full detail page for Tools at [/tools/:toolId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

### What's included:

Profile tab — displays the tool's description
Dynamic usage tabs — driven by [containerSummary](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from the API; renders an Engagements tab and/or Projects tab only when the tool has usages of that type
Engagement/Project panels — reuse existing DataGrid components with a tool-scoped filter
Search integration — Tool cards appear in global search results with clickable routing to the detail page
Route wired at [/tools/:toolId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the root router
[useDetailTabs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) Hook
Extracts the URL-synced tab state pattern shared across all detail pages into a single reusable hook.

Motivation: Every detail page was rolling its own [makeQueryHandler](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) + useEffect reset pattern. The hook consolidates this into one place and eliminates the one-frame flicker caused by the useEffect/reset approach by computing the fallback synchronously.
