### PR TITLE
Adds Primary Partner column to Projects data grid

### DIFF
--- a/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
+++ b/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
@@ -42,12 +42,12 @@ describe('PrimaryPartnerColumn', () => {
     const partner = makeRow('Seed Company', 'partner-123');
     const partnerName = partner.primaryPartner?.organization.value.name.value;
 
-    const params: GridRenderCellParams<TestRow, string | undefined> = {
+    const params = {
       value: partnerName,
       row: partner,
       colDef: column,
-      api: { current: null },
-    };
+      api: null,
+    } as unknown as GridRenderCellParams<TestRow, string | undefined>;
 
     render(<MemoryRouter>{column.renderCell(params)}</MemoryRouter>);
 
@@ -61,12 +61,12 @@ describe('PrimaryPartnerColumn', () => {
     const column = makeColumn();
     const emptyRow: TestRow = { primaryPartner: null };
 
-    const params: GridRenderCellParams<TestRow, undefined> = {
+    const params = {
       value: undefined,
       row: emptyRow,
       colDef: column,
-      api: { current: null },
-    };
+      api: null,
+    } as unknown as GridRenderCellParams<TestRow, undefined>;
 
     render(<MemoryRouter>{column.renderCell(params)}</MemoryRouter>);
 

--- a/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
+++ b/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
@@ -1,5 +1,5 @@
+import type { GridRenderCellParams } from '@mui/x-data-grid-pro';
 import { render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ProjectColumns } from '../../ProjectDataGrid/ProjectColumns';
 import { PrimaryPartnerColumn } from './PrimaryPartnerColumn';
@@ -18,17 +18,35 @@ interface TestRow {
 }
 
 const makeColumn = () =>
-  PrimaryPartnerColumn<TestRow>({
+  PrimaryPartnerColumn({
     field: 'primaryPartnership.partner.name',
-    valueGetter: (_, row) => row.primaryPartner,
+    valueGetter: (_value: never, row: TestRow) => row.primaryPartner,
   });
 
-type RenderCell = (params: {
-  value?: string;
-  row: TestRow;
-  colDef: ReturnType<typeof makeColumn>;
-  api: object;
-}) => ReactNode;
+type TestColumn = ReturnType<typeof makeColumn>;
+type RenderCellParams = GridRenderCellParams<
+  TestRow,
+  string | null | undefined
+>;
+
+const makeRenderCellParams = (
+  _column: TestColumn,
+  row: TestRow,
+  value?: string
+): RenderCellParams => ({
+  id: 'row-1',
+  field: 'primaryPartnership.partner.name',
+  value,
+  formattedValue: value,
+  row,
+  rowNode: null as never,
+  colDef: null as never,
+  cellMode: 'view',
+  hasFocus: false,
+  tabIndex: -1,
+  api: null as never,
+  isEditable: false,
+});
 
 const makeRow = (name = 'Seed Company'): TestRow => ({
   primaryPartner: {
@@ -46,12 +64,13 @@ const makeRow = (name = 'Seed Company'): TestRow => ({
 describe('PrimaryPartnerColumn', () => {
   it('extracts the partner organization name from the primary partnership', () => {
     const column = makeColumn();
+    const valueGetter = column.valueGetter;
 
     expect(
-      column.valueGetter(
+      valueGetter(
         undefined as never,
         makeRow(),
-        column,
+        undefined as never,
         undefined as never
       )
     ).toBe('Seed Company');
@@ -59,16 +78,12 @@ describe('PrimaryPartnerColumn', () => {
 
   it('renders the partner name as a link to the partner detail page', () => {
     const column = makeColumn();
-    const renderCell = column.renderCell as RenderCell;
 
     render(
       <MemoryRouter>
-        {renderCell({
-          value: 'Seed Company',
-          row: makeRow(),
-          colDef: column,
-          api: {},
-        })}
+        {column.renderCell(
+          makeRenderCellParams(column, makeRow(), 'Seed Company')
+        )}
       </MemoryRouter>
     );
 
@@ -80,18 +95,12 @@ describe('PrimaryPartnerColumn', () => {
 
   it('renders nothing when there is no primary partner', () => {
     const column = makeColumn();
-    const renderCell = column.renderCell as RenderCell;
 
     const emptyRow: TestRow = { primaryPartner: null };
 
     render(
       <MemoryRouter>
-        {renderCell({
-          value: undefined,
-          row: emptyRow,
-          colDef: column,
-          api: {},
-        })}
+        {column.renderCell(makeRenderCellParams(column, emptyRow))}
       </MemoryRouter>
     );
 
@@ -100,8 +109,9 @@ describe('PrimaryPartnerColumn', () => {
 
   it('creates the expected nested server filter', () => {
     const column = makeColumn();
+    const serverFilter = column.serverFilter;
 
-    expect(column.serverFilter('Seed Company')).toEqual({
+    expect(serverFilter('Seed Company')).toEqual({
       primaryPartnership: {
         partner: {
           organization: {

--- a/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
+++ b/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
@@ -17,40 +17,9 @@ interface TestRow {
   } | null;
 }
 
-const makeColumn = () =>
-  PrimaryPartnerColumn({
-    field: 'primaryPartnership.partner.name',
-    valueGetter: (_value: never, row: TestRow) => row.primaryPartner,
-  });
-
-type TestColumn = ReturnType<typeof makeColumn>;
-type RenderCellParams = GridRenderCellParams<
-  TestRow,
-  string | null | undefined
->;
-
-const makeRenderCellParams = (
-  _column: TestColumn,
-  row: TestRow,
-  value?: string
-): RenderCellParams => ({
-  id: 'row-1',
-  field: 'primaryPartnership.partner.name',
-  value,
-  formattedValue: value,
-  row,
-  rowNode: null as never,
-  colDef: null as never,
-  cellMode: 'view',
-  hasFocus: false,
-  tabIndex: -1,
-  api: null as never,
-  isEditable: false,
-});
-
-const makeRow = (name = 'Seed Company'): TestRow => ({
+const makeRow = (name = 'Seed Company', id = 'partner-1'): TestRow => ({
   primaryPartner: {
-    id: 'partner-1',
+    id,
     organization: {
       value: {
         name: {
@@ -61,57 +30,53 @@ const makeRow = (name = 'Seed Company'): TestRow => ({
   },
 });
 
-describe('PrimaryPartnerColumn', () => {
-  it('extracts the partner organization name from the primary partnership', () => {
-    const column = makeColumn();
-    const valueGetter = column.valueGetter;
-
-    expect(
-      valueGetter(
-        undefined as never,
-        makeRow(),
-        undefined as never,
-        undefined as never
-      )
-    ).toBe('Seed Company');
+const makeColumn = () =>
+  PrimaryPartnerColumn({
+    field: 'primaryPartnership.partner.name',
+    valueGetter: (_value: never, row: TestRow) => row.primaryPartner,
   });
 
+describe('PrimaryPartnerColumn', () => {
   it('renders the partner name as a link to the partner detail page', () => {
     const column = makeColumn();
+    const partner = makeRow('Seed Company', 'partner-123');
+    const partnerName = partner.primaryPartner?.organization.value.name.value;
 
-    render(
-      <MemoryRouter>
-        {column.renderCell(
-          makeRenderCellParams(column, makeRow(), 'Seed Company')
-        )}
-      </MemoryRouter>
-    );
+    const params: GridRenderCellParams<TestRow, string | undefined> = {
+      value: partnerName,
+      row: partner,
+      colDef: column,
+      api: { current: null },
+    };
+
+    render(<MemoryRouter>{column.renderCell(params)}</MemoryRouter>);
 
     expect(screen.getByRole('link', { name: 'Seed Company' })).toHaveAttribute(
       'href',
-      '/partners/partner-1'
+      '/partners/partner-123'
     );
   });
 
   it('renders nothing when there is no primary partner', () => {
     const column = makeColumn();
-
     const emptyRow: TestRow = { primaryPartner: null };
 
-    render(
-      <MemoryRouter>
-        {column.renderCell(makeRenderCellParams(column, emptyRow))}
-      </MemoryRouter>
-    );
+    const params: GridRenderCellParams<TestRow, undefined> = {
+      value: undefined,
+      row: emptyRow,
+      colDef: column,
+      api: { current: null },
+    };
+
+    render(<MemoryRouter>{column.renderCell(params)}</MemoryRouter>);
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('creates the expected nested server filter', () => {
     const column = makeColumn();
-    const serverFilter = column.serverFilter;
 
-    expect(serverFilter('Seed Company')).toEqual({
+    expect(column.serverFilter('Seed Company')).toEqual({
       primaryPartnership: {
         partner: {
           organization: {
@@ -122,12 +87,12 @@ describe('PrimaryPartnerColumn', () => {
     });
   });
 
-  it('is included in the project grid columns', () => {
-    expect(
-      ProjectColumns.find(
-        (column) => column.field === 'primaryPartnership.partner.name'
-      )
-    ).toMatchObject({
+  it('is included in the project grid columns with correct metadata', () => {
+    const column = ProjectColumns.find(
+      (col) => col.field === 'primaryPartnership.partner.name'
+    );
+
+    expect(column).toMatchObject({
       headerName: 'Primary Partner',
       width: 300,
     });

--- a/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
+++ b/src/components/Grid/Columns/PrimaryPartnerColumn.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProjectColumns } from '../../ProjectDataGrid/ProjectColumns';
+import { PrimaryPartnerColumn } from './PrimaryPartnerColumn';
+
+interface TestRow {
+  readonly primaryPartner: {
+    readonly id: string;
+    readonly organization: {
+      readonly value: {
+        readonly name: {
+          readonly value: string;
+        };
+      };
+    };
+  } | null;
+}
+
+const makeColumn = () =>
+  PrimaryPartnerColumn<TestRow>({
+    field: 'primaryPartnership.partner.name',
+    valueGetter: (_, row) => row.primaryPartner,
+  });
+
+type RenderCell = (params: {
+  value?: string;
+  row: TestRow;
+  colDef: ReturnType<typeof makeColumn>;
+  api: object;
+}) => ReactNode;
+
+const makeRow = (name = 'Seed Company'): TestRow => ({
+  primaryPartner: {
+    id: 'partner-1',
+    organization: {
+      value: {
+        name: {
+          value: name,
+        },
+      },
+    },
+  },
+});
+
+describe('PrimaryPartnerColumn', () => {
+  it('extracts the partner organization name from the primary partnership', () => {
+    const column = makeColumn();
+
+    expect(
+      column.valueGetter(
+        undefined as never,
+        makeRow(),
+        column,
+        undefined as never
+      )
+    ).toBe('Seed Company');
+  });
+
+  it('renders the partner name as a link to the partner detail page', () => {
+    const column = makeColumn();
+    const renderCell = column.renderCell as RenderCell;
+
+    render(
+      <MemoryRouter>
+        {renderCell({
+          value: 'Seed Company',
+          row: makeRow(),
+          colDef: column,
+          api: {},
+        })}
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'Seed Company' })).toHaveAttribute(
+      'href',
+      '/partners/partner-1'
+    );
+  });
+
+  it('renders nothing when there is no primary partner', () => {
+    const column = makeColumn();
+    const renderCell = column.renderCell as RenderCell;
+
+    const emptyRow: TestRow = { primaryPartner: null };
+
+    render(
+      <MemoryRouter>
+        {renderCell({
+          value: undefined,
+          row: emptyRow,
+          colDef: column,
+          api: {},
+        })}
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('creates the expected nested server filter', () => {
+    const column = makeColumn();
+
+    expect(column.serverFilter('Seed Company')).toEqual({
+      primaryPartnership: {
+        partner: {
+          organization: {
+            name: 'Seed Company',
+          },
+        },
+      },
+    });
+  });
+
+  it('is included in the project grid columns', () => {
+    expect(
+      ProjectColumns.find(
+        (column) => column.field === 'primaryPartnership.partner.name'
+      )
+    ).toMatchObject({
+      headerName: 'Primary Partner',
+      width: 300,
+    });
+  });
+});

--- a/src/components/Grid/Columns/PrimaryPartnerColumn.tsx
+++ b/src/components/Grid/Columns/PrimaryPartnerColumn.tsx
@@ -1,0 +1,37 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { Merge } from 'type-fest';
+import { PartnerLookupItem } from '../../form/Lookup';
+import { Link } from '../../Routing';
+import {
+  columnWithDefaults,
+  RowLike,
+  WithValueGetterReturning,
+} from '../ColumnTypes/definition.types';
+import { textColumn } from '../ColumnTypes/textColumn';
+
+export const PrimaryPartnerColumn = <
+  const Input extends Merge<
+    Partial<GridColDef<Row>>,
+    WithValueGetterReturning<PartnerLookupItem | null | undefined, Row>
+  >,
+  Row extends RowLike
+>({
+  valueGetter,
+  ...overrides
+}: Input) =>
+  columnWithDefaults<Row>()(overrides, {
+    ...textColumn<Row>(),
+    headerName: 'Primary Partner',
+    width: 300,
+    valueGetter: (...args) =>
+      valueGetter(...args)?.organization.value?.name.value,
+    renderCell: ({ value, row, colDef, api }) => {
+      const partner = valueGetter(null as never, row, colDef, { current: api });
+      return partner ? (
+        <Link to={`/partners/${partner.id}`}>{value}</Link>
+      ) : null;
+    },
+    serverFilter: (value) => ({
+      primaryPartnership: { partner: { organization: { name: value } } },
+    }),
+  });

--- a/src/components/Grid/Columns/PrimaryPartnerColumn.tsx
+++ b/src/components/Grid/Columns/PrimaryPartnerColumn.tsx
@@ -1,6 +1,5 @@
 import { GridColDef } from '@mui/x-data-grid-pro';
 import { Merge } from 'type-fest';
-import { PartnerLookupItem } from '../../form/Lookup';
 import { Link } from '../../Routing';
 import {
   columnWithDefaults,
@@ -9,10 +8,24 @@ import {
 } from '../ColumnTypes/definition.types';
 import { textColumn } from '../ColumnTypes/textColumn';
 
+interface PrimaryPartnerColumnPartner {
+  readonly id: string;
+  readonly organization: {
+    readonly value?: {
+      readonly name: {
+        readonly value?: string | null;
+      };
+    } | null;
+  };
+}
+
 export const PrimaryPartnerColumn = <
   const Input extends Merge<
     Partial<GridColDef<Row>>,
-    WithValueGetterReturning<PartnerLookupItem | null | undefined, Row>
+    WithValueGetterReturning<
+      PrimaryPartnerColumnPartner | null | undefined,
+      Row
+    >
   >,
   Row extends RowLike
 >({

--- a/src/components/ProjectDataGrid/ProjectColumns.tsx
+++ b/src/components/ProjectDataGrid/ProjectColumns.tsx
@@ -27,6 +27,7 @@ import {
   useFilterToggle,
 } from '../Grid';
 import { FieldRegionNameColumn } from '../Grid/Columns/FieldRegionNameColumn';
+import { PrimaryPartnerColumn } from '../Grid/Columns/PrimaryPartnerColumn';
 import { ProjectNameColumn } from '../Grid/Columns/ProjectNameColumn';
 import { SensitivityColumn } from '../Grid/Columns/SensitivityColumn';
 import { ProjectDataGridRowFragment as Project } from './projectDataGridRow.graphql';
@@ -91,6 +92,11 @@ export const ProjectColumns: Array<GridColDef<Project>> = [
     ...dateColumn(),
   },
   SensitivityColumn({}),
+  PrimaryPartnerColumn({
+    field: 'primaryPartnership.partner.name',
+    valueGetter: (_, { primaryPartnership }) =>
+      primaryPartnership.value?.partner.value ?? null,
+  }),
   {
     field: 'isMember',
     ...booleanColumn(),

--- a/src/components/ProjectDataGrid/projectDataGridRow.graphql
+++ b/src/components/ProjectDataGrid/projectDataGridRow.graphql
@@ -34,9 +34,18 @@ fragment projectDataGridRow on Project {
   }
   primaryPartnership {
     value {
+      id
       partner {
         value {
-          ...PartnerLookupItem
+          id
+          organization {
+            value {
+              id
+              name {
+                value
+              }
+            }
+          }
         }
       }
     }

--- a/src/components/ProjectDataGrid/projectDataGridRow.graphql
+++ b/src/components/ProjectDataGrid/projectDataGridRow.graphql
@@ -32,6 +32,15 @@ fragment projectDataGridRow on Project {
   mouEnd {
     value
   }
+  primaryPartnership {
+    value {
+      partner {
+        value {
+          ...PartnerLookupItem
+        }
+      }
+    }
+  }
 
   isMember
   pinned


### PR DESCRIPTION
## Summary

- Adds a **Primary Partner** column to the Projects list, positioned after the Sensitivity column
- Column renders the partner name as a clickable link to the partner detail page
- Sortable via column header (ASC/DESC) — wires into the existing `primaryPartnership.partner.name` sort chain on the API with no backend changes needed
- Filterable via text search, which maps to `primaryPartnership.partner.organization.name` on the API

## Changes

- `projectDataGridRow.graphql` — fetches `primaryPartnership.partner` using the existing `PartnerLookupItem` fragment
- `Grid/Columns/PrimaryPartnerColumn.tsx` — new reusable column component, following the `FieldRegionNameColumn` pattern
- `ProjectColumns.tsx` — imports and places the new column

## Notes

No backend changes required. The sort chain (`projectSorters['primaryPartnership.*']` → `partnershipSorters['partner.*']` → `partnerSorters['name']`) and filter infrastructure (`ProjectFilters.primaryPartnership`) already exist in the API.

This is the first in a series of PRs adding partner visibility to the Projects grid. Next PRs will add an All Partners column and multi-select partner filtering.

## Test plan

- [ ] Primary Partner column appears after Sensitivity in the Projects list
- [ ] Partner name renders as a link to `/partners/{id}`
- [ ] Projects with no primary partnership show an empty cell
- [ ] Clicking the column header sorts by partner name (ASC → DESC → back to default)
- [ ] Text filter in the column header searches by partner name
- [ ] Column can be hidden/shown via the Columns toolbar button

🤖 Generated with [Claude Code](https://claude.com/claude-code)