### PR TITLE
feat: responsive Name column widths with minWidth floor

### DIFF
--- a/src/components/Grid/Columns/LanguageNameColumn.tsx
+++ b/src/components/Grid/Columns/LanguageNameColumn.tsx
@@ -23,6 +23,7 @@ export const LanguageNameColumn = <
     ...textColumn<Row>(),
     headerName: 'Language',
     width: 200,
+    minWidth: 130,
     valueGetter: (...args) => {
       const lang = valueGetter(...args);
       return lang.displayName.value;

--- a/src/components/Grid/Columns/PartnerNameColumn.tsx
+++ b/src/components/Grid/Columns/PartnerNameColumn.tsx
@@ -22,7 +22,8 @@ export const PartnerNameColumn = <
   columnWithDefaults<Row>()(overrides, {
     ...textColumn<Row>(),
     headerName: 'Partner',
-    width: 300,
+    width: 200,
+    minWidth: 130,
     valueGetter: (...args) =>
       valueGetter(...args).organization.value?.name.value,
     renderCell: ({ value, row, colDef, api }) => {

--- a/src/components/Grid/Columns/ProjectNameColumn.tsx
+++ b/src/components/Grid/Columns/ProjectNameColumn.tsx
@@ -23,6 +23,7 @@ export const ProjectNameColumn = <
     ...textColumn<Row>(),
     headerName: 'Project',
     width: 200,
+    minWidth: 130,
     valueGetter: (...args) => valueGetter(...args).name.value,
     renderCell: ({ value, row, colDef, api }) => {
       const project = valueGetter(null as never, row, colDef, { current: api });

--- a/src/components/Grid/Columns/UserNameColumn.tsx
+++ b/src/components/Grid/Columns/UserNameColumn.tsx
@@ -22,7 +22,8 @@ export const UserNameColumn = <
   columnWithDefaults<Row>()(overrides, {
     ...textColumn<Row>(),
     headerName: 'Name',
-    width: 350,
+    width: 200,
+    minWidth: 130,
     valueGetter: (...args) => valueGetter(...args).fullName,
     renderCell: ({ value, row, colDef, api }) => {
       const user = valueGetter(null as never, row, colDef, { current: api });

--- a/src/components/PartnersDataGrid/PartnerColumns.tsx
+++ b/src/components/PartnersDataGrid/PartnerColumns.tsx
@@ -29,7 +29,6 @@ export const PartnerColumns: Array<GridColDef<Partner>> = [
     field: 'organization.name',
     headerName: 'Name',
     valueGetter: (_, partner) => partner,
-    width: 300,
   }),
   {
     field: 'organization.acronym',

--- a/src/components/ProjectDataGrid/ProjectColumns.tsx
+++ b/src/components/ProjectDataGrid/ProjectColumns.tsx
@@ -36,7 +36,6 @@ export const ProjectColumns: Array<GridColDef<Project>> = [
     field: 'name',
     headerName: 'Name',
     valueGetter: (_, project) => project,
-    width: 300,
   }),
   {
     field: 'primaryLocation.name',


### PR DESCRIPTION
## Summary

- Adds `minWidth: 130` to all Name column definitions (Language, Partner, Project, User) so columns clamp to a readable truncated width on narrow viewports instead of overflowing
- Reduces default `width` for Partner (300→200) and User (350→200) to match the other Name columns
- Removes hardcoded `width: 300` overrides at the `PartnerColumns` and `ProjectColumns` call sites that were bypassing the column defaults

## Test plan

- [ ] Open the Partners list on a mobile viewport — Name column truncates cleanly at ~130px
- [ ] Open the Partners list on desktop — Name column renders at 200px
- [ ] Confirm no column overflows or layout breakage on any list page
- [ ] Verify no regressions on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)