### PR TITLE
Pin CI to Node 24.14.1 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,10 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 24
+        # Pinned: Node 24.15+ hits EBADF in Yarn PnP's CJS-from-zip loader
+        # (yarnpkg/berry#7103 — HAS_BROKEN_FSTAT_FOR_ZIP_FDS gate misses 24.15
+        # backport of nodejs/node#61769). Unpin once Yarn ships the fix.
+        node-version: 24.14.1
 
     - name: Yarn cache
       uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- CI started failing on `yarn gql-gen -e` with `EBADF: bad file descriptor, fstat` after `actions/setup-node` rolled the `24` tag to **v24.15.0**.
- Root cause is in Yarn PnP, not our code: nodejs/node#61769 (ESM loader cycle reduction) was backported to Node 24.15.0, but Yarn's `HAS_BROKEN_FSTAT_FOR_ZIP_FDS` gate in `yarnpkg-pnp/sources/esm-loader/loaderFlags.ts` only covers `>=25.7`. Any CJS-from-zip read (e.g. `-r ts-node/register` under PnP) now crashes. Tracking issue: yarnpkg/berry#7103.
- Pinning [.github/actions/setup/action.yml](.github/actions/setup/action.yml) to `24.14.1` (last good patch) until Yarn widens the gate.