### PR TITLE
Replace Language.publicName with displayName.value

### DIFF
--- a/src/components/EngagementBreadcrumb/EngagementBreadcrumb.graphql
+++ b/src/components/EngagementBreadcrumb/EngagementBreadcrumb.graphql
@@ -7,7 +7,9 @@ fragment EngagementBreadcrumb on Engagement {
     language {
       value {
         id
-        publicName
+        displayName {
+          value
+        }
         name {
           canRead
           value

--- a/src/components/EngagementDataGrid/EngagementColumns.tsx
+++ b/src/components/EngagementDataGrid/EngagementColumns.tsx
@@ -59,7 +59,7 @@ export const EngagementColumns: Array<GridColDef<Engagement>> = [
     width: 200,
     valueGetter: (_, row) => {
       return row.__typename === 'LanguageEngagement'
-        ? row.language.value?.publicName
+        ? row.language.value?.displayName.value
         : row.__typename === 'InternshipEngagement'
         ? row.intern.value?.fullName
         : null;

--- a/src/components/EngagementDataGrid/engagementDataGridRow.graphql
+++ b/src/components/EngagementDataGrid/engagementDataGridRow.graphql
@@ -62,7 +62,9 @@ fragment engagementDataGridRow on Engagement {
     language {
       value {
         id
-        publicName
+        displayName {
+          value
+        }
         ethnologue {
           code {
             value

--- a/src/components/Grid/Columns/LanguageNameColumn.tsx
+++ b/src/components/Grid/Columns/LanguageNameColumn.tsx
@@ -25,7 +25,7 @@ export const LanguageNameColumn = <
     width: 200,
     valueGetter: (...args) => {
       const lang = valueGetter(...args);
-      return lang.publicName;
+      return lang.displayName.value;
     },
     renderCell: ({ value, row, colDef, api }) => {
       const apiRef = { current: api };

--- a/src/components/LanguageDataGrid/languageDataGridRow.graphql
+++ b/src/components/LanguageDataGrid/languageDataGridRow.graphql
@@ -1,6 +1,8 @@
 fragment languageDataGridRow on Language {
   id
-  publicName
+  displayName {
+    value
+  }
   ethnologue {
     code {
       value

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItem.graphql
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItem.graphql
@@ -7,7 +7,9 @@ fragment LanguageEngagementListItem on LanguageEngagement {
   language {
     value {
       id
-      publicName
+      displayName {
+        value
+      }
       population {
         value
       }

--- a/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
+++ b/src/components/LanguageEngagementListItemCard/LanguageEngagementListItemCard.tsx
@@ -27,7 +27,7 @@ export const LanguageEngagementListItemCard = (
   const numberFormatter = useNumberFormatter();
 
   const language = securedLanguage.value;
-  const name = language?.publicName;
+  const name = language?.displayName.value;
   const population = language?.population.value;
   const registryOfLanguageVarietiesCode =
     language?.registryOfLanguageVarietiesCode.value;

--- a/src/components/LanguageListItemCard/LanguageListItem.graphql
+++ b/src/components/LanguageListItemCard/LanguageListItem.graphql
@@ -1,6 +1,8 @@
 fragment LanguageListItem on Language {
   id
-  publicName
+  displayName {
+    value
+  }
   ethnologue {
     code {
       value

--- a/src/components/LanguageListItemCard/LanguageListItemCard.tsx
+++ b/src/components/LanguageListItemCard/LanguageListItemCard.tsx
@@ -49,7 +49,7 @@ export const LanguageListItemCard = ({
                 {!language ? (
                   <Skeleton width="50%" variant="text" />
                 ) : (
-                  language.publicName
+                  language.displayName.value
                 )}
               </Typography>
             </Grid>

--- a/src/components/form/Lookup/Language/LanguageField.test.tsx
+++ b/src/components/form/Lookup/Language/LanguageField.test.tsx
@@ -18,7 +18,7 @@ jest.mock('../../../../scenes/Languages/Create', () => ({
 const makeLang = (overrides?: object) => ({
   __typename: 'Language',
   id: 'lang-1',
-  publicName: 'English',
+  displayName: { __typename: 'SecuredString', value: 'English' },
   ethnologue: {
     __typename: 'EthnologueLanguage',
     code: { __typename: 'SecuredStringNullable', value: 'eng' },
@@ -115,7 +115,10 @@ describe('LanguageField', () => {
         makeLang(),
         makeLang({
           id: 'lang-2',
-          publicName: 'English Creole',
+          displayName: {
+            __typename: 'SecuredString',
+            value: 'English Creole',
+          },
           ethnologue: {
             __typename: 'EthnologueLanguage',
             code: { __typename: 'SecuredStringNullable', value: 'cpe' },

--- a/src/components/form/Lookup/Language/LanguageField.tsx
+++ b/src/components/form/Lookup/Language/LanguageField.tsx
@@ -44,7 +44,7 @@ export const LanguageField = LookupField.createFor<
   lookupDocument: LanguageLookupDocument,
   label: 'Language',
   placeholder: 'Search for a language by name',
-  getOptionLabel: (option) => option.publicName ?? '',
+  getOptionLabel: (option) => option.displayName.value ?? '',
   CreateDialogForm: CreateLanguage,
   getInitialValues: (name) => ({ name, displayName: name }),
   PaperComponent: LanguageDropdownPaper,
@@ -70,7 +70,7 @@ export const LanguageField = LookupField.createFor<
               whiteSpace: 'nowrap',
             }}
           >
-            {option.publicName}
+            {option.displayName.value}
           </Box>
           <Box
             sx={{

--- a/src/components/form/Lookup/Language/LanguageLookup.graphql
+++ b/src/components/form/Lookup/Language/LanguageLookup.graphql
@@ -10,7 +10,9 @@ query LanguageLookup($query: String!) {
 
 fragment LanguageLookupItem on Language {
   id
-  publicName
+  displayName {
+    value
+  }
   ethnologue {
     code {
       value

--- a/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.graphql
+++ b/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.graphql
@@ -5,7 +5,9 @@ fragment LanguageEngagementHeader on LanguageEngagement {
   language {
     value {
       id
-      publicName
+      displayName {
+        value
+      }
     }
   }
   lukePartnership {

--- a/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/Header/LanguageEngagementHeader.tsx
@@ -52,7 +52,7 @@ export const LanguageEngagementHeader = ({
     useDialog<Engagement>();
 
   const language = engagement.language.value;
-  const langName = language?.publicName;
+  const langName = language?.displayName.value;
   const ptRegistryId = engagement.paratextRegistryId;
   const rev79CommunityId = engagement.rev79CommunityId;
   const editable = canEditAny(engagement);

--- a/src/scenes/Languages/Detail/LanguageDetail.graphql
+++ b/src/scenes/Languages/Detail/LanguageDetail.graphql
@@ -8,7 +8,6 @@ query Language($languageId: ID!) @live {
 fragment LanguageDetail on Language {
   id
   createdAt
-  publicName
   name {
     canRead
     canEdit

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -42,7 +42,6 @@ export const LanguageDetail = () => {
     ethnologue,
     displayName,
     name,
-    publicName,
     sensitivity,
     isDialect,
     isSignLanguage,
@@ -78,7 +77,7 @@ export const LanguageDetail = () => {
         maxWidth: theme.breakpoints.values.xl,
       })}
     >
-      <Helmet title={publicName ?? undefined} />
+      <Helmet title={displayName?.value ?? undefined} />
       <Error error={error}>
         {{
           NotFound: 'Could not find language',

--- a/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.test.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.test.tsx
@@ -5,10 +5,13 @@ import { PartnerLanguagesSection } from './PartnerLanguagesSection';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const makeLang = (publicName: string) => ({
+const makeLang = (displayName: string) => ({
   __typename: 'Language' as const,
-  id: `lang-${publicName}`,
-  publicName,
+  id: `lang-${displayName}`,
+  displayName: {
+    __typename: 'SecuredString' as const,
+    value: displayName,
+  },
   ethnologue: {
     __typename: 'EthnologueLanguage' as const,
     code: { __typename: 'SecuredStringNullable' as const, value: null },

--- a/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Profile/PartnerLanguagesSection.tsx
@@ -57,7 +57,7 @@ export const PartnerLanguagesSection = ({
           ) : partner.languageOfReporting.canRead ? (
             <Typography component="p" variant="h4">
               {partner.languageOfReporting.value
-                ? partner.languageOfReporting.value.publicName
+                ? partner.languageOfReporting.value.displayName.value
                 : 'None'}
             </Typography>
           ) : (
@@ -81,7 +81,7 @@ export const PartnerLanguagesSection = ({
           ) : partner.languageOfWiderCommunication.canRead ? (
             <Typography component="p" variant="h4">
               {partner.languageOfWiderCommunication.value
-                ? partner.languageOfWiderCommunication.value.publicName
+                ? partner.languageOfWiderCommunication.value.displayName.value
                 : 'None'}
             </Typography>
           ) : (
@@ -112,7 +112,7 @@ export const PartnerLanguagesSection = ({
                     sx={{ listStyleType: 'none' }}
                     key={language.id}
                   >
-                    {language.publicName}
+                    {language.displayName.value}
                   </Typography>
                 ))}
               </Stack>

--- a/src/scenes/Products/Detail/ProductDetailHeader.tsx
+++ b/src/scenes/Products/Detail/ProductDetailHeader.tsx
@@ -25,7 +25,7 @@ export const ProductDetailHeader = ({ product }: { product?: Product }) => {
   const { classes } = useStyles();
 
   const language = product?.engagement.language.value;
-  const langName = language?.publicName;
+  const langName = language?.displayName.value;
   const project = product?.engagement.project;
 
   return (

--- a/src/scenes/ProgressReports/EditForm/ProgressReportDrawerHeader.tsx
+++ b/src/scenes/ProgressReports/EditForm/ProgressReportDrawerHeader.tsx
@@ -88,7 +88,9 @@ export const ProgressReportDrawerHeader = ({ report }: ReportProp) => {
           sx={{ gap: 2 }}
         >
           <Typography variant="h5">{project.name.value}</Typography>
-          <Typography variant="h5">{language.value?.publicName}</Typography>
+          <Typography variant="h5">
+            {language.value?.displayName.value}
+          </Typography>
         </Stack>
       </Box>
 

--- a/src/scenes/ProgressReports/EditForm/ProgressReportEdit.graphql
+++ b/src/scenes/ProgressReports/EditForm/ProgressReportEdit.graphql
@@ -36,7 +36,9 @@ fragment ProgressReportEdit on ProgressReport {
     language {
       value {
         id
-        publicName
+        displayName {
+          value
+        }
       }
     }
     project {

--- a/src/scenes/ProgressReports/StatusHistory/StatusHistory.tsx
+++ b/src/scenes/ProgressReports/StatusHistory/StatusHistory.tsx
@@ -57,7 +57,7 @@ export const StatusHistory = () => {
   const engagement = report?.parent;
 
   const reportTitle = getReportLabel(report);
-  const engagementTitle = engagement?.language.value?.publicName;
+  const engagementTitle = engagement?.language.value?.displayName.value;
 
   return (
     <Box


### PR DESCRIPTION
Prep for api-v3 removing the redundant `Language.publicName` field. Swaps all UI
consumers to `Language.displayName.value`, which has always been on the type and
is required at create time, so behavior is unchanged.

## Changes
- 9 GraphQL fragments: `publicName` → `displayName { value }`
- 11 TS/TSX consumers: `.publicName` → `.displayName.value`
- 2 test fixtures updated to match

