### PR TITLE
Updates parameters for Rev79 `GetCommunitiesByProjectId` query

### DIFF
--- a/src/api/seed/useRev79Communities.ts
+++ b/src/api/seed/useRev79Communities.ts
@@ -9,8 +9,8 @@ export interface Rev79Community {
 }
 
 const QUERY = gql`
-  query GetCommunitiesByProjectId($filter: JSONObject) {
-    getCommunitiesByProjectId(filter: $filter) {
+  query GetCommunitiesByProjectId($projectId: ID!) {
+    getCommunitiesByProjectId(projectId: $projectId) {
       id
       communitiesInUse {
         id
@@ -48,7 +48,7 @@ export const useRev79Communities = (
     seedClient
       .query<Rev79ProjectsData>({
         query: QUERY,
-        variables: { filter: { id: rev79ProjectId } },
+        variables: { projectId: rev79ProjectId },
       })
       .then(({ data }) => {
         if (!cancelled) {


### PR DESCRIPTION
Note:  This PR must be released in tangent with this [seed-api PR](https://github.com/SeedCompany/seed-api/pull/1063).

This pull request updates the way communities are queried by project ID in the `useRev79Communities` hook. The main change is to simplify and clarify the query by using a direct `projectId` variable instead of a filter object.

**GraphQL Query Simplification:**

* The `GetCommunitiesByProjectId` query now takes a direct `projectId: ID!` argument instead of a `filter: JSONObject`, and passes this directly to the backend.
* The hook now sets the `projectId` variable directly in the query variables, instead of wrapping it in a filter object.