### PR TITLE
Narrative reports for Multiplication engagements

### DIFF
--- a/src/components/PeriodicReports/PeriodicReport.graphql
+++ b/src/components/PeriodicReports/PeriodicReport.graphql
@@ -16,7 +16,19 @@ fragment PeriodicReport on PeriodicReport {
       ...FileNodeInfo
     }
   }
+  narrativeFile {
+    canEdit
+    canRead
+    value {
+      ...FileNodeInfo
+    }
+  }
   receivedDate {
+    canRead
+    canEdit
+    value
+  }
+  narrativeReceivedDate {
     canRead
     canEdit
     value

--- a/src/components/PeriodicReports/PeriodicReportRow.tsx
+++ b/src/components/PeriodicReports/PeriodicReportRow.tsx
@@ -1,8 +1,8 @@
 import { GridRow, GridRowProps } from '@mui/x-data-grid-pro';
 import { createContext, ReactNode, useContext } from 'react';
 import { PaperTooltip } from '../PaperTooltip';
+import type { PeriodicReportFileField } from './fileField';
 import { PeriodicReportFragment } from './PeriodicReport.graphql';
-import type { PeriodicReportFileField } from './PeriodicReportsTable';
 
 const PeriodicReportFileFieldContext =
   createContext<PeriodicReportFileField>('reportFile');

--- a/src/components/PeriodicReports/PeriodicReportRow.tsx
+++ b/src/components/PeriodicReports/PeriodicReportRow.tsx
@@ -1,10 +1,29 @@
 import { GridRow, GridRowProps } from '@mui/x-data-grid-pro';
+import { createContext, ReactNode, useContext } from 'react';
 import { PaperTooltip } from '../PaperTooltip';
 import { PeriodicReportFragment } from './PeriodicReport.graphql';
+import type { PeriodicReportFileField } from './PeriodicReportsTable';
+
+const PeriodicReportFileFieldContext =
+  createContext<PeriodicReportFileField>('reportFile');
+
+export const PeriodicReportFileFieldProvider = ({
+  fileField,
+  children,
+}: {
+  fileField: PeriodicReportFileField;
+  children: ReactNode;
+}) => (
+  <PeriodicReportFileFieldContext.Provider value={fileField}>
+    {children}
+  </PeriodicReportFileFieldContext.Provider>
+);
 
 export const PeriodicReportRow = (props: GridRowProps) => {
+  const fileField = useContext(PeriodicReportFileFieldContext);
   const report = props.row as PeriodicReportFragment;
   const skipped = report.skippedReason.value;
+  const file = report[fileField];
   return (
     <PaperTooltip
       title={skipped ? <>Skipped&mdash;{skipped}</> : ''}
@@ -17,9 +36,7 @@ export const PeriodicReportRow = (props: GridRowProps) => {
           css={(theme) => ({
             color: skipped ? theme.palette.text.disabled : undefined,
             cursor:
-              skipped || (report.reportFile.canRead && !report.reportFile.value)
-                ? undefined
-                : 'pointer',
+              skipped || (file.canRead && !file.value) ? undefined : 'pointer',
           })}
         />
       </div>

--- a/src/components/PeriodicReports/PeriodicReportsTable.tsx
+++ b/src/components/PeriodicReports/PeriodicReportsTable.tsx
@@ -24,6 +24,11 @@ import {
   useFileActions,
 } from '../files/FileActions';
 import { FormattedDate, FormattedDateTime } from '../Formatters';
+import {
+  dateFieldFor,
+  PeriodicReportEditShape,
+  PeriodicReportFileField,
+} from './fileField';
 import { PeriodicReportFragment } from './PeriodicReport.graphql';
 import {
   PeriodicReportFileFieldProvider,
@@ -31,26 +36,6 @@ import {
 } from './PeriodicReportRow';
 import { ReportLabel } from './ReportLabel';
 import { useUpdatePeriodicReport } from './Upload/useUpdatePeriodicReport';
-
-export type PeriodicReportFileField = 'reportFile' | 'narrativeFile';
-
-export type PeriodicReportDateField = 'receivedDate' | 'narrativeReceivedDate';
-
-export const dateFieldFor = (
-  fileField: PeriodicReportFileField
-): PeriodicReportDateField =>
-  fileField === 'narrativeFile' ? 'narrativeReceivedDate' : 'receivedDate';
-
-// A report that may have one of its file slots replaced with a pending File[]
-// upload payload (used by edit/upload dialog flows). Other slot stays as the
-// original SecuredFile from the fetched fragment.
-export type PeriodicReportEditShape = Omit<
-  PeriodicReportFragment,
-  'reportFile' | 'narrativeFile'
-> & {
-  reportFile?: PeriodicReportFragment['reportFile'] | File[];
-  narrativeFile?: PeriodicReportFragment['narrativeFile'] | File[];
-};
 
 type PeriodicReportsTableProps = Except<
   DataGridProps<PeriodicReportFragment>,

--- a/src/components/PeriodicReports/PeriodicReportsTable.tsx
+++ b/src/components/PeriodicReports/PeriodicReportsTable.tsx
@@ -25,27 +25,51 @@ import {
 } from '../files/FileActions';
 import { FormattedDate, FormattedDateTime } from '../Formatters';
 import { PeriodicReportFragment } from './PeriodicReport.graphql';
-import { PeriodicReportRow } from './PeriodicReportRow';
+import {
+  PeriodicReportFileFieldProvider,
+  PeriodicReportRow,
+} from './PeriodicReportRow';
 import { ReportLabel } from './ReportLabel';
 import { useUpdatePeriodicReport } from './Upload/useUpdatePeriodicReport';
+
+export type PeriodicReportFileField = 'reportFile' | 'narrativeFile';
+
+export type PeriodicReportDateField = 'receivedDate' | 'narrativeReceivedDate';
+
+export const dateFieldFor = (
+  fileField: PeriodicReportFileField
+): PeriodicReportDateField =>
+  fileField === 'narrativeFile' ? 'narrativeReceivedDate' : 'receivedDate';
+
+// A report that may have one of its file slots replaced with a pending File[]
+// upload payload (used by edit/upload dialog flows). Other slot stays as the
+// original SecuredFile from the fetched fragment.
+export type PeriodicReportEditShape = Omit<
+  PeriodicReportFragment,
+  'reportFile' | 'narrativeFile'
+> & {
+  reportFile?: PeriodicReportFragment['reportFile'] | File[];
+  narrativeFile?: PeriodicReportFragment['narrativeFile'] | File[];
+};
 
 type PeriodicReportsTableProps = Except<
   DataGridProps<PeriodicReportFragment>,
   'columns' | 'rows'
 > & {
   data?: readonly PeriodicReportFragment[];
+  fileField?: PeriodicReportFileField;
 };
 
 export const PeriodicReportsTableInContext = ({
   data,
+  fileField = 'reportFile',
   ...props
 }: PeriodicReportsTableProps) => {
-  const uploadFile = useUpdatePeriodicReport();
+  const uploadFile = useUpdatePeriodicReport(fileField);
+  const dateField = dateFieldFor(fileField);
   const { openFilePreview } = useFileActions();
   const { enqueueSnackbar } = useSnackbar();
-  const [reportBeingEdited, editReport] = useState<
-    Omit<PeriodicReportFragment, 'reportFile'> & { reportFile?: File[] }
-  >();
+  const [reportBeingEdited, editReport] = useState<PeriodicReportEditShape>();
 
   const [editState, editField, fieldsBeingEdited] =
     useDialog<Many<EditablePeriodicReportField>>();
@@ -67,7 +91,7 @@ export const PeriodicReportsTableInContext = ({
       headerName: 'Submitted By',
       field: 'modifiedBy',
       width: 200,
-      valueGetter: (_, row) => row.reportFile.value?.modifiedBy.fullName,
+      valueGetter: (_, row) => row[fileField].value?.modifiedBy.fullName,
       renderCell: ({ row: report, value }) =>
         report.skippedReason.value ? <>&mdash;</> : value,
     },
@@ -75,23 +99,23 @@ export const PeriodicReportsTableInContext = ({
       headerName: 'Submitted Date',
       field: 'modifiedAt',
       width: 150,
-      valueGetter: (_, row) => row.reportFile.value?.modifiedAt,
+      valueGetter: (_, row) => row[fileField].value?.modifiedAt,
       renderCell: ({ row: report }) =>
         report.skippedReason.value ? (
           <>&mdash;</>
         ) : (
-          <FormattedDateTime date={report.reportFile.value?.modifiedAt} />
+          <FormattedDateTime date={report[fileField].value?.modifiedAt} />
         ),
     },
     {
       headerName: 'Received Date',
-      field: 'receivedDate',
+      field: dateField,
       width: 150,
       renderCell: ({ row: report }) =>
         report.skippedReason.value ? (
           <>&mdash;</>
         ) : (
-          <FormattedDate date={report.receivedDate.value} />
+          <FormattedDate date={report[dateField].value} />
         ),
     },
     {
@@ -101,14 +125,14 @@ export const PeriodicReportsTableInContext = ({
       align: 'right',
       sortable: false,
       renderCell: ({ row: report }) => {
-        const reportFile = report.reportFile;
-        const fileActions = reportFile.value
+        const file = report[fileField];
+        const fileActions = file.value
           ? without(
-              getPermittedFileActions(reportFile.canRead, reportFile.canEdit),
+              getPermittedFileActions(file.canRead, file.canEdit),
               FileAction.Delete,
               FileAction.Rename
             )
-          : reportFile.canEdit && !report.skippedReason.value
+          : file.canEdit && !report.skippedReason.value
           ? [FileAction.NewVersion]
           : [];
 
@@ -118,10 +142,10 @@ export const PeriodicReportsTableInContext = ({
             actions={{
               file: [
                 ...fileActions,
-                ...(report.receivedDate.canEdit && !report.skippedReason.value
+                ...(report[dateField].canEdit && !report.skippedReason.value
                   ? [FileAction.UpdateReceivedDate]
                   : []),
-                ...(!report.receivedDate.value && !report.skippedReason.value
+                ...(!report[dateField].value && !report.skippedReason.value
                   ? [FileAction.Skip]
                   : []),
                 ...(report.skippedReason.value
@@ -130,13 +154,11 @@ export const PeriodicReportsTableInContext = ({
               ],
               version: [
                 FileAction.Download,
-                ...(reportFile.canEdit
-                  ? [FileAction.Rename, FileAction.Delete]
-                  : []),
+                ...(file.canEdit ? [FileAction.Rename, FileAction.Delete] : []),
               ],
             }}
             // @ts-expect-error refactor file functionality later to make all this easier
-            item={reportFile.value ?? { __typename: '' }}
+            item={file.value ?? { __typename: '' }}
             onVersionUpload={(files) =>
               reportBeingEdited
                 ? async () => {
@@ -150,20 +172,20 @@ export const PeriodicReportsTableInContext = ({
             onVersionAccepted={(files) => {
               editReport({
                 ...report,
-                reportFile: files,
+                [fileField]: files,
               });
-              editField(['reportFile', 'receivedDate']);
+              editField([fileField, dateField]);
             }}
             onUpdateReceivedDate={() => {
-              editReport({ ...report, reportFile: undefined });
-              editField('receivedDate');
+              editReport({ ...report, [fileField]: undefined });
+              editField(dateField);
             }}
             onSkip={() => {
-              editReport({ ...report, reportFile: undefined });
+              editReport({ ...report, [fileField]: undefined });
               editField('skippedReason');
             }}
             onEditSkipReason={() => {
-              editReport({ ...report, reportFile: undefined });
+              editReport({ ...report, [fileField]: undefined });
               editField('skippedReason');
             }}
           />
@@ -176,10 +198,11 @@ export const PeriodicReportsTableInContext = ({
     <>
       {reportBeingEdited && fieldsBeingEdited === 'skippedReason' ? (
         <SkipPeriodicReportDialog {...editState} report={reportBeingEdited} />
-      ) : reportBeingEdited?.receivedDate.canEdit ? (
+      ) : reportBeingEdited?.[dateField].canEdit ? (
         <UpdatePeriodicReportDialog
           {...editState}
           editFields={fieldsBeingEdited}
+          fileField={fileField}
           report={reportBeingEdited}
         />
       ) : null}
@@ -217,17 +240,18 @@ export const PeriodicReportsTableInContext = ({
             props.onRowClick(params, event, details);
           } else {
             const report = params.row as PeriodicReportFragment;
-            if (!report.reportFile.canRead) {
+            const file = report[fileField];
+            if (!file.canRead) {
               enqueueSnackbar(
                 `You don't have permission to view this report file`
               );
               return;
             }
-            if (report.reportFile.value) {
-              openFilePreview(report.reportFile.value);
+            if (file.value) {
+              openFilePreview(file.value);
               return;
             }
-            if (report.reportFile.canEdit) {
+            if (file.canEdit) {
               // TODO Upload
             }
           }
@@ -239,6 +263,10 @@ export const PeriodicReportsTableInContext = ({
 
 export const PeriodicReportsTable = (props: PeriodicReportsTableProps) => (
   <FileActionsContextProvider>
-    <PeriodicReportsTableInContext {...props} />
+    <PeriodicReportFileFieldProvider
+      fileField={props.fileField ?? 'reportFile'}
+    >
+      <PeriodicReportsTableInContext {...props} />
+    </PeriodicReportFileFieldProvider>
   </FileActionsContextProvider>
 );

--- a/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
+++ b/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
@@ -7,7 +7,7 @@ import { CalendarDateOrISO } from '~/common';
 import { useUploadFiles } from '../../files/hooks';
 import { IconButton } from '../../IconButton';
 import { Link, useNavigate } from '../../Routing';
-import { dateFieldFor, PeriodicReportFileField } from '../PeriodicReportsTable';
+import { dateFieldFor, PeriodicReportFileField } from '../fileField';
 import {
   ProductLabelDocument,
   UpdatePeriodicReportDocument,

--- a/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
+++ b/src/components/PeriodicReports/Upload/useUpdatePeriodicReport.tsx
@@ -7,16 +7,24 @@ import { CalendarDateOrISO } from '~/common';
 import { useUploadFiles } from '../../files/hooks';
 import { IconButton } from '../../IconButton';
 import { Link, useNavigate } from '../../Routing';
+import { dateFieldFor, PeriodicReportFileField } from '../PeriodicReportsTable';
 import {
   ProductLabelDocument,
   UpdatePeriodicReportDocument,
 } from './UpdatePeriodicReport.graphql';
 
-export const useUpdatePeriodicReport = () => {
+export const useUpdatePeriodicReport = (
+  fileField: PeriodicReportFileField = 'reportFile'
+) => {
   const uploadFiles = useUploadFiles();
-  const [uploadFile, { client }] = useMutation(UpdatePeriodicReportDocument);
+  const [updatePeriodicReport, { client }] = useMutation(
+    UpdatePeriodicReportDocument
+  );
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const navigate = useNavigate();
+
+  const dateField = dateFieldFor(fileField);
+  const isPnp = fileField === 'reportFile';
 
   return async (
     id: string,
@@ -25,72 +33,73 @@ export const useUpdatePeriodicReport = () => {
     skippedReason?: string | null
   ) => {
     const updateReport = async (uploadId?: string, name?: string) => {
-      await uploadFile({
+      await updatePeriodicReport({
         variables: {
           input: {
             id,
             ...(uploadId && name
-              ? { reportFile: { upload: uploadId, name } }
+              ? { [fileField]: { upload: uploadId, name } }
               : {}),
-            receivedDate,
+            [dateField]: receivedDate,
             skippedReason,
           },
-          refreshFromPnp: !!uploadId,
+          refreshFromPnp: isPnp && !!uploadId,
         },
-        onError: (err) => {
-          const showError = async () => {
-            const info = getErrorInfo(err);
-            if (!isErrorCode(info, 'StepNotPlanned')) {
-              return;
+        onError: isPnp
+          ? (err) => {
+              const showError = async () => {
+                const info = getErrorInfo(err);
+                if (!isErrorCode(info, 'StepNotPlanned')) {
+                  return;
+                }
+
+                const productInfo = await client.query({
+                  query: ProductLabelDocument,
+                  variables: { id: info.productId },
+                });
+
+                enqueueSnackbar(
+                  <>
+                    <i>{ProductStepLabels[info.step]}</i>&nbsp;step is not
+                    planned for goal&nbsp;
+                    <Link to={`/products/${info.productId}`} color="inherit">
+                      {productInfo.data.product.label}
+                    </Link>
+                  </>,
+                  {
+                    action: (key) => (
+                      <IconButton
+                        color="inherit"
+                        onClick={() => {
+                          closeSnackbar(key);
+                          navigate(`/products/${info.productId}/edit`);
+                        }}
+                      >
+                        <Edit />
+                      </IconButton>
+                    ),
+                    autoHideDuration: 15_000,
+                    variant: 'error',
+                  }
+                );
+              };
+              void showError();
+              throw err;
             }
-
-            const productInfo = await client.query({
-              query: ProductLabelDocument,
-              variables: { id: info.productId },
-            });
-
-            enqueueSnackbar(
-              <>
-                <i>{ProductStepLabels[info.step]}</i>&nbsp;step is not planned
-                for goal&nbsp;
-                <Link to={`/products/${info.productId}`} color="inherit">
-                  {productInfo.data.product.label}
-                </Link>
-              </>,
-              {
-                action: (key) => (
-                  <IconButton
-                    color="inherit"
-                    onClick={() => {
-                      closeSnackbar(key);
-                      navigate(`/products/${info.productId}/edit`);
-                    }}
-                  >
-                    <Edit />
-                  </IconButton>
-                ),
-                autoHideDuration: 15_000,
-                variant: 'error',
-              }
-            );
-          };
-          void showError();
-          throw err;
-        },
+          : undefined,
       });
     };
-    if (id) {
-      if (files) {
-        uploadFiles({
-          files,
-          handleUploadCompleted: async ({ uploadId, name }) => {
-            await updateReport(uploadId, name);
-          },
-          parentId: id,
-        });
-      } else {
-        await updateReport();
-      }
+    if (!id) return;
+    if (files) {
+      uploadFiles({
+        files,
+        handleUploadCompleted: async ({ uploadId, name }) => {
+          await updateReport(uploadId, name);
+        },
+        parentId: id,
+      });
+    } else {
+      await updateReport();
     }
   };
 };

--- a/src/components/PeriodicReports/fileField.ts
+++ b/src/components/PeriodicReports/fileField.ts
@@ -1,0 +1,21 @@
+import { PeriodicReportFragment } from './PeriodicReport.graphql';
+
+export type PeriodicReportFileField = 'reportFile' | 'narrativeFile';
+
+export type PeriodicReportDateField = 'receivedDate' | 'narrativeReceivedDate';
+
+export const dateFieldFor = (
+  fileField: PeriodicReportFileField
+): PeriodicReportDateField =>
+  fileField === 'narrativeFile' ? 'narrativeReceivedDate' : 'receivedDate';
+
+// A report that may have one of its file slots replaced with a pending File[]
+// upload payload (used by edit/upload dialog flows). Other slot stays as the
+// original SecuredFile from the fetched fragment.
+export type PeriodicReportEditShape = Omit<
+  PeriodicReportFragment,
+  'reportFile' | 'narrativeFile'
+> & {
+  reportFile?: PeriodicReportFragment['reportFile'] | File[];
+  narrativeFile?: PeriodicReportFragment['narrativeFile'] | File[];
+};

--- a/src/components/ProgressReportsOverviewCard/NarrativeReportsOverviewCard.tsx
+++ b/src/components/ProgressReportsOverviewCard/NarrativeReportsOverviewCard.tsx
@@ -1,0 +1,73 @@
+import { Box, Card, CardActions, CardContent, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+import { SecuredProp, StyleProps } from '~/common';
+import { Due, SkippedText } from '../PeriodicReports/OverviewCard/ReportInfo';
+import { ReportInfoContainer } from '../PeriodicReports/OverviewCard/ReportInfoContainer';
+import { ReportLabel } from '../PeriodicReports/ReportLabel';
+import { ButtonLink } from '../Routing';
+import { ProgressReportOverviewItemFragment as Report } from './ProgressReportOverview.graphql';
+
+export interface NarrativeReportsOverviewCardProps extends StyleProps {
+  dueCurrently?: SecuredProp<Report>;
+  dueNext?: SecuredProp<Report>;
+}
+
+export const NarrativeReportsOverviewCard = ({
+  dueCurrently,
+  dueNext,
+  ...rest
+}: NarrativeReportsOverviewCardProps) => (
+  <Card {...rest} sx={{ width: 1 }}>
+    <CardContent sx={{ width: 1 }}>
+      <Typography variant="h4" paragraph>
+        Narrative Reports
+      </Typography>
+      <ReportInfoContainer horizontalAt={260} spaceEvenlyAt={430}>
+        {dueCurrently?.value && (
+          <ReportInfo title="Current" report={dueCurrently.value} extra />
+        )}
+        {dueNext?.value && <ReportInfo title="Next" report={dueNext.value} />}
+      </ReportInfoContainer>
+    </CardContent>
+    <CardActions sx={{ justifyContent: 'flex-end' }}>
+      <ButtonLink color="primary" to="reports/narrative">
+        All Reports
+      </ButtonLink>
+    </CardActions>
+  </Card>
+);
+
+const ReportInfo = ({
+  title,
+  report,
+  extra,
+  ...rest
+}: {
+  title: ReactNode;
+  report: Report;
+  extra?: boolean;
+} & StyleProps) => {
+  const skipped = report.skippedReason.value;
+  const hasFile = !!report.narrativeFile.value;
+  const needsUpload = !hasFile && report.narrativeFile.canEdit && !skipped;
+  return (
+    <Box {...rest}>
+      <Typography variant="body2" color="text.secondary">
+        {title}
+      </Typography>
+      <Typography variant="h4" sx={{ my: 1 }}>
+        <ReportLabel report={report} />
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {skipped && <SkippedText />}
+        {extra && !skipped && (
+          <>
+            {hasFile ? 'Uploaded' : needsUpload ? 'Awaiting upload' : null}
+            {!hasFile && needsUpload && <> &mdash; </>}
+            {!hasFile && <Due date={report.due} />}
+          </>
+        )}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/ProgressReportsOverviewCard/ProgressReportOverview.graphql
+++ b/src/components/ProgressReportsOverviewCard/ProgressReportOverview.graphql
@@ -11,7 +11,19 @@ fragment ProgressReportOverviewItem on ProgressReport {
       ...FileNodeInfo
     }
   }
+  narrativeFile {
+    canEdit
+    canRead
+    value {
+      ...FileNodeInfo
+    }
+  }
   receivedDate {
+    canRead
+    canEdit
+    value
+  }
+  narrativeReceivedDate {
     canRead
     canEdit
     value

--- a/src/components/files/FileActions/DeleteFile.tsx
+++ b/src/components/files/FileActions/DeleteFile.tsx
@@ -1,18 +1,20 @@
 import { MutationFunctionOptions, useMutation } from '@apollo/client';
 import { Typography } from '@mui/material';
 import { Except } from 'type-fest';
+import { removeItemFromList } from '~/api';
 import { DialogForm, DialogFormProps } from '../../Dialog/DialogForm';
 import { SubmitError } from '../../form';
 import { DeleteFileNodeDocument } from './FileActions.graphql';
-import { FilesActionItem } from './FileActionsContext';
+import { FileActionItem, FilesActionItem } from './FileActionsContext';
 
 export type DeleteFileProps = DialogFormProps<{ id: string }> & {
   item: FilesActionItem | undefined;
+  parentFile?: FileActionItem;
   refetchQueries?: MutationFunctionOptions['refetchQueries'];
 };
 
 export const DeleteFile = (props: Except<DeleteFileProps, 'onSubmit'>) => {
-  const { item, refetchQueries } = props;
+  const { item, parentFile, refetchQueries } = props;
   const [deleteFile] = useMutation(DeleteFileNodeDocument);
 
   if (!item) return null;
@@ -23,6 +25,12 @@ export const DeleteFile = (props: Except<DeleteFileProps, 'onSubmit'>) => {
     await deleteFile({
       variables: { id },
       refetchQueries,
+      update: parentFile
+        ? removeItemFromList({
+            listId: [parentFile, 'children'],
+            item,
+          })
+        : undefined,
     });
   };
 

--- a/src/components/files/FileActions/FileActionsContext.tsx
+++ b/src/components/files/FileActions/FileActionsContext.tsx
@@ -118,10 +118,8 @@ export const FileActionsContextProvider = (props: ChildrenProp) => {
     [actions]
   );
 
-  const deleteRefetches =
-    fileNodeToDelete?.__typename === 'FileVersion'
-      ? GQLOperations.Query.FileVersions
-      : GQLOperations.Query.ProjectDirectory;
+  const isDeletingVersion = fileNodeToDelete?.__typename === 'FileVersion';
+  const versionParentFile = isDeletingVersion ? versionToView?.item : undefined;
 
   const context = useMemo(
     () => ({
@@ -137,7 +135,12 @@ export const FileActionsContextProvider = (props: ChildrenProp) => {
         <RenameFile item={fileNodeToRename} {...renameState} />
         <DeleteFile
           item={fileNodeToDelete}
-          refetchQueries={[deleteRefetches]}
+          parentFile={versionParentFile}
+          refetchQueries={
+            isDeletingVersion
+              ? undefined
+              : [GQLOperations.Query.ProjectDirectory]
+          }
           {...deleteState}
         />
         <FileVersions

--- a/src/components/files/FileActions/FileVersions.tsx
+++ b/src/components/files/FileActions/FileVersions.tsx
@@ -47,7 +47,12 @@ export const FileVersions = (props: FileVersionsProps) => {
     : [];
 
   return !file ? null : (
-    <Dialog {...dialogProps} aria-labelledby="dialog-file-versions">
+    <Dialog
+      fullWidth
+      maxWidth="xs"
+      {...dialogProps}
+      aria-labelledby="dialog-file-versions"
+    >
       <DialogTitle id="dialog-file-versions">File History</DialogTitle>
       <List dense>
         {loading

--- a/src/scenes/Engagement/Engagements.tsx
+++ b/src/scenes/Engagement/Engagements.tsx
@@ -12,6 +12,9 @@ const CreateProduct = loadable(() => import('../Products'), {
 const ProgressReportsList = loadable(() => import('../ProgressReports'), {
   resolveComponent: (m) => m.ProgressReportListPage,
 });
+const NarrativeReportsList = loadable(() => import('../ProgressReports'), {
+  resolveComponent: (m) => m.NarrativeReportListPage,
+});
 
 export const Engagements = () => (
   <Routes>
@@ -31,6 +34,7 @@ const EngagementDetail = () => (
         path="reports/progress/:reportId"
         element={<OldProgressReportDetail />}
       />
+      <Route path="reports/narrative" element={<NarrativeReportsList />} />
       {NotFoundRoute}
     </Routes>
   </ChangesetContext>

--- a/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
+++ b/src/scenes/Engagement/LanguageEngagement/LanguageEngagementDetail.tsx
@@ -1,7 +1,7 @@
 import { Add } from '@mui/icons-material';
 import { Card, Grid, Tooltip, Typography } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
-import { PeriodicReportCard } from '~/components/PeriodicReports';
+import { NarrativeReportsOverviewCard } from '../../../components/ProgressReportsOverviewCard/NarrativeReportsOverviewCard';
 import { ProgressReportsOverviewCard } from '../../../components/ProgressReportsOverviewCard/ProgressReportsOverviewCard';
 import { ResponsiveDivider } from '../../../components/ResponsiveDivider';
 import { FabLink } from '../../../components/Routing';
@@ -66,20 +66,21 @@ export const LanguageEngagementDetail = ({ engagement }: EngagementQuery) => {
         <Grid item container spacing={5}>
           <Grid item lg={5} container direction="column" spacing={3}>
             <Grid item container spacing={3}>
+              {isMultiplication && (
+                <Grid item container className={classes.details}>
+                  <NarrativeReportsOverviewCard
+                    dueCurrently={engagement.currentProgressReportDue}
+                    dueNext={engagement.nextProgressReportDue}
+                  />
+                </Grid>
+              )}
               <Grid item container className={classes.details}>
-                {isMultiplication ? (
-                  <PeriodicReportCard
-                    type="Progress"
-                    dueCurrently={engagement.currentProgressReportDue}
-                    dueNext={engagement.nextProgressReportDue}
-                  />
-                ) : (
-                  <ProgressReportsOverviewCard
-                    dueCurrently={engagement.currentProgressReportDue}
-                    dueNext={engagement.nextProgressReportDue}
-                  />
-                )}
+                <ProgressReportsOverviewCard
+                  dueCurrently={engagement.currentProgressReportDue}
+                  dueNext={engagement.nextProgressReportDue}
+                />
               </Grid>
+
               <Grid item container className={classes.details}>
                 <PlanningSpreadsheet engagement={engagement} />
               </Grid>

--- a/src/scenes/ProgressReports/List/NarrativeReportListPage.tsx
+++ b/src/scenes/ProgressReports/List/NarrativeReportListPage.tsx
@@ -1,13 +1,13 @@
 import { useQuery } from '@apollo/client';
+import { PeriodicReportsTable } from '~/components/PeriodicReports/PeriodicReportsTable';
 import { useChangesetAwareIdFromUrl } from '../../../components/Changeset';
 import { EngagementBreadcrumb } from '../../../components/EngagementBreadcrumb';
 import { Error } from '../../../components/Error';
 import { PeriodicReportsList as PeriodicReportListLayout } from '../../../components/PeriodicReports';
 import { ProjectBreadcrumb } from '../../../components/ProjectBreadcrumb';
 import { ProgressReportsOfEngagementDocument as ReportsOfEngagement } from './ProgressReportsOfEngagement.graphql';
-import { ProgressReportsTable } from './ProgressReportsTable';
 
-export const ProgressReportListPage = () => {
+export const NarrativeReportListPage = () => {
   const { id: engagementId, changesetId } =
     useChangesetAwareIdFromUrl('engagementId');
   const { data, error } = useQuery(ReportsOfEngagement, {
@@ -22,7 +22,7 @@ export const ProgressReportListPage = () => {
       <Error page error={error}>
         {{
           NotFound: 'Could not find engagement',
-          Default: 'Error loading progress reports',
+          Default: 'Error loading narrative reports',
         }}
       </Error>
     );
@@ -33,23 +33,31 @@ export const ProgressReportListPage = () => {
       ? data.engagement
       : undefined;
 
+  const isMultiplication =
+    engagement?.project.__typename === 'MultiplicationTranslationProject';
+
+  if (engagement && !isMultiplication) {
+    return (
+      <Error page>
+        {{
+          Default: 'Narrative reports are not available for this engagement',
+        }}
+      </Error>
+    );
+  }
+
   return (
     <PeriodicReportListLayout
-      type="Progress"
+      type="Narrative"
       pageTitleSuffix={engagement?.project.name.value ?? 'A Project'}
       breadcrumbs={[
         <ProjectBreadcrumb key="project" data={engagement?.project} />,
         <EngagementBreadcrumb key="engagement" data={engagement} />,
       ]}
-      TableCardProps={{
-        sx: {
-          maxWidth: 400,
-        },
-      }}
     >
-      <ProgressReportsTable
-        loading={!engagement}
-        rows={engagement?.progressReports.items ?? []}
+      <PeriodicReportsTable
+        fileField="narrativeFile"
+        data={engagement?.progressReports.items}
       />
     </PeriodicReportListLayout>
   );

--- a/src/scenes/ProgressReports/List/ProgressReportListItem.graphql
+++ b/src/scenes/ProgressReports/List/ProgressReportListItem.graphql
@@ -16,7 +16,19 @@ fragment ProgressReportListItem on ProgressReport {
       ...FileNodeInfo
     }
   }
+  narrativeFile {
+    canEdit
+    canRead
+    value {
+      ...FileNodeInfo
+    }
+  }
   receivedDate {
+    canRead
+    canEdit
+    value
+  }
+  narrativeReceivedDate {
     canRead
     canEdit
     value

--- a/src/scenes/ProgressReports/List/index.ts
+++ b/src/scenes/ProgressReports/List/index.ts
@@ -1,1 +1,2 @@
+export * from './NarrativeReportListPage';
 export * from './ProgressReportListPage';

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -496,13 +496,16 @@ export const ProjectOverview = () => {
                 dueNext={project?.nextFinancialReportDue}
               />
             </Grid>
-            <Grid item xs={12} md={6}>
-              <PeriodicReportCard
-                type="Narrative"
-                dueCurrently={project?.currentNarrativeReportDue}
-                dueNext={project?.nextNarrativeReportDue}
-              />
-            </Grid>
+            {project &&
+              project.__typename !== 'MultiplicationTranslationProject' && (
+                <Grid item xs={12} md={6}>
+                  <PeriodicReportCard
+                    type="Narrative"
+                    dueCurrently={project.currentNarrativeReportDue}
+                    dueNext={project.nextNarrativeReportDue}
+                  />
+                </Grid>
+              )}
           </Grid>
 
           <CardGroup horizontal="mdUp">

--- a/src/scenes/Projects/Reports/UpdatePeriodicReportDialog.tsx
+++ b/src/scenes/Projects/Reports/UpdatePeriodicReportDialog.tsx
@@ -13,19 +13,28 @@ import {
   DropzoneField,
   SubmitError,
 } from '../../../components/form';
-import { PeriodicReportFragment } from '../../../components/PeriodicReports/PeriodicReport.graphql';
+import {
+  dateFieldFor,
+  PeriodicReportEditShape,
+  PeriodicReportFileField,
+} from '../../../components/PeriodicReports/PeriodicReportsTable';
 import { useUpdatePeriodicReport } from '../../../components/PeriodicReports/Upload/useUpdatePeriodicReport';
 
 export type EditablePeriodicReportField = ExtractStrict<
   keyof UpdatePeriodicReportInput,
   // Add more fields here as needed
-  'receivedDate' | 'reportFile' | 'skippedReason'
+  | 'receivedDate'
+  | 'narrativeReceivedDate'
+  | 'reportFile'
+  | 'narrativeFile'
+  | 'skippedReason'
 >;
 
 type UpdatePeriodicReportFormValues = Merge<
   UpdatePeriodicReportInput,
   {
     reportFile?: File[];
+    narrativeFile?: File[];
   }
 >;
 
@@ -33,13 +42,15 @@ type UpdatePeriodicReportDialogProps = Except<
   DialogFormProps<UpdatePeriodicReportFormValues>,
   'onSubmit' | 'initialValues'
 > & {
-  report: Omit<PeriodicReportFragment, 'reportFile'> & { reportFile?: File[] };
+  report: PeriodicReportEditShape;
   editFields?: Many<EditablePeriodicReportField>;
+  fileField?: PeriodicReportFileField;
 };
 
 export const UpdatePeriodicReportDialog = ({
   report,
   editFields: editFieldsProp,
+  fileField = 'reportFile',
   ...props
 }: UpdatePeriodicReportDialogProps) => {
   const editFields = useMemo(
@@ -47,19 +58,26 @@ export const UpdatePeriodicReportDialog = ({
     [editFieldsProp]
   );
 
-  const updateReceivedDateOnly =
-    editFields.includes('receivedDate') && !editFields.includes('reportFile');
+  const dateField = dateFieldFor(fileField);
 
-  const updatePeriodicReport = useUpdatePeriodicReport();
+  const updateReceivedDateOnly =
+    editFields.includes(dateField) && !editFields.includes(fileField);
+
+  const updatePeriodicReport = useUpdatePeriodicReport(fileField);
 
   const initialValues = useMemo(() => {
-    const receivedDate = report.receivedDate.value ?? null;
+    const date = report[dateField].value ?? null;
     const fullInitialValuesFields: Except<
       UpdatePeriodicReportFormValues,
       'id'
     > = {
-      reportFile: report.reportFile,
-      receivedDate,
+      reportFile: Array.isArray(report.reportFile)
+        ? report.reportFile
+        : undefined,
+      narrativeFile: Array.isArray(report.narrativeFile)
+        ? report.narrativeFile
+        : undefined,
+      [dateField]: date,
     };
 
     // Filter out irrelevant initial values so they don't get added to the mutation
@@ -71,7 +89,9 @@ export const UpdatePeriodicReportDialog = ({
       id: report.id,
       ...filteredInitialValuesFields,
     };
-  }, [editFields, report.receivedDate, report.reportFile, report.id]);
+  }, [editFields, dateField, report]);
+
+  const incomingFile = initialValues[fileField];
 
   return (
     <DialogForm<UpdatePeriodicReportFormValues>
@@ -81,15 +101,17 @@ export const UpdatePeriodicReportDialog = ({
       {...props}
       initialValues={initialValues}
       // the only time this form will have an initial value for the file field is when adding a new version
-      sendIfClean={Boolean(initialValues.reportFile)}
-      onSubmit={async ({ id, reportFile, receivedDate }) =>
-        await updatePeriodicReport(id, reportFile, receivedDate)
-      }
+      sendIfClean={Boolean(incomingFile)}
+      onSubmit={async (values) => {
+        const file = values[fileField];
+        const date = values[dateField];
+        await updatePeriodicReport(values.id, file, date);
+      }}
     >
       <SubmitError />
-      {!updateReceivedDateOnly ? <DropzoneField name="reportFile" /> : null}
+      {!updateReceivedDateOnly ? <DropzoneField name={fileField} /> : null}
       <DateField
-        name="receivedDate"
+        name={dateField}
         label="Received Date"
         required={!updateReceivedDateOnly}
         openTo="day"

--- a/src/scenes/Projects/Reports/UpdatePeriodicReportDialog.tsx
+++ b/src/scenes/Projects/Reports/UpdatePeriodicReportDialog.tsx
@@ -17,7 +17,7 @@ import {
   dateFieldFor,
   PeriodicReportEditShape,
   PeriodicReportFileField,
-} from '../../../components/PeriodicReports/PeriodicReportsTable';
+} from '../../../components/PeriodicReports/fileField';
 import { useUpdatePeriodicReport } from '../../../components/PeriodicReports/Upload/useUpdatePeriodicReport';
 
 export type EditablePeriodicReportField = ExtractStrict<


### PR DESCRIPTION
API PR: https://github.com/SeedCompany/cord-api-v3/pull/3792

## Summary

Multiplication engagements now expose a Narrative Reports card alongside the existing Progress (PnP) card. Narrative PDFs upload against a new `ProgressReport.narrativeFile` slot, paired with `narrativeReceivedDate` — entirely independent of the PnP `reportFile` / `receivedDate` slot.

- **Engagement page (Multiplication):** two stacked overview cards — Progress (links to `reports/progress`, stepper flow) and Narrative (links to `reports/narrative`, PDF upload only).
- **New route:** `reports/narrative` per engagement, scoped to Multiplication; non-Multiplication engagements 404 the route.
- **Project page (Multiplication):** project-level Narrative card hidden — narrative moves to the engagement grain. Momentum unchanged.
- **Progress reports list:** Multiplication no longer falls back to the file-only periodic-reports table; all engagements use the stepper-linked list.

Internally, `PeriodicReportsTable`, `UpdatePeriodicReportDialog`, `PeriodicReportRow`, and `useUpdatePeriodicReport` are parameterized by `fileField: 'reportFile' | 'narrativeFile'`. The paired date field is derived via `dateFieldFor`. PnP-specific behavior (`refreshFromPnp`, `StepNotPlanned` snackbar) stays gated to the `reportFile` slot. Defaults preserve every existing call site.

Depends on the api-v3 schema additions: `PeriodicReport.narrativeFile`, `PeriodicReport.narrativeReceivedDate`, and `UpdatePeriodicReport.narrativeFile` / `narrativeReceivedDate` input fields.