### PR TITLE
Add Tool grid 

### DIFF
--- a/src/components/ToolDataGrid/ToolColumns.tsx
+++ b/src/components/ToolDataGrid/ToolColumns.tsx
@@ -1,0 +1,77 @@
+import { Box } from '@mui/material';
+import {
+  DataGridProProps as DataGridProps,
+  GridColDef,
+  GridToolbarColumnsButton,
+  GridToolbarFilterButton,
+} from '@mui/x-data-grid-pro';
+import {
+  booleanColumn,
+  getInitialVisibility,
+  textColumn,
+  Toolbar,
+} from '../Grid';
+import { Link } from '../Routing';
+import { ToolDataGridRowFragment as Tool } from './toolDataGridRow.graphql';
+
+export const ToolColumns: Array<GridColDef<Tool>> = [
+  {
+    field: 'name',
+    ...textColumn(),
+    headerName: 'Name',
+    width: 240,
+    valueGetter: (_, row) => row.name.value || '',
+    renderCell: ({ value, row }) => (
+      <Link to={`/tools/${row.id}`}>{value}</Link>
+    ),
+    hideable: false,
+  },
+  {
+    field: 'aiBased',
+    ...booleanColumn(),
+    headerName: 'AI-based',
+    width: 120,
+    valueGetter: (_, row) => row.aiBased.value,
+  },
+  {
+    field: 'usageCount',
+    headerName: 'Usages',
+    description: 'Total engagements and projects using this tool',
+    type: 'number',
+    width: 130,
+    valueGetter: (_, row) =>
+      row.containerSummary.reduce((sum, c) => sum + c.total, 0),
+    sortable: false,
+    filterable: false,
+  },
+  {
+    field: 'description',
+    ...textColumn(),
+    headerName: 'Description',
+    flex: 1,
+    minWidth: 500,
+    valueGetter: (_, row) => row.description.value || '',
+    sortable: false,
+    filterable: false,
+  },
+];
+
+export const ToolInitialState = {
+  pinnedColumns: {
+    left: ToolColumns.slice(0, 1).map((column) => column.field),
+  },
+  columns: {
+    columnVisibilityModel: {
+      ...getInitialVisibility(ToolColumns),
+    },
+  },
+} satisfies DataGridProps['initialState'];
+
+export const ToolToolbar = () => (
+  <Toolbar sx={{ justifyContent: 'flex-start', gap: 2 }}>
+    <Box flex={1}>
+      <GridToolbarColumnsButton />
+      <GridToolbarFilterButton />
+    </Box>
+  </Toolbar>
+);

--- a/src/components/ToolDataGrid/index.ts
+++ b/src/components/ToolDataGrid/index.ts
@@ -1,0 +1,2 @@
+export * from './ToolColumns';
+export * from './toolDataGridRow.graphql';

--- a/src/components/ToolDataGrid/toolDataGridRow.graphql
+++ b/src/components/ToolDataGrid/toolDataGridRow.graphql
@@ -1,0 +1,16 @@
+fragment toolDataGridRow on Tool {
+  id
+  name {
+    value
+  }
+  description {
+    value
+  }
+  aiBased {
+    value
+  }
+  containerSummary {
+    containerType
+    total
+  }
+}

--- a/src/scenes/Root/Creates/Creates.tsx
+++ b/src/scenes/Root/Creates/Creates.tsx
@@ -3,6 +3,7 @@ import { ComponentType } from 'react';
 import { Except } from 'type-fest';
 import { Power } from '~/api/schema.graphql';
 import { DialogFormProps } from '../../../components/Dialog/DialogForm';
+import { CreateTool } from '../../../components/Tool/CreateTool/CreateTool';
 import { CreateLanguage } from '../../Languages/Create';
 import { CreateLocation } from '../../Locations/Create';
 import { CreatePartner } from '../../Partners/Create';
@@ -20,4 +21,5 @@ export const creates = mapOf<Power, Create>([
   ['CreateUser', [CreateUser, 'Person']],
   ['CreatePartner', [CreatePartner]],
   ['CreateLocation', [CreateLocation]],
+  ['CreateTool', [CreateTool]],
 ]);

--- a/src/scenes/Root/Sidebar/Sidebar.tsx
+++ b/src/scenes/Root/Sidebar/Sidebar.tsx
@@ -1,4 +1,10 @@
-import { Dashboard, FolderOpen, Person, Translate } from '@mui/icons-material';
+import {
+  Build,
+  Dashboard,
+  FolderOpen,
+  Person,
+  Translate,
+} from '@mui/icons-material';
 import {
   Drawer,
   List,
@@ -93,6 +99,7 @@ const SidebarContent = ({
         <NavItem to="/languages" label="Languages" icon={Translate} />
         <NavItem to="/users" label="People" icon={Person} />
         <NavItem to="/partners" label="Partners" icon={PeopleJoinedIcon} />
+        <NavItem to="/tools" label="Tools" icon={Build} />
       </List>
     </div>
   </>

--- a/src/scenes/Tools/List/ToolGrid.tsx
+++ b/src/scenes/Tools/List/ToolGrid.tsx
@@ -1,0 +1,45 @@
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
+import {
+  DefaultDataGridStyles,
+  flexLayout,
+  noFooter,
+  noHeaderFilterButtons,
+  useDataGridSlots,
+  useDataGridSource,
+} from '~/components/Grid';
+import {
+  ToolDataGridRowFragment as Tool,
+  ToolColumns,
+  ToolInitialState,
+  ToolToolbar,
+} from '~/components/ToolDataGrid';
+import { ToolsDocument } from './tools.graphql';
+
+export const ToolGrid = () => {
+  const [dataGridProps] = useDataGridSource({
+    query: ToolsDocument,
+    variables: { input: {} },
+    listAt: 'tools',
+    initialInput: {
+      sort: ToolColumns[0]!.field,
+    },
+  });
+
+  const { slots, slotProps } = useDataGridSlots(dataGridProps, {
+    slots: { toolbar: ToolToolbar },
+  });
+
+  return (
+    <DataGrid<Tool>
+      {...DefaultDataGridStyles}
+      {...dataGridProps}
+      slots={slots}
+      slotProps={slotProps}
+      columns={ToolColumns}
+      initialState={ToolInitialState}
+      headerFilters
+      hideFooter
+      sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+    />
+  );
+};

--- a/src/scenes/Tools/List/ToolList.tsx
+++ b/src/scenes/Tools/List/ToolList.tsx
@@ -1,0 +1,29 @@
+import { Paper, Stack, Typography } from '@mui/material';
+import { Helmet } from 'react-helmet-async';
+import { ToolGrid } from './ToolGrid';
+
+export const ToolList = () => {
+  return (
+    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+      <Helmet title="Tools" />
+      <Stack component="main" sx={{ flex: 1 }}>
+        <Typography variant="h2" paragraph>
+          Tools
+        </Typography>
+        <Stack sx={{ flex: 1, containerType: 'size' }}>
+          <Paper
+            sx={{
+              flex: 1,
+              minHeight: 375,
+              maxHeight: '100cqh',
+              width: 'min-content',
+              maxWidth: '100cqw',
+            }}
+          >
+            <ToolGrid />
+          </Paper>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/scenes/Tools/List/ToolList.tsx
+++ b/src/scenes/Tools/List/ToolList.tsx
@@ -1,28 +1,52 @@
 import { Paper, Stack, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
+import { useIsMobile } from '~/common';
+import { EntityList as ToolsList } from '~/components/List';
+import { ToolColumns } from '~/components/ToolDataGrid';
 import { ToolGrid } from './ToolGrid';
+import { ToolsDocument } from './tools.graphql';
 
 export const ToolList = () => {
+  const isMobile = useIsMobile();
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 2, md: 4 }, pt: 2 }}>
       <Helmet title="Tools" />
       <Stack component="main" sx={{ flex: 1 }}>
-        <Typography variant="h2" paragraph>
-          Tools
-        </Typography>
-        <Stack sx={{ flex: 1, containerType: 'size' }}>
-          <Paper
-            sx={{
-              flex: 1,
-              minHeight: 375,
-              maxHeight: '100cqh',
-              width: 'min-content',
-              maxWidth: '100cqw',
+        {!isMobile && (
+          <Typography variant="h2" paragraph>
+            Tools
+          </Typography>
+        )}
+        {isMobile ? (
+          <ToolsList
+            title="Tools"
+            query={ToolsDocument}
+            listAt={(data) => data.tools}
+            columns={ToolColumns}
+            sortDefault={{
+              field: ToolColumns[0]!.field,
+              direction: 'ASC',
             }}
-          >
-            <ToolGrid />
-          </Paper>
-        </Stack>
+            defaultSecondaryField="description"
+            primary={(tool) => tool.name.value}
+            to={(tool) => `/tools/${tool.id}`}
+          />
+        ) : (
+          // ai edge-case The grid (and its `useDataGridSource`) must only mount on desktop.
+          <Stack sx={{ flex: 1, containerType: 'size' }}>
+            <Paper
+              sx={{
+                flex: 1,
+                minHeight: 375,
+                maxHeight: '100cqh',
+                width: 'min-content',
+                maxWidth: '100cqw',
+              }}
+            >
+              <ToolGrid />
+            </Paper>
+          </Stack>
+        )}
       </Stack>
     </Stack>
   );

--- a/src/scenes/Tools/List/index.ts
+++ b/src/scenes/Tools/List/index.ts
@@ -1,0 +1,1 @@
+export * from './ToolList';

--- a/src/scenes/Tools/List/tools.graphql
+++ b/src/scenes/Tools/List/tools.graphql
@@ -1,0 +1,8 @@
+query Tools($input: ToolListInput!) {
+  tools(input: $input) {
+    items {
+      ...toolDataGridRow
+    }
+    ...Pagination
+  }
+}

--- a/src/scenes/Tools/Tools.tsx
+++ b/src/scenes/Tools/Tools.tsx
@@ -1,9 +1,11 @@
 import { Route, Routes } from 'react-router-dom';
 import { NotFoundRoute } from '~/components/Error';
 import { ToolDetail } from './Detail';
+import { ToolList } from './List';
 
 export const Tools = () => (
   <Routes>
+    <Route path="" element={<ToolList />} />
     <Route path=":toolId" element={<ToolDetail />} />
     {NotFoundRoute}
   </Routes>


### PR DESCRIPTION
## Summary
- New Tools list scene at `/tools` with a DataGrid (Name, AI-based, Usages, Description), modeled on the Languages list pattern
- Adds `ToolDataGrid` component (row fragment + columns + toolbar)
- Wires `Tools` into the sidebar (with the `Build` icon) and adds `CreateTool` to the global "Create New Item" menu
- Routes `path=""` on the Tools router to the new list page; existing `/tools/:toolId` detail page is unchanged