### PR TITLE
feat: show user's full name in profile menu on mobile

### DIFF
--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
@@ -40,6 +40,20 @@ export const ProfileMenu = (props: Partial<MenuProps>) => {
       <Typography variant="h4" pt={1} p={2} {...skipAutoFocus}>
         Profile Info
       </Typography>
+      {session?.fullName && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          px={2}
+          pb={1}
+          sx={{
+            display: { xs: 'block', mobile: 'none' },
+          }}
+          {...skipAutoFocus}
+        >
+          {session.fullName}
+        </Typography>
+      )}
       <Divider {...skipAutoFocus} />
       {userId && (
         <MenuItemLink to={`/users/${userId}`}>View Profile</MenuItemLink>


### PR DESCRIPTION
## Summary

- On `xs` screens where the header toolbar hides the user's name, the profile menu now displays it below the "Profile Info" heading so users can confirm who they're signed in as

## Test plan

- [ ] Open the profile menu on a mobile viewport (~390px wide) — full name should appear below "Profile Info"
- [ ] Open the profile menu on a desktop viewport — the extra name line should not appear (hidden via `display: none` above `mobile` breakpoint)
- [ ] Verify no regressions on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)