### PR TITLE
feat: responsive dashboard layout and widget sizing

### DIFF
--- a/src/scenes/Dashboard/Dashboard.tsx
+++ b/src/scenes/Dashboard/Dashboard.tsx
@@ -19,8 +19,18 @@ export const DashboardRoutes = () => (
 
 const MainDashboard = () => (
   <WidgetGrid>
-    <ProgressReportsWidget colSpan={8} rowSpan={6} expanded={false} />
-    <PnpProblemsWidget colSpan={8} rowSpan={6} expanded={false} />
+    <ProgressReportsWidget
+      colSpan={8}
+      rowSpan={6}
+      expanded={false}
+      sx={{ gridColumn: { xs: 'span 12', mobile: 'span 8' } }}
+    />
+    <PnpProblemsWidget
+      colSpan={8}
+      rowSpan={6}
+      expanded={false}
+      sx={{ gridColumn: { xs: 'span 12', mobile: 'span 8' } }}
+    />
   </WidgetGrid>
 );
 

--- a/src/scenes/Dashboard/DashboardLayout.tsx
+++ b/src/scenes/Dashboard/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from '@mui/material';
+import { Stack } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { ChildrenProp } from '~/common';
 
@@ -7,7 +7,7 @@ export const DashboardLayout = ({ children }: ChildrenProp) => (
     component="main"
     sx={{
       flex: 1,
-      p: 2,
+      p: { xs: 1, mobile: 2 },
       mb: 2,
       gap: 2,
       overflowY: 'scroll',
@@ -15,22 +15,6 @@ export const DashboardLayout = ({ children }: ChildrenProp) => (
     }}
   >
     <Helmet title="My Dashboard" />
-
-    <Typography
-      component="h1"
-      variant="h3"
-      sx={{
-        backgroundColor: (theme) =>
-          theme.palette.mode === 'dark'
-            ? theme.palette.background.paper
-            : '#E3F0F4',
-        p: 4,
-        borderRadius: 1,
-      }}
-    >
-      My Dashboard
-    </Typography>
-
     {children}
   </Stack>
 );


### PR DESCRIPTION
## Summary

- Dashboard widgets span full width on `xs` screens and revert to their column span on `mobile+`
- Layout padding becomes responsive (`xs: 1`, `mobile: 2`)
- Removes the decorative "My Dashboard" heading — the page title is already set via Helmet and shown in the app header

## Test plan

- [ ] Open the dashboard on a mobile viewport (~390px wide) — widgets should stack full width
- [ ] Open the dashboard on desktop — widgets should render at their original column spans side by side
- [ ] Confirm the "My Dashboard" heading is gone and the Helmet-driven title appears in the browser tab and app header
- [ ] Verify no regressions on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)