### PR TITLE
feat: responsive data grid toolbar and filters on mobile

### DIFF
--- a/src/components/Grid/DefaultDataGridStyles.tsx
+++ b/src/components/Grid/DefaultDataGridStyles.tsx
@@ -48,6 +48,21 @@ export const DefaultDataGridStyles = {
           .map((column) => column.field),
     },
     filterPanel: {
+      sx: {
+        maxWidth: 'calc(100vw - 16px)',
+        '& .MuiDataGrid-filterForm': {
+          flexWrap: 'wrap',
+          rowGap: 0.5,
+        },
+        '& .MuiDataGrid-filterFormColumnInput, & .MuiDataGrid-filterFormOperatorInput':
+          {
+            flex: '1 1 auto',
+            minWidth: 80,
+          },
+        '& .MuiDataGrid-filterFormValueInput': {
+          flex: '1 1 100%',
+        },
+      },
       filterFormProps: {
         valueInputProps: {
           InputComponentProps,

--- a/src/components/Grid/QuickFilters.tsx
+++ b/src/components/Grid/QuickFilters.tsx
@@ -10,25 +10,40 @@ import { useMemoizedFn } from 'ahooks';
 import { useMemo } from 'react';
 import { ChildrenProp, extendSx, StyleProps } from '~/common';
 
-export const QuickFilters = (props: ChildrenProp & StyleProps) => (
-  <Stack
-    direction="row"
-    alignItems="center"
-    gap={1}
-    sx={[
-      {
-        '.MuiToggleButton-root:not(.MuiToggleButtonGroup-grouped)': {
-          margin: 0,
-          py: 0.5,
+export const QuickFilters = (props: ChildrenProp & StyleProps) => {
+  const className = ['GridQuickFilters', props.className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      className={className}
+      gap={1}
+      sx={[
+        {
+          maxWidth: '100%',
+          flexWrap: 'nowrap',
+          overflowX: 'auto',
+          WebkitOverflowScrolling: 'touch',
+          '.MuiTypography-root': {
+            whiteSpace: 'nowrap',
+          },
+          '.MuiToggleButton-root:not(.MuiToggleButtonGroup-grouped)': {
+            margin: 0,
+            py: 0.5,
+            flexShrink: 0,
+          },
         },
-      },
-      ...extendSx(props.sx),
-    ]}
-  >
-    <Typography variant="body2">Quick Filters:</Typography>
-    {props.children}
-  </Stack>
-);
+        ...extendSx(props.sx),
+      ]}
+    >
+      <Typography variant="body2">Quick Filters:</Typography>
+      {props.children}
+    </Stack>
+  );
+};
 
 export const QuickFilterButton = (props: ToggleButtonProps) => (
   <ToggleButton color="info" size="small" {...props} />

--- a/src/components/Grid/Toolbar.tsx
+++ b/src/components/Grid/Toolbar.tsx
@@ -10,23 +10,48 @@ export const Toolbar = (props: ChildrenProp & StyleProps) => {
     <Stack
       {...props}
       sx={[
-        {
+        (theme) => ({
           flexDirection: 'row',
+          flexWrap: 'nowrap',
           justifyContent: 'space-between',
           alignItems: 'center',
+          columnGap: 2,
+          rowGap: 0,
           background: 'var(--DataGrid-containerBackground)',
           p: 1,
           borderBottom: 'thin solid var(--DataGrid-rowBorderColor)',
           borderTopLeftRadius: 'inherit',
           borderTopRightRadius: 'inherit',
-        },
+          '& > .GridQuickFilters': {
+            flex: '1 1 auto',
+            minWidth: 0,
+            order: 1,
+          },
+          '& > .GridToolbarRowCount': {
+            marginLeft: 'auto',
+            order: 2,
+            whiteSpace: 'nowrap',
+          },
+          '& > :not(.GridQuickFilters):not(.GridToolbarRowCount)': {
+            order: 1,
+          },
+          [theme.breakpoints.down('mobile')]: {
+            flexWrap: 'wrap',
+            justifyContent: 'flex-start',
+            rowGap: 1,
+            '& > .GridQuickFilters': {
+              flex: '1 0 100%',
+              order: 3,
+            },
+          },
+        }),
         ...extendSx(props.sx),
       ]}
     >
       {props.children}
       {rootProps.rowCount != null && (
-        <Typography>
-          Total Rows: <FormattedNumber value={rootProps.rowCount} />
+        <Typography className="GridToolbarRowCount" variant="body2">
+          Rows: <FormattedNumber value={rootProps.rowCount} />
         </Typography>
       )}
     </Stack>

--- a/src/components/Grid/Toolbar.tsx
+++ b/src/components/Grid/Toolbar.tsx
@@ -35,7 +35,7 @@ export const Toolbar = (props: ChildrenProp & StyleProps) => {
           '& > :not(.GridQuickFilters):not(.GridToolbarRowCount)': {
             order: 1,
           },
-          [theme.breakpoints.down('mobile')]: {
+          [theme.breakpoints.down('sm')]: {
             flexWrap: 'wrap',
             justifyContent: 'flex-start',
             rowGap: 1,

--- a/src/scenes/Languages/List/LanguageList.tsx
+++ b/src/scenes/Languages/List/LanguageList.tsx
@@ -1,15 +1,12 @@
-import { Paper, Stack, Typography } from '@mui/material';
+import { Paper, Stack } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { LanguageGrid } from './LanguageGrid';
 
 export const LanguageList = () => {
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 1, sm: 4 }, pt: 2 }}>
       <Helmet title="Languages" />
       <Stack component="main" sx={{ flex: 1 }}>
-        <Typography variant="h2" paragraph>
-          Languages
-        </Typography>
         <Stack sx={{ flex: 1, containerType: 'size' }}>
           <Paper
             sx={{

--- a/src/scenes/Partners/List/PartnerList.tsx
+++ b/src/scenes/Partners/List/PartnerList.tsx
@@ -1,15 +1,12 @@
-import { Paper, Stack, Typography } from '@mui/material';
+import { Paper, Stack } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { PartnerGrid } from './PartnerGrid';
 
 export const PartnerList = () => {
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 1, sm: 4 }, pt: 2 }}>
       <Helmet title="Partners" />
       <Stack component="main" sx={{ flex: 1 }}>
-        <Typography variant="h2" paragraph>
-          Partners
-        </Typography>
         <Stack sx={{ flex: 1, containerType: 'size' }}>
           <Paper
             sx={{

--- a/src/scenes/Projects/List/ProjectList.tsx
+++ b/src/scenes/Projects/List/ProjectList.tsx
@@ -11,7 +11,7 @@ export const ProjectList = () => {
   const { pathname } = useLocation();
 
   return (
-    <ContentContainer sx={{ p: 4, pt: 2, overflow: 'initial' }}>
+    <ContentContainer sx={{ p: { xs: 1, sm: 4 }, pt: 2, overflow: 'initial' }}>
       <Helmet title={pathname === '/projects' ? 'Projects' : 'Engagements'} />
       <Stack component="main" sx={{ flex: 1 }}>
         <TabsContainer>

--- a/src/scenes/Users/List/UserList.tsx
+++ b/src/scenes/Users/List/UserList.tsx
@@ -1,15 +1,12 @@
-import { Paper, Stack, Typography } from '@mui/material';
+import { Paper, Stack } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { UserGrid } from './UserGrid';
 
 export const UserList = () => {
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 1, sm: 4 }, pt: 2 }}>
       <Helmet title="People" />
       <Stack component="main" sx={{ flex: 1 }}>
-        <Typography variant="h2" paragraph>
-          People
-        </Typography>
         <Stack sx={{ flex: 1, containerType: 'size' }}>
           <Paper
             sx={{


### PR DESCRIPTION
## Summary

- Grid toolbar wraps to two rows on mobile with quick-filter buttons scrolling horizontally
- Filter panel inputs flex with the container rather than overflowing
- List pages (Languages, Partners, Projects, Users) get responsive padding (`xs: 1`, `sm: 4`)

## Test plan

- [ ] Open a list page on a mobile viewport (~390px wide)
- [ ] Confirm toolbar wraps — filters row appears below columns/filter buttons
- [ ] Confirm quick-filter toggle buttons scroll horizontally when there are many
- [ ] Open the filter panel and confirm inputs don't overflow the panel width
- [ ] Verify no regressions on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)