### PR TITLE
User - Partner Grids

### DIFF
--- a/src/components/Grid/GridFilterInputBoolean.tsx
+++ b/src/components/Grid/GridFilterInputBoolean.tsx
@@ -18,8 +18,9 @@ export const GridFilterInputBoolean = (props: GridFilterInputBooleanProps) => {
     ...others
   } = props;
 
-  // TODO MUI produces warning with null value, handle somehow?
-  const value = item.value ?? null;
+  // Use empty string as the "Any" sentinel — passing null to Select renders
+  // a null value on the underlying <input>, which React warns about.
+  const value = item.value ?? '';
 
   const rootProps = useGridRootProps();
   const labelId = useId();
@@ -31,7 +32,9 @@ export const GridFilterInputBoolean = (props: GridFilterInputBooleanProps) => {
 
   const onFilterChange = useCallback(
     (event: SelectChangeEvent<unknown>) => {
-      const next = { ...item, value: event.target.value };
+      const raw = event.target.value;
+      const nextValue = raw === '' ? null : raw;
+      const next = { ...item, value: nextValue };
       // Not using applyValues here because it has a falsy check.
       // Replacing here with nil check, so we can use false as a filter value.
       // Also, only delete item if this is a header filter change,
@@ -88,7 +91,7 @@ export const GridFilterInputBoolean = (props: GridFilterInputBooleanProps) => {
           <rootProps.slots.baseSelectOption
             {...baseSelectOptionProps}
             native={false}
-            value={null}
+            value=""
           >
             <i>Any</i>
           </rootProps.slots.baseSelectOption>
@@ -113,5 +116,11 @@ export const GridFilterInputBoolean = (props: GridFilterInputBooleanProps) => {
   );
 };
 
-const renderValue = (value: boolean | null) =>
-  value == null ? <Box color="text.disabled">Any</Box> : value ? 'Yes' : 'No';
+const renderValue = (value: unknown) =>
+  value === '' || value == null ? (
+    <Box color="text.disabled">Any</Box>
+  ) : value ? (
+    'Yes'
+  ) : (
+    'No'
+  );

--- a/src/components/Grid/GridFilterInputBoolean.tsx
+++ b/src/components/Grid/GridFilterInputBoolean.tsx
@@ -116,11 +116,8 @@ export const GridFilterInputBoolean = (props: GridFilterInputBooleanProps) => {
   );
 };
 
-const renderValue = (value: unknown) =>
-  value === '' || value == null ? (
-    <Box color="text.disabled">Any</Box>
-  ) : value ? (
-    'Yes'
-  ) : (
-    'No'
-  );
+const renderValue = (value: unknown) => {
+  if (value === '' || value == null)
+    return <Box color="text.disabled">Any</Box>;
+  return value === true ? 'Yes' : 'No';
+};

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -265,7 +265,17 @@ function useCachedList<
     { wait: 500 }
   );
 
-  return { rows, total, loading, isCacheComplete, onFetchRows };
+  // Imperatively push a row into the DataGrid so the visible list updates
+  // immediately. The Apollo cache update is the caller's responsibility
+  // (typically via addItemToList in the mutation's update callback) — that
+  // keeps the cache correct for future reads. This sidesteps the prop-vs-
+  // internal row state drift caused by unstable_replaceRows during paged
+  // loads, where cache reactivity alone doesn't reach the grid.
+  const addRow = useMemoizedFn((item: { id: string }) => {
+    apiRef.current.updateRows([item]);
+  });
+
+  return { rows, total, loading, isCacheComplete, onFetchRows, addRow };
 }
 
 // ─── useDataGridSource ───────────────────────────────────────────────────────
@@ -312,17 +322,18 @@ export const useDataGridSource = <
     initialSort,
   } = useViewState({ opName, initialInput, apiRef, variables });
 
-  const { rows, total, loading, isCacheComplete, onFetchRows } = useCachedList({
-    query,
-    variables,
-    variablesWithFilter,
-    listAt,
-    keyArgs,
-    hasFilter,
-    input,
-    viewRef,
-    apiRef,
-  });
+  const { rows, total, loading, isCacheComplete, onFetchRows, addRow } =
+    useCachedList({
+      query,
+      variables,
+      variablesWithFilter,
+      listAt,
+      keyArgs,
+      hasFilter,
+      input,
+      viewRef,
+      apiRef,
+    });
 
   const onSortModelChange: DataGridProps['onSortModelChange'] & {} =
     useMemoizedFn((next) => {
@@ -407,7 +418,7 @@ export const useDataGridSource = <
     slotProps: apiSlotProps,
   } satisfies Partial<DataGridProps>;
 
-  return [dataGridProps] as const;
+  return [dataGridProps, { addRow }] as const;
 };
 
 // ─── Utilities ───────────────────────────────────────────────────────────────

--- a/src/scenes/Partners/Detail/PartnerDetail.graphql
+++ b/src/scenes/Partners/Detail/PartnerDetail.graphql
@@ -7,6 +7,7 @@ query Partner($input: ID!) @live {
 fragment partnerDetails on Partner {
   ...Id
   ...partnerOwnDetails
+  ...partnerDetailPeople
   organization {
     canRead
     canEdit

--- a/src/scenes/Partners/Detail/PartnerDetail.tsx
+++ b/src/scenes/Partners/Detail/PartnerDetail.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client';
 import {
   Edit,
   Event as EventIcon,
+  Person as PersonIcon,
   Timeline as TimelineIcon,
 } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
@@ -185,6 +186,16 @@ const PartnerDataButtons = ({
       children={(date) => <FormattedDate date={date} />}
       loading={!partner}
     />
+    <DataButton
+      label="Point of Contact"
+      onClick={() => edit('partner.pointOfContact')}
+      secured={partner?.pointOfContact}
+      startIcon={<PersonIcon color="info" />}
+      empty="None"
+      redacted="You do not have permission to view point of contact"
+      children={(user) => user.fullName}
+      loading={!partner}
+    />
   </Box>
 );
 
@@ -220,7 +231,7 @@ const PartnerTabs = (props: PartnerViewEditProps) => {
           <PartnerDetailFinance {...props} />
         </TabPanel>
         <TabPanel value="people">
-          <PartnerDetailPeople {...props} />
+          <PartnerDetailPeople partner={props.partner} />
         </TabPanel>
         <TabPanel value="projects">
           <PartnerDetailProjects />

--- a/src/scenes/Partners/Detail/Tabs/People/AddPersonToPartnerForm.tsx
+++ b/src/scenes/Partners/Detail/Tabs/People/AddPersonToPartnerForm.tsx
@@ -1,0 +1,56 @@
+import { useMutation } from '@apollo/client';
+import { Except } from 'type-fest';
+import { addItemToList } from '~/api';
+import { DialogForm, DialogFormProps } from '~/components/Dialog/DialogForm';
+import { SubmitError } from '~/components/form';
+import { UserField, UserLookupItem } from '~/components/form/Lookup/User';
+import { UserDataGridRowFragment } from '~/components/UserDataGrid/userDataGridRow.graphql';
+import {
+  AssignPersonToPartnerDocument,
+  PartnerDetailPeopleFragment,
+} from './PartnerDetailsPeople.graphql';
+
+interface FormValues {
+  user: UserLookupItem;
+}
+
+type AddPersonToPartnerFormProps = Except<
+  DialogFormProps<FormValues>,
+  'onSubmit' | 'initialValues'
+> & {
+  partner: PartnerDetailPeopleFragment;
+  onAdded: (user: UserDataGridRowFragment) => void;
+};
+
+export const AddPersonToPartnerForm = ({
+  partner,
+  onAdded,
+  ...props
+}: AddPersonToPartnerFormProps) => {
+  const [assignOrganization] = useMutation(AssignPersonToPartnerDocument);
+
+  return (
+    <DialogForm<FormValues>
+      title="Add Person to Partner"
+      {...props}
+      onSubmit={async ({ user }) => {
+        const res = await assignOrganization({
+          variables: {
+            user: user.id,
+            org: partner.organization.value!.id,
+          },
+          update: addItemToList({
+            listId: [partner, 'people'],
+            outputToItem: (data) => data.assignOrganizationToUser.user,
+          }),
+        });
+        if (res.data) {
+          onAdded(res.data.assignOrganizationToUser.user);
+        }
+      }}
+    >
+      <SubmitError />
+      <UserField name="user" required />
+    </DialogForm>
+  );
+};

--- a/src/scenes/Partners/Detail/Tabs/People/PartnerDetailPeople.tsx
+++ b/src/scenes/Partners/Detail/Tabs/People/PartnerDetailPeople.tsx
@@ -1,69 +1,138 @@
-import { Add } from '@mui/icons-material';
+import { useMutation } from '@apollo/client';
+import { Delete as DeleteIcon } from '@mui/icons-material';
+import { IconButton, Tooltip } from '@mui/material';
+import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { removeItemFromList } from '~/api';
+import { useDialog } from '~/components/Dialog';
 import {
-  Button,
-  CardActionArea,
-  CardContent,
-  Skeleton,
-  Typography,
-} from '@mui/material';
-import { Many } from 'lodash';
-import { square } from '~/common';
-import { Avatar } from '~/components/Avatar';
+  booleanColumn,
+  createAddItemFooter,
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSlots,
+  useDataGridSource,
+} from '~/components/Grid';
 import { TabPanelContent } from '~/components/Tabs';
-import { UserListItemCardPortrait } from '~/components/UserListItemCard';
-import { EditablePartnerField } from '../../../Edit';
-import { PartnerDetailPeopleFragment } from './PartnerDetailsPeople.graphql';
+import {
+  UserColumns,
+  UserInitialState,
+  UserToolbar,
+} from '~/components/UserDataGrid/UserColumns';
+import { UserDataGridRowFragment as User } from '~/components/UserDataGrid/userDataGridRow.graphql';
+import { AddPersonToPartnerForm } from './AddPersonToPartnerForm';
+import {
+  PartnerDetailPeopleFragment,
+  PartnerPeopleDocument,
+  RemovePersonFromPartnerDocument,
+} from './PartnerDetailsPeople.graphql';
 
 interface Props {
-  partner: PartnerDetailPeopleFragment | undefined;
-  editPartner: (item: Many<EditablePartnerField>) => void;
+  partner?: PartnerDetailPeopleFragment;
 }
 
-export const PartnerDetailPeople = ({ partner, editPartner: edit }: Props) => {
-  return (
-    <TabPanelContent sx={{ pb: 4 }}>
-      <Typography variant="h3" gutterBottom>
-        {partner ? 'Point of Contact' : <Skeleton width="120px" />}
-      </Typography>
-      <UserListItemCardPortrait
-        user={partner?.pointOfContact.value || undefined}
-        content={
-          !partner?.pointOfContact.value ? (
-            <CardActionArea
-              onClick={() => edit('partner.pointOfContact')}
-              sx={{
-                flex: 1,
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-              aria-label="add mentor"
-            >
-              <CardContent>
-                <Avatar
-                  sx={(theme) => ({
-                    ...square(86),
-                    fontSize: 70,
-                    color: theme.palette.background.paper,
-                  })}
-                >
-                  <Add fontSize="inherit" />
-                </Avatar>
-              </CardContent>
-            </CardActionArea>
-          ) : undefined
-        }
-        action={
-          <Button
-            color="primary"
-            disabled={
-              !partner?.pointOfContact || !partner.pointOfContact.canEdit
+export const PartnerDetailPeople = ({ partner }: Props) => {
+  const { partnerId = '' } = useParams();
+  const orgId = partner?.organization.value?.id;
+  const pocId = partner?.pointOfContact.value?.id;
+  const canCreate = partner?.people.canCreate ?? false;
+
+  const [addState, openAdd] = useDialog();
+  const [removePerson] = useMutation(RemovePersonFromPartnerDocument);
+
+  const [dataGridProps, { addRow }] = useDataGridSource({
+    query: PartnerPeopleDocument,
+    variables: { id: partnerId },
+    listAt: 'partner.people',
+    initialInput: { sort: 'fullName' },
+  });
+
+  const columns = useMemo<Array<GridColDef<User>>>(() => {
+    const pocCol: GridColDef<User> = {
+      field: 'isPointOfContact',
+      headerName: 'Point of Contact',
+      width: 160,
+      ...booleanColumn(),
+      valueGetter: (_, row) => row.id === pocId,
+    };
+
+    const actionsCol: GridColDef<User> = {
+      field: 'actions',
+      headerName: '',
+      width: 60,
+      align: 'center',
+      sortable: false,
+      filterable: false,
+      disableColumnMenu: true,
+      hideable: false,
+      renderCell: ({ row }) => (
+        <Tooltip title="Remove from Partner">
+          <IconButton
+            size="small"
+            onClick={() =>
+              void removePerson({
+                variables: { user: row.id, org: orgId! },
+                update: partner
+                  ? removeItemFromList({
+                      listId: [partner, 'people'],
+                      item: row,
+                    })
+                  : undefined,
+              })
             }
-            onClick={() => edit('partner.pointOfContact')}
           >
-            {partner?.pointOfContact.value ? 'Edit' : 'Add'} Point of Contact
-          </Button>
-        }
+            <DeleteIcon fontSize="small" color="error" />
+          </IconButton>
+        </Tooltip>
+      ),
+    };
+
+    const [name, ...rest] = UserColumns;
+    return [
+      name!,
+      pocCol,
+      ...rest,
+      ...(canCreate && orgId ? [actionsCol] : []),
+    ];
+  }, [canCreate, orgId, partner, pocId, removePerson]);
+
+  const AddFooter = useMemo(
+    () =>
+      createAddItemFooter({
+        addItem: openAdd,
+        tooltipTitle: 'Add Person to Partner',
+      }),
+    [openAdd]
+  );
+
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: UserToolbar, footer: AddFooter },
+  });
+
+  return (
+    <TabPanelContent>
+      <DataGrid<User>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={columns}
+        initialState={UserInitialState}
+        getRowId={(row) => row.id}
+        headerFilters
+        hideFooter={!canCreate}
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
       />
+      {canCreate && partner ? (
+        <AddPersonToPartnerForm
+          partner={partner}
+          onAdded={addRow}
+          {...addState}
+        />
+      ) : null}
     </TabPanelContent>
   );
 };

--- a/src/scenes/Partners/Detail/Tabs/People/PartnerDetailsPeople.graphql
+++ b/src/scenes/Partners/Detail/Tabs/People/PartnerDetailsPeople.graphql
@@ -1,9 +1,46 @@
 fragment partnerDetailPeople on Partner {
-  pointOfContact {
-    canRead
-    canEdit
+  id
+  organization {
     value {
-      ...UserListItem
+      id
+    }
+  }
+  pointOfContact {
+    value {
+      id
+    }
+  }
+  people {
+    canCreate
+  }
+}
+
+query PartnerPeople($id: ID!, $input: PartnerPeopleListInput) {
+  partner(id: $id) {
+    id
+    people(input: $input) {
+      canRead
+      hasMore
+      total
+      items {
+        ...userDataGridRow
+      }
+    }
+  }
+}
+
+mutation AssignPersonToPartner($user: ID!, $org: ID!) {
+  assignOrganizationToUser(user: $user, org: $org) {
+    user {
+      ...userDataGridRow
+    }
+  }
+}
+
+mutation RemovePersonFromPartner($user: ID!, $org: ID!) {
+  removeOrganizationFromUser(user: $user, org: $org) {
+    user {
+      id
     }
   }
 }

--- a/src/scenes/Partners/Edit/EditPartner.tsx
+++ b/src/scenes/Partners/Edit/EditPartner.tsx
@@ -4,6 +4,7 @@ import { Decorator } from 'final-form';
 import onFieldChange from 'final-form-calculate';
 import { ComponentType, useMemo } from 'react';
 import { Except, Merge, Paths, Split } from 'type-fest';
+import { addItemToList } from '~/api';
 import {
   CoerceNonPrimitives,
   FinancialReportingTypeLabels,
@@ -44,6 +45,10 @@ import {
   UserLookupItem,
 } from '../../../components/form/Lookup';
 import { PartnerDetailsFragment } from '../Detail/PartnerDetail.graphql';
+import {
+  AssignPersonToPartnerDocument,
+  PartnerPeopleDocument,
+} from '../Detail/Tabs/People/PartnerDetailsPeople.graphql';
 import { UpdatePartnerDocument } from './UpdatePartner.graphql';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -202,6 +207,7 @@ export const EditPartner = ({
   ...props
 }: EditPartnerProps) => {
   const [updatePartner] = useMutation(UpdatePartnerDocument);
+  const [assignOrganization] = useMutation(AssignPersonToPartnerDocument);
 
   const initialValues = useMemo(() => {
     const organization = partner.organization.value!;
@@ -239,24 +245,39 @@ export const EditPartner = ({
       {...props}
       decorators={decorators}
       initialValues={initialValues}
-      onSubmit={async ({ partner, organization }) => {
+      onSubmit={async ({ partner: next, organization }) => {
+        const oldPocId = initialValues.partner.pointOfContact?.id ?? null;
+        const newPocId = next.pointOfContact?.id ?? null;
+        const orgId = organization.id;
+
         await updatePartner({
           variables: {
             partner: {
-              ...partner,
-              pointOfContact: partner.pointOfContact?.id ?? null,
-              fieldRegions: partner.fieldRegions.map((region) => region.id),
-              countries: partner.countries.map((country) => country.id),
-              languageOfReporting: partner.languageOfReporting?.id ?? null,
+              ...next,
+              pointOfContact: newPocId,
+              fieldRegions: next.fieldRegions.map((region) => region.id),
+              countries: next.countries.map((country) => country.id),
+              languageOfReporting: next.languageOfReporting?.id ?? null,
               languageOfWiderCommunication:
-                partner.languageOfWiderCommunication?.id ?? null,
-              languagesOfConsulting: partner.languagesOfConsulting.map(
+                next.languageOfWiderCommunication?.id ?? null,
+              languagesOfConsulting: next.languagesOfConsulting.map(
                 (l) => l.id
               ),
             },
             organization,
           },
         });
+
+        if (newPocId && newPocId !== oldPocId) {
+          await assignOrganization({
+            variables: { user: newPocId, org: orgId },
+            update: addItemToList({
+              listId: [partner, 'people'],
+              outputToItem: (data) => data.assignOrganizationToUser.user,
+            }),
+            refetchQueries: [PartnerPeopleDocument],
+          });
+        }
       }}
     >
       {({ values }) => (

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -19,6 +19,7 @@ import { useComments } from '../../../components/Comments/CommentsContext';
 import { EditUser } from '../Edit';
 import { UsersQueryVariables } from '../List/users.graphql';
 import { ImpersonationToggle } from './ImpersonationToggle';
+import { UserDetailPartners } from './Tabs/Partners/UserDetailPartners';
 import { UserDetailProfile } from './Tabs/Profile/UserDetailProfile';
 import { UserDetailProjects } from './Tabs/Projects/UserDetailProjects';
 import { UserDocument } from './UserDetail.graphql';
@@ -30,7 +31,11 @@ export const UserDetail = () => {
     fetchPolicy: 'cache-and-network',
   });
   useComments(userId);
-  const [activeTab, setTab] = useDetailTabs(['profile', 'projects']);
+  const [activeTab, setTab] = useDetailTabs([
+    'profile',
+    'projects',
+    'partners',
+  ]);
   const [editUserState, editUser] = useDialog();
   const user = data?.user;
 
@@ -109,12 +114,18 @@ export const UserDetail = () => {
               >
                 <Tab label="Profile" value="profile" />
                 <Tab label="Projects" value="projects" />
+                <Tab label="Partners" value="partners" />
               </TabList>
               <TabPanel value="profile">
                 {user && <UserDetailProfile user={user} />}
               </TabPanel>
               <TabPanel value="projects">
                 <UserDetailProjects />
+              </TabPanel>
+              <TabPanel value="partners">
+                {user && (
+                  <UserDetailPartners canCreate={user.partners.canCreate} />
+                )}
               </TabPanel>
             </TabContext>
           </TabsContainer>


### PR DESCRIPTION
API PR: https://github.com/SeedCompany/cord-api-v3/pull/3782
## Summary

Adds a Partner People grid to the Partner detail page with point-of-contact management.

- **People tab** now renders a DataGrid of users associated with the partner. Reuses [`UserColumns`](src/components/UserDataGrid/UserColumns.tsx) (Name / Title / Roles / Status / Pinned) plus a derived **Point of Contact** boolean column (`row.id === partner.pointOfContact.value?.id`).
- **Partner header** gains a *Point of Contact* `DataButton` alongside Status and Start Date — clicking opens `EditPartner` scoped to the POC field.
- **Add Person** dialog assigns the chosen user to the partner's organization. `addItemToList` writes to the Apollo cache and a new `useDataGridSource.addRow` imperatively updates the visible grid via `apiRef.updateRows`, sidestepping the prop-vs-internal row-state drift caused by `unstable_replaceRows` during paged loads.
- **EditPartner POC change** auto-assigns the new POC to the partner's organization so they appear in the grid (with `refetchQueries: [PartnerPeopleDocument]` as a safety net for grid reactivity). The old POC stays as a regular member — their POC chip clears via the partner-prop-derived column.
- **GridFilterInputBoolean fix**: the "Any" option's value changed from `null` → `""`, silencing React's `value prop on input should not be null` warning that's been firing whenever a `booleanColumn` header filter renders (Partners list, Languages list, Dashboard widgets, the new POC column, etc.).
- **UserDetail**: register `'partners'` as a recognized tab — supports the in-progress User Overview rework.

## API dependencies

Depends on the new `Partner.people: SecuredUserList` field and `PartnerPeopleListInput` input type. Already on `develop` via the schema regen.
