### PR TITLE
Add partner organization management to user profiles

### DIFF
--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
@@ -8,6 +8,7 @@ import {
   DisplaySimpleProperty,
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
+import { Link } from '~/components/Routing';
 import { UserProfileFragment } from './UserDetailProfile.graphql';
 
 interface UserDetailProfileProps {
@@ -15,6 +16,15 @@ interface UserDetailProfileProps {
 }
 
 export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
+  const organization = user.organizations.items[0];
+  const partner = organization
+    ? user.partners.items.find(
+        (item) => item.organization.value?.id === organization.id
+      )
+    : user.partners.items[0];
+  const partnerName =
+    organization?.name.value ?? partner?.organization.value?.name.value;
+
   return (
     <Box
       component={Paper}
@@ -38,6 +48,14 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
         <DisplayProperty
           label="Roles"
           value={labelsFrom(RoleLabels)(user.roles.value)}
+        />
+        <DisplayProperty
+          label="Partner"
+          value={
+            partner && partnerName ? (
+              <Link to={`/partners/${partner.id}`}>{partnerName}</Link>
+            ) : null
+          }
         />
         <DisplayProperty
           label="Local Time"

--- a/src/scenes/Users/Edit/EditUser.graphql
+++ b/src/scenes/Users/Edit/EditUser.graphql
@@ -6,3 +6,24 @@ mutation UpdateUser($input: UpdateUser!) {
     }
   }
 }
+
+mutation EditUserOrganization(
+  $userId: ID!
+  $newOrgId: ID!
+  $oldOrgId: ID!
+  $doAssign: Boolean!
+  $doRemove: Boolean!
+) {
+  removeOrganizationFromUser(user: $userId, org: $oldOrgId)
+    @include(if: $doRemove) {
+    user {
+      id
+    }
+  }
+  assignOrganizationToUser(user: $userId, org: $newOrgId)
+    @include(if: $doAssign) {
+    user {
+      id
+    }
+  }
+}

--- a/src/scenes/Users/Edit/EditUser.tsx
+++ b/src/scenes/Users/Edit/EditUser.tsx
@@ -1,17 +1,27 @@
 import { useMutation } from '@apollo/client';
 import { useMemo } from 'react';
 import { Except } from 'type-fest';
+import { onUpdateInvalidateProps } from '~/api';
 import { UpdateUser as UpdateUserInput } from '~/api/schema.graphql';
+import type { OrganizationLookupItemFragment } from '../../../components/form/Lookup/Organization/OrganizationLookup.graphql';
 import { UserForm, UserFormProps } from '../UserForm';
-import { UpdateUserDocument } from './EditUser.graphql';
+import {
+  EditUserOrganizationDocument,
+  UpdateUserDocument,
+} from './EditUser.graphql';
+
+type EditUserFormValues = UpdateUserInput & {
+  organization?: OrganizationLookupItemFragment | null;
+};
 
 export type EditUserProps = Except<
-  UserFormProps<UpdateUserInput>,
+  UserFormProps<EditUserFormValues>,
   'onSubmit' | 'initialValues'
 >;
 
 export const EditUser = (props: EditUserProps) => {
   const [updateUser] = useMutation(UpdateUserDocument);
+  const [editOrganization] = useMutation(EditUserOrganizationDocument);
   const user = props.user;
 
   const initialValues = useMemo(
@@ -31,19 +41,38 @@ export const EditUser = (props: EditUserProps) => {
             roles: user.roles.value,
             status: user.status.value,
             gender: user.gender.value,
+            organization: user.organizations.items[0] ?? null,
           }
         : undefined,
     [user]
   );
 
   return (
-    <UserForm<UpdateUserInput>
+    <UserForm<EditUserFormValues>
       title="Edit Person"
       {...props}
       initialValues={initialValues}
-      onSubmit={async (input) => {
+      onSubmit={async ({ organization: newOrg, ...userInput }) => {
         await updateUser({
-          variables: { input },
+          variables: { input: userInput },
+        });
+
+        const oldOrg = user?.organizations.items[0] ?? null;
+        const orgChanged = newOrg?.id !== oldOrg?.id;
+        if (!user || !orgChanged) return;
+
+        const doRemove = !!oldOrg;
+        const doAssign = !!newOrg;
+        await editOrganization({
+          variables: {
+            userId: user.id,
+            // These are required GraphQL variables even when skipped by @include.
+            newOrgId: newOrg?.id ?? user.id,
+            oldOrgId: oldOrg?.id ?? user.id,
+            doAssign,
+            doRemove,
+          },
+          update: onUpdateInvalidateProps(user, 'organizations'),
         });
       }}
     />

--- a/src/scenes/Users/UserForm/UserForm.graphql
+++ b/src/scenes/Users/UserForm/UserForm.graphql
@@ -3,4 +3,11 @@ fragment UserForm on User {
   roles {
     assignableRoles
   }
+  organizations {
+    canRead
+    canCreate
+    items {
+      ...OrganizationLookupItem
+    }
+  }
 }

--- a/src/scenes/Users/UserForm/UserForm.tsx
+++ b/src/scenes/Users/UserForm/UserForm.tsx
@@ -20,6 +20,7 @@ import {
   TextField,
 } from '../../../components/form';
 import { AutocompleteField } from '../../../components/form/AutocompleteField';
+import { OrganizationField } from '../../../components/form/Lookup/Organization';
 import { useSession } from '../../../components/Session';
 import { UserFormFragment } from './UserForm.graphql';
 
@@ -164,6 +165,13 @@ export const UserForm = <T, R = void>({
             />
           )}
         </SecuredField>
+        {user?.organizations.canRead && (
+          <OrganizationField
+            name="organization"
+            label="Partner"
+            disabled={!user.organizations.canCreate}
+          />
+        )}
       </Stack>
     </DialogForm>
   );


### PR DESCRIPTION
Enhances the user profile by adding the ability to assign a Partner to a Person and the Partner to be listed on the Details tab with a link to the partner organization. This includes mutations for assigning and removing organizations. 

Initially will be restricted to Admins, API PR: SeedCompany/cord-api-v3/pull/3770

Co-authored with Copilot and Claude Code.

Tested locally, still working on permissions.

<img width="690" height="682" alt="Screenshot 2026-05-04 at 4 32 23 PM" src="https://github.com/user-attachments/assets/082a4ac0-529d-41c5-b451-167444b22eed" />
<img width="636" height="593" alt="Screenshot 2026-05-04 at 4 32 31 PM" src="https://github.com/user-attachments/assets/0f817800-f657-4672-ab87-dc08c758408c" />