### PR TITLE
Mobile-friendly UI: responsive nav, dense lists, tabs, and detail-page polish

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -14,6 +14,7 @@ export * from './sensitivity';
 export * from './styles';
 export * from './sx';
 export * from './types';
+export * from './useIsMobile';
 export * from './urls';
 export * from './use-styles.types';
 export * from './unmatchedIndex';

--- a/src/common/useIsMobile.ts
+++ b/src/common/useIsMobile.ts
@@ -1,0 +1,16 @@
+import { useMediaQuery } from '@mui/material';
+import { Breakpoint, useTheme } from '@mui/material/styles';
+
+/**
+ * Whether the viewport is at or below the given breakpoint (default `md`, i.e.
+ * < 900px). Used to switch the app into its mobile layout — collapsing the
+ * sidebar into a drawer, rendering grids as dense lists, full-screen dialogs, etc.
+ */
+export const useIsMobile = (breakpoint: Breakpoint = 'md') => {
+  const theme = useTheme();
+  // `noSsr` reads matchMedia on the first client render (the app uses
+  // `createRoot`, not hydration), so mobile shows the mobile layout immediately
+  // instead of briefly rendering the desktop view — e.g. a wide DataGrid that
+  // horizontally overflows — before the media query resolves.
+  return useMediaQuery(theme.breakpoints.down(breakpoint), { noSsr: true });
+};

--- a/src/components/Comments/CommentsBar.tsx
+++ b/src/components/Comments/CommentsBar.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight as CloseIcon } from '@mui/icons-material';
 import { Drawer, Stack, Tooltip, Typography } from '@mui/material';
+import { useIsMobile } from '~/common';
 import { IconButton } from '../IconButton';
 import { useCommentsContext } from './CommentsContext';
 import { CommentsThreadList } from './CommentsThreadList';
@@ -11,22 +12,20 @@ export const CommentsBar = () => {
   const { isCommentsBarOpen, toggleCommentsBar, resourceId } =
     useCommentsContext();
   const open = isCommentsBarOpen && !!resourceId;
+  // On mobile the bar overlays content (temporary) instead of squeezing the
+  // layout (persistent), and widens to be usable on a small screen.
+  const isMobile = useIsMobile();
 
   return (
     <Drawer
-      variant="persistent"
+      variant={isMobile ? 'temporary' : 'persistent'}
       open={open}
       anchor="right"
       elevation={0}
+      onClose={() => toggleCommentsBar(false)}
       PaperProps={{
         sx: (theme) => ({
-          width: CommentsDrawerWidth,
-          // Artificially position this below the app header
-          // Still up for consideration.
-          // And maybe doable in another way without magic numbers.
-          // top: 65,
-          // height: 'calc(100vh - 65px)',
-
+          width: isMobile ? 'min(360px, 90vw)' : CommentsDrawerWidth,
           '--gutter': theme.spacing(2),
           padding: 'var(--gutter)',
           '--gap': theme.spacing(1),
@@ -36,7 +35,7 @@ export const CommentsBar = () => {
       sx={[
         !open && { display: 'none' },
         { overflowY: 'auto', display: 'flex' },
-        open && { width: CommentsDrawerWidth, flexShrink: 0 },
+        open && !isMobile && { width: CommentsDrawerWidth, flexShrink: 0 },
       ]}
     >
       <Stack

--- a/src/components/Dialog/DialogForm.tsx
+++ b/src/components/Dialog/DialogForm.tsx
@@ -19,7 +19,7 @@ import { ReactNode, useCallback, useMemo, useRef } from 'react';
 import { FormRenderProps, RenderableProps } from 'react-final-form';
 import { Except } from 'type-fest';
 import { inChangesetVar } from '~/api';
-import { callAll } from '~/common';
+import { callAll, useIsMobile } from '~/common';
 import { ChangesetModificationWarning } from '../Changeset/ChangesetModificationWarning';
 import {
   blurOnSubmit,
@@ -95,6 +95,7 @@ export function DialogForm<T, R = void>({
   ...FormProps
 }: DialogFormProps<T, R>) {
   const inChangeset = useReactiveVar(inChangesetVar);
+  const isMobile = useIsMobile();
   const formRef = useRef<FormApi<T> | undefined>();
 
   const mergedTransitionProps: TransitionProps = useMemo(() => {
@@ -134,6 +135,7 @@ export function DialogForm<T, R = void>({
           <Dialog
             fullWidth
             maxWidth="xs"
+            fullScreen={isMobile}
             {...DialogProps}
             open={open}
             onClose={(e, reason) => {

--- a/src/components/EngagementDataGrid/EngagementColumns.tsx
+++ b/src/components/EngagementDataGrid/EngagementColumns.tsx
@@ -41,6 +41,14 @@ import { SensitivityColumn } from '../Grid/Columns/SensitivityColumn';
 import { Link } from '../Routing';
 import { EngagementDataGridRowFragment as Engagement } from './engagementDataGridRow.graphql';
 
+/** An engagement's display name: its language (language engagement) or intern (internship). */
+export const engagementName = (engagement: Engagement) =>
+  engagement.__typename === 'LanguageEngagement'
+    ? engagement.language.value?.displayName.value
+    : engagement.__typename === 'InternshipEngagement'
+    ? engagement.intern.value?.fullName
+    : undefined;
+
 export const EngagementColumns: Array<GridColDef<Engagement>> = [
   ProjectNameColumn({
     field: 'project.name',
@@ -57,13 +65,7 @@ export const EngagementColumns: Array<GridColDef<Engagement>> = [
     field: 'nameProjectLast',
     ...textColumn(),
     width: 200,
-    valueGetter: (_, row) => {
-      return row.__typename === 'LanguageEngagement'
-        ? row.language.value?.displayName.value
-        : row.__typename === 'InternshipEngagement'
-        ? row.intern.value?.fullName
-        : null;
-    },
+    valueGetter: (_, row) => engagementName(row) ?? null,
     renderCell: ({ value, row }) => {
       return row.__typename === 'LanguageEngagement' ? (
         <Link to={`/languages/${row.language.value!.id}`}>{value}</Link>

--- a/src/components/FieldOverviewCard/FieldOverviewCard.tsx
+++ b/src/components/FieldOverviewCard/FieldOverviewCard.tsx
@@ -69,7 +69,7 @@ export const FieldOverviewCard = ({
           flex: 1,
           display: 'flex',
           justifyContent: 'space-evenly',
-          padding: theme.spacing(3, 4),
+          padding: { xs: theme.spacing(2), md: theme.spacing(3, 4) },
         })}
         onClick={onClick}
       >
@@ -78,7 +78,7 @@ export const FieldOverviewCard = ({
           sx={{
             flex: 1,
             alignSelf: 'flex-start',
-            pl: 4,
+            pl: { xs: 2, md: 4 },
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'space-evenly',

--- a/src/components/Grid/DefaultDataGridStyles.tsx
+++ b/src/components/Grid/DefaultDataGridStyles.tsx
@@ -165,5 +165,7 @@ export const getInitialVisibility = (columns: GridColDef[]) =>
 declare module '@mui/x-data-grid/internals' {
   interface GridBaseColDef {
     hidden?: boolean;
+    /** Hide this column on mobile viewports (see `useResponsiveColumnVisibility`). */
+    mobileHidden?: boolean;
   }
 }

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -1,5 +1,6 @@
 import './sorting';
 
+export * from './useResponsiveColumnVisibility';
 export * from './DefaultDataGridStyles';
 export * from './EditNumberCell';
 export * from './useCurrencyColumn';

--- a/src/components/Grid/useDataGridSource.tsx
+++ b/src/components/Grid/useDataGridSource.tsx
@@ -388,8 +388,14 @@ export const useDataGridSource = <
   // fully cached, unsorted list.
   // See: docs/data-grid-source.md#applying-client-side-sort-after-cache-completion
   useEffect(() => {
+    // `applySorting` is only present once the grid has mounted. When this source
+    // feeds a responsive view that renders a list (not the grid) on mobile, the
+    // grid never mounts — there's nothing to sort, so skip it rather than crash.
     if (isCacheComplete) {
-      apiRef.current.applySorting();
+      // The type says `applySorting` is always present, but `apiRef.current` is
+      // an empty object until the grid mounts (it may never, on mobile).
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      apiRef.current.applySorting?.();
     }
   }, [apiRef, isCacheComplete]);
 

--- a/src/components/Grid/useResponsiveColumnVisibility.ts
+++ b/src/components/Grid/useResponsiveColumnVisibility.ts
@@ -1,0 +1,43 @@
+import {
+  DataGridProProps,
+  GridColDef,
+  GridColumnVisibilityModel,
+} from '@mui/x-data-grid-pro';
+import { merge } from 'lodash';
+import { useMemo } from 'react';
+import { useIsMobile } from '~/common';
+
+/**
+ * For data grids that have no dedicated mobile list view, this narrows them on
+ * small screens: columns flagged `mobileHidden` are hidden and the primary
+ * column(s) are pinned left so the identity stays visible while the rest scroll.
+ *
+ * Returns the grid's `initialState` unchanged on desktop, and a merged
+ * `initialState` on mobile — pass the result straight to `<DataGridPro initialState={...}>`.
+ * Because it works through `initialState` (applied at mount), it adapts on load
+ * rather than live breakpoint changes, which is sufficient for these fallback grids.
+ */
+export const useResponsiveColumnVisibility = (
+  columns: readonly GridColDef[],
+  initialState: DataGridProProps['initialState'],
+  { pinnedLeft = [] }: { pinnedLeft?: readonly string[] } = {}
+): DataGridProProps['initialState'] => {
+  const isMobile = useIsMobile();
+  return useMemo(() => {
+    if (!isMobile) {
+      return initialState;
+    }
+    const columnVisibilityModel: GridColumnVisibilityModel = {};
+    for (const column of columns) {
+      if (column.mobileHidden) {
+        columnVisibilityModel[column.field] = false;
+      }
+    }
+    return merge({}, initialState, {
+      columns: { columnVisibilityModel },
+      ...(pinnedLeft.length > 0
+        ? { pinnedColumns: { left: [...pinnedLeft] } }
+        : {}),
+    });
+  }, [isMobile, columns, initialState, pinnedLeft]);
+};

--- a/src/components/Grid/useResponsiveColumnVisibility.ts
+++ b/src/components/Grid/useResponsiveColumnVisibility.ts
@@ -33,11 +33,17 @@ export const useResponsiveColumnVisibility = (
         columnVisibilityModel[column.field] = false;
       }
     }
-    return merge({}, initialState, {
+    const merged = merge({}, initialState, {
       columns: { columnVisibilityModel },
-      ...(pinnedLeft.length > 0
-        ? { pinnedColumns: { left: [...pinnedLeft] } }
-        : {}),
     });
+    // Pin the primary column(s) left on mobile. Assign after the merge so the
+    // array is replaced wholesale — lodash `merge` merges arrays by index, which
+    // would otherwise leave stale trailing entries from `initialState`.
+    return pinnedLeft.length > 0
+      ? {
+          ...merged,
+          pinnedColumns: { ...merged.pinnedColumns, left: [...pinnedLeft] },
+        }
+      : merged;
   }, [isMobile, columns, initialState, pinnedLeft]);
 };

--- a/src/components/List/EntityList.tsx
+++ b/src/components/List/EntityList.tsx
@@ -1,0 +1,133 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { Box } from '@mui/material';
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { ReactNode, useMemo } from 'react';
+import { Entity, PaginatedListOutput } from '~/api';
+import { EntityListItem } from './EntityListItem';
+import {
+  columnsToFilterControls,
+  columnsToSortOptions,
+  rowSecondary,
+  SortState,
+} from './gridColumnAdapters';
+import { List } from './List';
+import { useRowListFilters } from './MobileFilters';
+import { usePagedListQuery } from './usePagedListQuery';
+
+export interface EntityListProps<Data, Item extends Entity> {
+  /** The list query — shares the grid's document, so the data already has every column's field. */
+  query: TypedDocumentNode<Data, any>;
+  /** Where the paginated list lives in the result (may be nested, e.g. `d.language.locations`). */
+  listAt: (data: Data) => PaginatedListOutput<Item> & { canCreate?: boolean };
+  /** Query variables other than `input` (e.g. a parent id); `input` is supplied by the drawer. */
+  variables?: Record<string, any>;
+  /** The grid's columns — drive the filter/sort drawer and the labeled secondary. */
+  columns: readonly GridColDef[];
+  sortDefault: SortState;
+  /**
+   * Column field shown (labeled) as the secondary line while on the default
+   * sort. Used only by the default row render — omit it when supplying `renderItem`.
+   */
+  defaultSecondaryField?: string;
+  /** Row primary text. Required unless `renderItem` is supplied. */
+  primary?: (item: Item) => ReactNode;
+  /** Row navigation target. Required unless `renderItem` is supplied. */
+  to?: (item: Item) => string;
+  /** Leading element (e.g. a sensitivity icon), rendered raw in the row's avatar slot. */
+  avatar?: (item: Item) => ReactNode;
+  /** Override the whole row (e.g. a computed primary/secondary); receives the active sort field. */
+  renderItem?: (item: Item, sort: string | undefined) => ReactNode;
+}
+
+/**
+ * The mobile dense-list counterpart to a {@link DataGrid}, reusable for any list
+ * scene or detail-page tab. Derives its filter/sort drawer + labeled secondary
+ * from the grid's `columns`, drives a {@link usePagedListQuery}, and renders a
+ * tappable {@link EntityListItem} per item. Self-contained: it clips horizontal
+ * overflow and scrolls vertically, so it's safe inside the grid's
+ * `containerType: size` tab panels.
+ */
+export function EntityList<Data, Item extends Entity>({
+  query,
+  listAt,
+  variables,
+  columns,
+  sortDefault,
+  defaultSecondaryField,
+  primary,
+  to,
+  avatar,
+  renderItem,
+}: EntityListProps<Data, Item>) {
+  const filterControls = useMemo(
+    () => columnsToFilterControls(columns),
+    [columns]
+  );
+  const sortOptions = useMemo(() => columnsToSortOptions(columns), [columns]);
+  const { filter, sort, order } = useRowListFilters(filterControls, {
+    options: sortOptions,
+    default: sortDefault,
+  });
+
+  // Merge the drawer's filter with any base scoping filter (e.g. a tool filter),
+  // rather than overwriting it.
+  const baseInput: Record<string, any> = variables?.input ?? {};
+  const mergedFilter =
+    baseInput.filter || filter ? { ...baseInput.filter, ...filter } : undefined;
+
+  const list = usePagedListQuery(query, {
+    listAt,
+    variables: {
+      ...variables,
+      input: { ...baseInput, sort, order, filter: mergedFilter },
+    },
+  });
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <List
+        {...list}
+        showCount
+        bleed={false}
+        sx={{ flex: 1 }}
+        spacing={0}
+        // The list is a single vertical column. MUI Grid containers default to
+        // `flex-wrap: wrap`, so a `direction="column"` grid whose rows exceed the
+        // available height wraps into extra COLUMNS — horizontal overflow. Force
+        // nowrap so it stays one column and scrolls vertically instead.
+        ContainerProps={{ wrap: 'nowrap' }}
+        ItemProps={{ xs: 12 }}
+        renderItem={(item) =>
+          renderItem ? (
+            renderItem(item, sort)
+          ) : (
+            <EntityListItem
+              to={to?.(item)}
+              avatar={avatar?.(item)}
+              primary={primary?.(item)}
+              secondary={rowSecondary(
+                columns,
+                sort,
+                sortDefault.field,
+                defaultSecondaryField,
+                item
+              )}
+            />
+          )
+        }
+        renderSkeleton={
+          <EntityListItem loading avatar={!!avatar || undefined} />
+        }
+      />
+    </Box>
+  );
+}

--- a/src/components/List/EntityListItem.tsx
+++ b/src/components/List/EntityListItem.tsx
@@ -1,0 +1,116 @@
+import { ChevronRight } from '@mui/icons-material';
+import {
+  Avatar,
+  Box,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Skeleton,
+  SxProps,
+  Theme,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { ReactNode } from 'react';
+import { ListItemLink } from '../Routing';
+
+export interface EntityListItemProps {
+  /** Internal route the row links to. Omit for a non-navigable row or while `loading`. */
+  to?: string;
+  /** Render a loading skeleton instead of content. */
+  loading?: boolean;
+  /** Leading image avatar (e.g. user photo). Takes precedence over `icon`. */
+  avatar?: ReactNode;
+  /** Leading type icon, rendered inside a tinted avatar circle. */
+  icon?: ReactNode;
+  primary?: ReactNode;
+  secondary?: ReactNode;
+  /** Trailing content; defaults to a chevron on navigable rows. */
+  trailing?: ReactNode;
+}
+
+const avatarSx: SxProps<Theme> = (theme) => ({
+  bgcolor: alpha(theme.palette.primary.main, 0.12),
+  color: 'primary.main',
+  fontWeight: 600,
+});
+
+// Slightly separated, outlined rows rather than flush divider lines. A fixed
+// minHeight keeps rows uniform whether or not they have a `secondary` line
+// (single-line content is vertically centered by the ListItem).
+const rowSx: SxProps<Theme> = {
+  minHeight: 64,
+  mb: 1,
+  border: 1,
+  borderColor: 'divider',
+  borderRadius: 1,
+  bgcolor: 'background.paper',
+};
+
+/**
+ * A compact, full-width list row — the mobile counterpart to the desktop data
+ * grids and the bulky `*ListItemCard` components. Built on MUI list primitives
+ * and {@link ListItemLink} so the whole row navigates on tap. An avatar (image
+ * or type icon) is shown only when provided; trails with a chevron when navigable.
+ */
+export const EntityListItem = ({
+  to,
+  loading,
+  avatar,
+  icon,
+  primary,
+  secondary,
+  trailing,
+}: EntityListItemProps) => {
+  const hasAvatar = !!(avatar || icon);
+
+  const leading = loading ? (
+    hasAvatar ? (
+      <ListItemAvatar>
+        <Skeleton variant="circular" width={40} height={40} />
+      </ListItemAvatar>
+    ) : null
+  ) : avatar ? (
+    <ListItemAvatar>{avatar}</ListItemAvatar>
+  ) : icon ? (
+    <ListItemAvatar>
+      {/* Decorative — the row's primary text conveys the entity/type. */}
+      <Avatar aria-hidden sx={avatarSx}>
+        {icon}
+      </Avatar>
+    </ListItemAvatar>
+  ) : null;
+
+  const content = (
+    <>
+      {leading}
+      <ListItemText
+        primary={loading ? <Skeleton width="55%" /> : primary}
+        secondary={loading ? <Skeleton width="35%" /> : secondary}
+        primaryTypographyProps={{ fontWeight: 'medium', noWrap: true }}
+        secondaryTypographyProps={{ noWrap: true }}
+      />
+      {!loading &&
+        (trailing != null ? (
+          <Box sx={{ ml: 2, flexShrink: 0, color: 'text.secondary' }}>
+            {trailing}
+          </Box>
+        ) : to ? (
+          <ChevronRight sx={{ ml: 1, flexShrink: 0, color: 'action.active' }} />
+        ) : null)}
+    </>
+  );
+
+  if (loading || !to) {
+    return (
+      <ListItem component="div" sx={rowSx} aria-busy={loading || undefined}>
+        {content}
+      </ListItem>
+    );
+  }
+
+  return (
+    <ListItemLink to={to} selected={false} sx={rowSx}>
+      {content}
+    </ListItemLink>
+  );
+};

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,10 +1,12 @@
-import { Box, Grid, GridProps } from '@mui/material';
+import { Box, Grid, GridProps, Typography } from '@mui/material';
 import { times } from 'lodash';
 import { ReactNode, RefObject, useRef } from 'react';
 import { Entity, isNetworkRequestInFlight, PaginatedListOutput } from '~/api';
 import { extendSx, StyleProps } from '~/common';
 import { usePersistedScroll } from '../../hooks/usePersistedScroll';
 import { ChangesetBadge, useDetermineChangesetDiffItem } from '../Changeset';
+import { Error } from '../Error';
+import { FormattedNumber } from '../Formatters';
 import { ProgressButton, ProgressButtonProps } from '../ProgressButton';
 import { ListQueryResult } from './useListQuery';
 
@@ -18,6 +20,16 @@ export interface ListProps<Item extends Entity>
   renderItem: (item: Item) => ReactNode;
   renderSkeleton: ReactNode | ((index: number) => ReactNode);
   renderCreate?: ReactNode;
+  /** Shown when the list has loaded with no items. Defaults to "No results found". */
+  renderEmpty?: ReactNode;
+  /** Show a "Total Rows" count above the list (matching the data grid). */
+  showCount?: boolean;
+  /**
+   * Bleed the scroll area into a negative-margin gutter so a per-item
+   * `ChangesetBadge` isn't clipped at the edge. On by default (card lists);
+   * pass `false` for flush row lists that supply their own spacing.
+   */
+  bleed?: boolean;
   skeletonCount?: number;
   ContainerProps?: GridProps;
   ItemProps?: GridProps;
@@ -36,11 +48,15 @@ export const List = <Item extends Entity>(
   const {
     networkStatus,
     data,
+    error,
     loadMore,
     skeletonCount = 5,
     renderItem,
     renderSkeleton,
     renderCreate,
+    renderEmpty,
+    showCount,
+    bleed = true,
     ContainerProps,
     spacing = 2,
     ItemProps,
@@ -58,52 +74,83 @@ export const List = <Item extends Entity>(
   const determineChangesetDiff = useDetermineChangesetDiffItem();
 
   return (
-    <Box
-      sx={[
-        {
-          overflow: 'auto',
-          ml: -2,
-          p: 2,
-        },
-        ...extendSx(sx),
-      ]}
-      ref={scrollRef}
-    >
-      <Grid direction="column" spacing={spacing} {...ContainerProps} container>
-        {!data?.items
-          ? times(skeletonCount).map((index) => (
+    <>
+      {showCount && data && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ px: 2, pb: 1, flexShrink: 0 }}
+        >
+          Total Rows: <FormattedNumber value={data.total} />
+        </Typography>
+      )}
+      <Box
+        sx={[{ overflow: 'auto' }, bleed && { ml: -2, p: 2 }, ...extendSx(sx)]}
+        ref={scrollRef}
+      >
+        <Grid
+          direction="column"
+          spacing={spacing}
+          {...ContainerProps}
+          container
+        >
+          {error && !data?.items ? (
+            <Grid item xs={12}>
+              <Error error={error}>Error loading list</Error>
+            </Grid>
+          ) : !data?.items ? (
+            times(skeletonCount).map((index) => (
               <Grid {...ItemProps} {...SkeletonItemProps} item key={index}>
                 {typeof renderSkeleton === 'function'
                   ? renderSkeleton(index)
                   : renderSkeleton}
               </Grid>
             ))
-          : data.items.map((item) => (
+          ) : (
+            data.items.map((item) => (
               <Grid {...ItemProps} {...DataItemProps} item key={item.id}>
                 <ChangesetBadge mode={determineChangesetDiff(item).mode}>
                   {renderItem(item)}
                 </ChangesetBadge>
               </Grid>
-            ))}
-        {data?.canCreate && renderCreate && (
-          <Grid {...ItemProps} {...CreateItemProps} item>
-            {renderCreate}
-          </Grid>
-        )}
-        {data?.hasMore && (
-          <Grid {...ItemProps} {...LoadMoreItemProps} item>
-            <ProgressButton
-              color="primary"
-              fullWidth
-              {...LoadMoreButtonProps}
-              progress={isNetworkRequestInFlight(networkStatus)}
-              onClick={loadMore}
-            >
-              Load More
-            </ProgressButton>
-          </Grid>
-        )}
-      </Grid>
-    </Box>
+            ))
+          )}
+          {data?.items &&
+            data.items.length === 0 &&
+            !(data.canCreate && renderCreate) && (
+              <Grid item xs={12}>
+                {renderEmpty ?? (
+                  <Typography
+                    color="text.secondary"
+                    align="center"
+                    sx={{ py: 4 }}
+                  >
+                    No results found
+                  </Typography>
+                )}
+              </Grid>
+            )}
+          {data?.canCreate && renderCreate && (
+            <Grid {...ItemProps} {...CreateItemProps} item>
+              {renderCreate}
+            </Grid>
+          )}
+          {data?.hasMore && (
+            <Grid {...ItemProps} {...LoadMoreItemProps} item>
+              <ProgressButton
+                color="primary"
+                fullWidth
+                {...LoadMoreButtonProps}
+                progress={isNetworkRequestInFlight(networkStatus)}
+                disabled={isNetworkRequestInFlight(networkStatus)}
+                onClick={loadMore}
+              >
+                Load More
+              </ProgressButton>
+            </Grid>
+          )}
+        </Grid>
+      </Box>
+    </>
   );
 };

--- a/src/components/List/MobileFilterButton.test.tsx
+++ b/src/components/List/MobileFilterButton.test.tsx
@@ -1,0 +1,60 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  columnsToFilterControls,
+  columnsToSortOptions,
+} from './gridColumnAdapters';
+import {
+  MobileFilterButton,
+  MobileFilterProvider,
+  useRowListFilters,
+} from './MobileFilters';
+
+const cols = [
+  { field: 'name', headerName: 'Name' },
+  { field: 'status', headerName: 'Status' },
+] as unknown as GridColDef[];
+
+// A stand-in row list that registers its controls + sort with the provider,
+// the same way a scene's renderList does via EntityList.
+const RegisterList = () => {
+  useRowListFilters(columnsToFilterControls(cols), {
+    options: columnsToSortOptions(cols),
+    default: { field: 'name', direction: 'ASC' },
+  });
+  return null;
+};
+
+const setup = () =>
+  render(
+    <MobileFilterProvider>
+      <RegisterList />
+      <MobileFilterButton />
+    </MobileFilterProvider>
+  );
+
+const openDrawer = async () =>
+  fireEvent.click(await screen.findByRole('button', { name: 'Filters' }));
+
+describe('MobileFilterButton', () => {
+  it('keeps "Clear all" disabled until something changes', async () => {
+    setup();
+    await openDrawer();
+    expect(screen.getByRole('button', { name: 'Clear all' })).toBeDisabled();
+  });
+
+  it('enables "Clear all" after a sort-only change and resets it', async () => {
+    setup();
+    await openDrawer();
+    const clearAll = screen.getByRole('button', { name: 'Clear all' });
+    expect(clearAll).toBeDisabled();
+
+    // Change only the sort direction — no filters touched.
+    fireEvent.click(screen.getByRole('button', { name: 'Descending' }));
+    await waitFor(() => expect(clearAll).toBeEnabled());
+
+    // Clearing resets the sort back to its default.
+    fireEvent.click(clearAll);
+    await waitFor(() => expect(clearAll).toBeDisabled());
+  });
+});

--- a/src/components/List/MobileFilters.tsx
+++ b/src/components/List/MobileFilters.tsx
@@ -1,0 +1,482 @@
+import { Close as CloseIcon, FilterList } from '@mui/icons-material';
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Divider,
+  Drawer,
+  ListItemText,
+  MenuItem,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from '@mui/material';
+import { useDebounce } from 'ahooks';
+import { mergeWith } from 'lodash';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { IconButton } from '../IconButton';
+import {
+  FilterControl,
+  SortConfig,
+  SortDirection,
+  SortOption,
+  SortState,
+} from './gridColumnAdapters';
+
+type FilterValues = Record<string, unknown>;
+
+interface MobileFilterState {
+  controls: readonly FilterControl[];
+  values: FilterValues;
+  setValue: (key: string, value: unknown) => void;
+  clearAll: () => void;
+  register: (
+    controls: readonly FilterControl[],
+    sort?: SortConfig & { key: string }
+  ) => void;
+  unregister: () => void;
+  sortOptions: readonly SortOption[];
+  sort?: SortState;
+  /** True when the active sort differs from the list's default (so "Clear all" has work to do). */
+  sortDirty: boolean;
+  /** Identifies which registered list `sort` belongs to (see {@link useRowListFilters}). */
+  sortKey: string;
+  setSort: (sort: SortState) => void;
+}
+
+const MobileFilterContext = createContext<MobileFilterState | null>(null);
+
+/**
+ * Holds the active list's filter controls + values so the global header filter
+ * button can render and drive them. Lives in the app shell (wraps Header + content).
+ */
+export const MobileFilterProvider = ({ children }: { children: ReactNode }) => {
+  const [controls, setControls] = useState<readonly FilterControl[]>([]);
+  const [values, setValues] = useState<FilterValues>({});
+  const [sortOptions, setSortOptions] = useState<readonly SortOption[]>([]);
+  const [sort, setSort] = useState<SortState | undefined>(undefined);
+  const [sortKey, setSortKey] = useState('');
+  const [defaultSort, setDefaultSort] = useState<SortState | undefined>(
+    undefined
+  );
+
+  const register = useCallback<MobileFilterState['register']>(
+    (next, sortCfg) => {
+      setControls(next);
+      setValues({});
+      setSortOptions(sortCfg?.options ?? []);
+      setSort(sortCfg?.default);
+      setDefaultSort(sortCfg?.default);
+      setSortKey(sortCfg?.key ?? '');
+    },
+    []
+  );
+  const unregister = useCallback(() => {
+    setControls([]);
+    setValues({});
+    setSortOptions([]);
+    setSort(undefined);
+    setDefaultSort(undefined);
+    setSortKey('');
+  }, []);
+  const setValue = useCallback((key: string, value: unknown) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }, []);
+  const clearAll = useCallback(() => {
+    setValues({});
+    setSort(defaultSort);
+  }, [defaultSort]);
+
+  const sortDirty =
+    !!sort &&
+    !!defaultSort &&
+    (sort.field !== defaultSort.field ||
+      sort.direction !== defaultSort.direction);
+
+  const value = useMemo(
+    () => ({
+      controls,
+      values,
+      setValue,
+      clearAll,
+      register,
+      unregister,
+      sortOptions,
+      sort,
+      sortDirty,
+      sortKey,
+      setSort,
+    }),
+    [
+      controls,
+      values,
+      setValue,
+      clearAll,
+      register,
+      unregister,
+      sortOptions,
+      sort,
+      sortDirty,
+      sortKey,
+    ]
+  );
+
+  return (
+    <MobileFilterContext.Provider value={value}>
+      {children}
+    </MobileFilterContext.Provider>
+  );
+};
+
+const useMobileFilters = () => useContext(MobileFilterContext);
+
+// Combine selected filters; arrays (e.g. `status`) concatenate rather than overwrite.
+const concatArrays = (objValue: unknown, srcValue: unknown) =>
+  Array.isArray(objValue) ? objValue.concat(srcValue) : undefined;
+
+const buildFilter = (
+  controls: readonly FilterControl[],
+  values: FilterValues
+): Record<string, any> | undefined => {
+  const fragments = controls
+    .map((c) => c.toFilter(values[c.key]))
+    .filter((f): f is Record<string, any> => !!f);
+  if (fragments.length === 0) {
+    return undefined;
+  }
+  const initial: Record<string, any> = {};
+  return fragments.reduce((acc, f) => mergeWith(acc, f, concatArrays), initial);
+};
+
+/**
+ * Mobile filtering for a dense row list. Registers `controls` with the app shell
+ * (so the header filter button can drive them) and returns the merged API `filter`
+ * for `useListQuery`. Returns `undefined` when nothing is selected.
+ */
+export const useRowListFilters = (
+  controls: readonly FilterControl[],
+  sort?: SortConfig
+) => {
+  const ctx = useContext(MobileFilterContext);
+  const register = ctx?.register;
+  const unregister = ctx?.unregister;
+  const values = ctx?.values;
+
+  const keysSig = controls.map((c) => c.key).join('|');
+  const optionsSig = sort?.options.map((o) => o.field).join('|') ?? '';
+  // Identifies this list's sort registration; the context `sort` is only trusted
+  // when it carries the same key (see effectiveSort below).
+  const sortKey = sort
+    ? `${optionsSig}#${sort.default.field}:${sort.default.direction}`
+    : '';
+
+  useEffect(() => {
+    register?.(controls, sort ? { ...sort, key: sortKey } : undefined);
+    return () => unregister?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keysSig/sortKey capture the meaningful change
+  }, [keysSig, sortKey, register, unregister]);
+
+  const filter = useMemo(
+    () => buildFilter(controls, values ?? {}),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keysSig captures the meaningful change
+    [keysSig, values]
+  );
+
+  // Use the shared sort only when it belongs to THIS list (matching sortKey).
+  // On first render — before this list registers — the context still holds the
+  // previous list's sort, so fall back to our own default and never query with a
+  // stale/foreign sort.
+  const effectiveSort =
+    ctx?.sortKey === sortKey && ctx.sort ? ctx.sort : sort?.default;
+
+  return {
+    filter,
+    sort: effectiveSort?.field,
+    order: effectiveSort?.direction,
+  };
+};
+
+/**
+ * Global filter button for mobile: when the active list registers filters (via
+ * {@link useRowListFilters}), this opens a drawer matching the grid's header filters.
+ */
+export const MobileFilterButton = () => {
+  const ctx = useMobileFilters();
+  const [open, setOpen] = useState(false);
+
+  if (!ctx || ctx.controls.length === 0) {
+    return null;
+  }
+  const {
+    controls,
+    values,
+    setValue,
+    clearAll,
+    sortOptions,
+    sort,
+    sortDirty,
+    setSort,
+  } = ctx;
+  const activeCount = controls.filter(
+    (c) => !!c.toFilter(values[c.key])
+  ).length;
+
+  return (
+    <>
+      <IconButton
+        aria-label={
+          activeCount > 0 ? `Filters, ${activeCount} active` : 'Filters'
+        }
+        onClick={() => setOpen(true)}
+      >
+        <Badge color="info" badgeContent={activeCount}>
+          <FilterList />
+        </Badge>
+      </IconButton>
+      <Drawer anchor="right" open={open} onClose={() => setOpen(false)}>
+        <Stack sx={{ width: 'min(380px, 90vw)', height: 1 }}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}
+          >
+            <Typography variant="h3">Filters</Typography>
+            <IconButton
+              aria-label="Close filters"
+              onClick={() => setOpen(false)}
+            >
+              <CloseIcon />
+            </IconButton>
+          </Stack>
+
+          <Stack sx={{ flex: 1, overflowY: 'auto', p: 2, gap: 2 }}>
+            {sortOptions.length > 0 && sort && (
+              <>
+                <SortField
+                  options={sortOptions}
+                  value={sort}
+                  onChange={setSort}
+                />
+                {controls.length > 0 && <Divider />}
+              </>
+            )}
+            {controls.map((control) => (
+              <FilterField
+                key={control.key}
+                control={control}
+                value={values[control.key]}
+                setValue={setValue}
+              />
+            ))}
+          </Stack>
+
+          <Stack
+            direction="row"
+            gap={1}
+            sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}
+          >
+            <Button
+              fullWidth
+              color="secondary"
+              // Enabled when there are filters OR a non-default sort to reset.
+              disabled={activeCount === 0 && !sortDirty}
+              onClick={clearAll}
+            >
+              Clear all
+            </Button>
+            <Button
+              fullWidth
+              variant="contained"
+              color="secondary"
+              disableElevation
+              onClick={() => setOpen(false)}
+            >
+              Done
+            </Button>
+          </Stack>
+        </Stack>
+      </Drawer>
+    </>
+  );
+};
+
+const SortField = ({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly SortOption[];
+  value: SortState;
+  onChange: (sort: SortState) => void;
+}) => {
+  const { field, direction } = value;
+  return (
+    <Stack gap={1}>
+      <TextField
+        select
+        label="Sort by"
+        size="small"
+        fullWidth
+        value={field}
+        onChange={(e) => onChange({ field: e.target.value, direction })}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.field} value={option.field}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+      <ToggleButtonGroup
+        exclusive
+        fullWidth
+        size="small"
+        color="primary"
+        value={direction}
+        onChange={(_, next: SortDirection | null) =>
+          next && onChange({ field, direction: next })
+        }
+      >
+        <ToggleButton value="ASC">Ascending</ToggleButton>
+        <ToggleButton value="DESC">Descending</ToggleButton>
+      </ToggleButtonGroup>
+    </Stack>
+  );
+};
+
+const FilterField = ({
+  control,
+  value,
+  setValue,
+}: {
+  control: FilterControl;
+  value: unknown;
+  setValue: (key: string, value: unknown) => void;
+}) => {
+  const { kind, key, label, options = [] } = control;
+
+  if (kind === 'search') {
+    return (
+      <FilterSearchField
+        label={label}
+        external={typeof value === 'string' ? value : ''}
+        onChange={(text) => setValue(key, text)}
+      />
+    );
+  }
+
+  if (kind === 'boolean') {
+    const current = value === true ? 'true' : value === false ? 'false' : '';
+    return (
+      <TextField
+        select
+        label={label}
+        size="small"
+        fullWidth
+        value={current}
+        onChange={(e) =>
+          setValue(
+            key,
+            e.target.value === '' ? undefined : e.target.value === 'true'
+          )
+        }
+      >
+        <MenuItem value="">Any</MenuItem>
+        <MenuItem value="true">Yes</MenuItem>
+        <MenuItem value="false">No</MenuItem>
+      </TextField>
+    );
+  }
+
+  if (kind === 'select') {
+    return (
+      <TextField
+        select
+        label={label}
+        size="small"
+        fullWidth
+        value={typeof value === 'string' ? value : ''}
+        onChange={(e) => setValue(key, e.target.value || undefined)}
+      >
+        <MenuItem value="">Any</MenuItem>
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    );
+  }
+
+  const selected = Array.isArray(value) ? (value as string[]) : [];
+  return (
+    <TextField
+      select
+      label={label}
+      size="small"
+      fullWidth
+      value={selected}
+      onChange={(e) => setValue(key, e.target.value)}
+      SelectProps={{
+        multiple: true,
+        renderValue: (sel) =>
+          (sel as string[])
+            .map((v) => options.find((o) => o.value === v)?.label ?? v)
+            .join(', '),
+      }}
+    >
+      {options.map((option) => (
+        <MenuItem key={option.value} value={option.value}>
+          <Checkbox checked={selected.includes(option.value)} />
+          <ListItemText primary={option.label} />
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};
+
+const FilterSearchField = ({
+  label,
+  external,
+  onChange,
+}: {
+  label: string;
+  external: string;
+  onChange: (value: string) => void;
+}) => {
+  const [text, setText] = useState(external);
+  const debounced = useDebounce(text, { wait: 400 });
+
+  // Push debounced input up to the shared filter state.
+  useEffect(() => {
+    onChange(debounced);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire on debounced value change
+  }, [debounced]);
+
+  // Reflect external resets (e.g. "Clear all") back into the field.
+  useEffect(() => {
+    if (!external) {
+      setText('');
+    }
+  }, [external]);
+
+  return (
+    <TextField
+      label={label}
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      size="small"
+      fullWidth
+    />
+  );
+};

--- a/src/components/List/gridColumnAdapters.test.ts
+++ b/src/components/List/gridColumnAdapters.test.ts
@@ -84,10 +84,11 @@ describe('columnsToFilterControls', () => {
     expect(control!.toFilter('Bob')).toEqual({ name: 'Bob' });
   });
 
-  it('skips date and non-filterable columns', () => {
+  it('skips date, dateTime, and non-filterable columns', () => {
     const controls = columnsToFilterControls(
       asColumns([
         { field: 'mouStart', headerName: 'MOU Start', type: 'date' },
+        { field: 'createdAt', headerName: 'Created At', type: 'dateTime' },
         { field: 'count', headerName: 'Count', filterable: false },
         { field: 'name', headerName: 'Name' },
       ])

--- a/src/components/List/gridColumnAdapters.test.ts
+++ b/src/components/List/gridColumnAdapters.test.ts
@@ -1,0 +1,168 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import {
+  columnsToFilterControls,
+  columnsToSortOptions,
+  rowSecondary,
+} from './gridColumnAdapters';
+
+// Build a representative set of columns matching how the data grids declare them.
+const asColumns = (cols: any[]) => cols as unknown as readonly GridColDef[];
+
+describe('columnsToFilterControls', () => {
+  it('maps a text column to a debounced search filter using the field path', () => {
+    const [control] = columnsToFilterControls(
+      asColumns([{ field: 'name', headerName: 'Name' }])
+    );
+    expect(control).toMatchObject({
+      key: 'name',
+      label: 'Name',
+      kind: 'search',
+    });
+    expect(control!.toFilter('  Acme  ')).toEqual({ name: 'Acme' });
+    // empty / whitespace yields no filter fragment
+    expect(control!.toFilter('   ')).toBeUndefined();
+    expect(control!.toFilter('')).toBeUndefined();
+  });
+
+  it('maps a boolean column to a yes/no filter', () => {
+    const [control] = columnsToFilterControls(
+      asColumns([{ field: 'pinned', headerName: 'Pinned', type: 'boolean' }])
+    );
+    expect(control!.kind).toBe('boolean');
+    expect(control!.toFilter(true)).toEqual({ pinned: true });
+    expect(control!.toFilter(false)).toEqual({ pinned: false });
+    expect(control!.toFilter(undefined)).toBeUndefined();
+  });
+
+  it('maps a singleSelect column to a single dropdown', () => {
+    const [control] = columnsToFilterControls(
+      asColumns([
+        {
+          field: 'status',
+          headerName: 'Status',
+          type: 'singleSelect',
+          valueOptions: ['Active', 'Inactive'],
+        },
+      ])
+    );
+    expect(control!.kind).toBe('select');
+    expect(control!.options).toEqual([
+      { value: 'Active', label: 'Active' },
+      { value: 'Inactive', label: 'Inactive' },
+    ]);
+    expect(control!.toFilter('Active')).toEqual({ status: 'Active' });
+    expect(control!.toFilter(undefined)).toBeUndefined();
+  });
+
+  it('maps an unsortable singleSelect (multi-enum) to a multi-select', () => {
+    const [control] = columnsToFilterControls(
+      asColumns([
+        {
+          field: 'roles',
+          headerName: 'Roles',
+          type: 'singleSelect',
+          sortable: false,
+          valueOptions: ['A', 'B'],
+        },
+      ])
+    );
+    expect(control!.kind).toBe('multiSelect');
+    expect(control!.toFilter(['A', 'B'])).toEqual({ roles: ['A', 'B'] });
+    expect(control!.toFilter([])).toBeUndefined();
+  });
+
+  it("honors a column's serverFilter for the API shape", () => {
+    const [control] = columnsToFilterControls(
+      asColumns([
+        {
+          field: 'fullName',
+          headerName: 'Name',
+          serverFilter: (value: unknown) => ({ name: value }),
+        },
+      ])
+    );
+    expect(control!.toFilter('Bob')).toEqual({ name: 'Bob' });
+  });
+
+  it('skips date and non-filterable columns', () => {
+    const controls = columnsToFilterControls(
+      asColumns([
+        { field: 'mouStart', headerName: 'MOU Start', type: 'date' },
+        { field: 'count', headerName: 'Count', filterable: false },
+        { field: 'name', headerName: 'Name' },
+      ])
+    );
+    expect(controls.map((c) => c.key)).toEqual(['name']);
+  });
+});
+
+describe('columnsToSortOptions', () => {
+  it('includes labeled sortable columns and excludes the rest', () => {
+    const options = columnsToSortOptions(
+      asColumns([
+        { field: 'name', headerName: 'Name' },
+        { field: 'roles', headerName: 'Roles', sortable: false }, // multi-enum
+        { field: 'Engagement', headerName: '' }, // link column, no label
+        { field: 'actions', headerName: 'x', type: 'actions' },
+        { field: 'status', headerName: 'Status' },
+      ])
+    );
+    expect(options).toEqual([
+      { field: 'name', label: 'Name' },
+      { field: 'status', label: 'Status' },
+    ]);
+  });
+});
+
+describe('rowSecondary', () => {
+  const columns = asColumns([
+    {
+      field: 'name',
+      headerName: 'Name',
+      valueGetter: (_: any, r: any) => r.name,
+    },
+    {
+      field: 'country',
+      headerName: 'Country',
+      valueGetter: (_: any, r: any) => r.country,
+    },
+    {
+      field: 'step',
+      headerName: 'Step',
+      type: 'singleSelect',
+      valueGetter: (_: any, r: any) => r.step,
+      valueFormatter: (v: any) => (v === 'active' ? 'Active' : v),
+    },
+    {
+      field: 'pinned',
+      headerName: 'Pinned',
+      type: 'boolean',
+      valueGetter: (_: any, r: any) => r.pinned,
+    },
+  ]);
+  const row = { name: 'Acme', country: 'USA', step: 'active', pinned: false };
+
+  it('shows the default secondary column (labeled) on the default sort', () => {
+    expect(rowSecondary(columns, 'name', 'name', 'country', row)).toBe(
+      'Country: USA'
+    );
+  });
+
+  it('shows the sorted column (labeled) when sort differs from default', () => {
+    expect(rowSecondary(columns, 'step', 'name', 'country', row)).toBe(
+      'Step: Active'
+    );
+  });
+
+  it('formats booleans as Yes/No', () => {
+    expect(rowSecondary(columns, 'pinned', 'name', 'country', row)).toBe(
+      'Pinned: No'
+    );
+  });
+
+  it('returns undefined when the value is empty', () => {
+    expect(
+      rowSecondary(columns, 'name', 'name', 'country', { ...row, country: '' })
+    ).toBeUndefined();
+  });
+});

--- a/src/components/List/gridColumnAdapters.ts
+++ b/src/components/List/gridColumnAdapters.ts
@@ -1,0 +1,239 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { set } from 'lodash';
+import { DateTime } from 'luxon';
+
+/**
+ * Adapters that translate a data grid's column definitions into the mobile row
+ * list's filter controls, sort options, and labeled cell values — so the mobile
+ * experience mirrors the grid's header filters / sortable columns without
+ * re-declaring any of it. Consumed by {@link EntityList} and the mobile
+ * filter drawer ({@link MobileFilterButton}).
+ *
+ * **Shared contract (single source of truth).** These reuse the column's own
+ * typed props rather than a parallel mobile config — keeping drift low:
+ * - Filter → API: the column's `serverFilter` (typed via the `GridBaseColDef`
+ *   augmentation in `convertMuiFiltersToApi.ts`), else `lodash.set({}, field, value)`.
+ *   This is byte-for-byte the grid's own default in {@link convertMuiFiltersToApi}.
+ * - Display value: the column's `valueGetter` / `valueFormatter`.
+ * - Sort field: the column's `field` (matches the grid's sort model → list input).
+ *
+ * **Known limitation (intentional, not silent):** the grid additionally applies
+ * filter-operator–specific conversions via `getAsApiInput` (e.g. date
+ * after/before ranges). The mobile drawer does NOT replicate those, so columns
+ * that depend on them are excluded — date columns are skipped here, and any new
+ * column needing custom API mapping must express it via `serverFilter` (which
+ * both the grid and these adapters honor). The `as any` casts below are confined
+ * to invoking the column value pipeline without a grid `apiRef` (try/catch
+ * guarded); column shape contracts are locked by gridColumnAdapters.test.ts.
+ */
+
+export interface EnumOption {
+  value: string;
+  label: string;
+}
+
+export type FilterKind = 'search' | 'select' | 'multiSelect' | 'boolean';
+
+/**
+ * A single mobile filter control, derived from a data-grid column. `toFilter`
+ * turns the control's current value into the matching slice of the API `filter`
+ * input (or `undefined` when empty), mirroring how the grid's header filters map
+ * to the API.
+ */
+export interface FilterControl {
+  key: string;
+  label: string;
+  kind: FilterKind;
+  options?: readonly EnumOption[];
+  toFilter: (value: unknown) => Record<string, any> | undefined;
+}
+
+export type SortDirection = 'ASC' | 'DESC';
+
+/** A single sortable field offered in the mobile drawer (mirrors a grid column). */
+export interface SortOption {
+  field: string;
+  label: string;
+}
+
+export interface SortState {
+  field: string;
+  direction: SortDirection;
+}
+
+/** Sort config a row list registers: its sortable fields + the default selection. */
+export interface SortConfig {
+  options: readonly SortOption[];
+  default: SortState;
+}
+
+const optionLabel = (col: any, raw: unknown): string => {
+  let label: unknown;
+  if (typeof col.getOptionLabel === 'function') {
+    label = col.getOptionLabel(raw);
+  }
+  if (typeof label !== 'string' && typeof col.valueFormatter === 'function') {
+    label = col.valueFormatter(raw, undefined, col, undefined);
+  }
+  return typeof label === 'string' ? label : String(raw);
+};
+
+/**
+ * Derive mobile filter controls from a grid's column definitions, so the filter
+ * drawer matches the grid's header filters. Maps each filterable column to a
+ * control by its type (boolean → toggle, singleSelect → dropdown, else → search)
+ * and converts values to the API `filter` the same way `convertMuiFiltersToApi`
+ * does — via the column's `serverFilter`, or its `field` path by default.
+ *
+ * Date columns are not yet supported on mobile and are skipped.
+ */
+export const columnsToFilterControls = (
+  columns: readonly GridColDef[]
+): FilterControl[] =>
+  columns.flatMap((column): FilterControl[] => {
+    const col = column as any;
+    if (col.filterable === false || !col.field || col.type === 'date') {
+      return [];
+    }
+    const field: string = col.field;
+    const label = String(col.headerName ?? field);
+    const apply = (val: unknown) =>
+      typeof col.serverFilter === 'function'
+        ? col.serverFilter(val, { field, value: val, operator: 'is' })
+        : set({}, field, val);
+
+    if (col.type === 'boolean') {
+      return [
+        {
+          key: field,
+          label,
+          kind: 'boolean',
+          toFilter: (v) => (v === true || v === false ? apply(v) : undefined),
+        },
+      ];
+    }
+    if (col.type === 'singleSelect' && Array.isArray(col.valueOptions)) {
+      const options: EnumOption[] = col.valueOptions.map((opt: any) => {
+        const raw = opt && typeof opt === 'object' ? opt.value : opt;
+        const lbl =
+          opt && typeof opt === 'object' && opt.label != null
+            ? String(opt.label)
+            : optionLabel(col, raw);
+        return { value: String(raw), label: lbl };
+      });
+      // multiEnumColumn marks itself unsortable; single enumColumn does not.
+      const multi = col.sortable === false;
+      return [
+        {
+          key: field,
+          label,
+          kind: multi ? 'multiSelect' : 'select',
+          options,
+          toFilter: multi
+            ? (v) => (Array.isArray(v) && v.length > 0 ? apply(v) : undefined)
+            : (v) => (v ? apply(v) : undefined),
+        },
+      ];
+    }
+    return [
+      {
+        key: field,
+        label,
+        kind: 'search',
+        toFilter: (v) => {
+          const text = typeof v === 'string' ? v.trim() : '';
+          return text ? apply(text) : undefined;
+        },
+      },
+    ];
+  });
+
+/**
+ * Derive the sort options for the mobile drawer from a grid's columns — every
+ * column the grid lets you sort by (i.e. not `sortable: false`, e.g. link/action
+ * and multi-enum columns) that has a label. The `field` is the API `sort` value,
+ * matching how the grid maps its sort model to the list input.
+ */
+export const columnsToSortOptions = (
+  columns: readonly GridColDef[]
+): SortOption[] =>
+  columns.flatMap((column): SortOption[] => {
+    const col = column as any;
+    const label = col.headerName ? String(col.headerName) : '';
+    if (
+      !col.field ||
+      col.sortable === false ||
+      col.type === 'actions' ||
+      !label
+    ) {
+      return [];
+    }
+    return [{ field: col.field, label }];
+  });
+
+// Extract a row's display string for a column, reusing the grid column's
+// value pipeline (the same machinery the header cells use). Falls back through
+// valueGetter → valueFormatter → type-aware formatting; returns undefined when
+// the value is empty or can't be derived.
+const formatColumnValue = (col: any, row: any): string | undefined => {
+  let raw: any;
+  try {
+    raw =
+      typeof col.valueGetter === 'function'
+        ? col.valueGetter(undefined, row, col, undefined)
+        : row[col.field];
+  } catch {
+    return undefined;
+  }
+  if (raw == null || raw === '') {
+    return undefined;
+  }
+  try {
+    if (typeof col.valueFormatter === 'function') {
+      const formatted = col.valueFormatter(raw, row, col, undefined);
+      return formatted == null || formatted === ''
+        ? undefined
+        : String(formatted);
+    }
+  } catch {
+    // fall through to type-aware formatting
+  }
+  if (col.type === 'date' && raw instanceof Date) {
+    return DateTime.fromJSDate(raw).toLocaleString(DateTime.DATE_MED);
+  }
+  if (col.type === 'boolean') {
+    return raw ? 'Yes' : 'No';
+  }
+  return String(raw);
+};
+
+/** A row's column value labeled with its header (e.g. `"Step: Active"`), or undefined when empty. */
+const labelColumnValue = (
+  columns: readonly GridColDef[],
+  field: string,
+  row: Record<string, any>
+): string | undefined => {
+  const col = columns.find((c) => c.field === field) as any;
+  if (!col?.headerName) {
+    return undefined;
+  }
+  const value = formatColumnValue(col, row);
+  return value == null ? undefined : `${String(col.headerName)}: ${value}`;
+};
+
+/**
+ * The (always-labeled) secondary line a row should show: the sorted column when
+ * the active sort differs from the list's default, otherwise the list's default
+ * secondary column. Labeled with the column header (e.g. `"Step: Active"`).
+ * Returns undefined when no value derives.
+ */
+export const rowSecondary = (
+  columns: readonly GridColDef[],
+  sort: string | undefined,
+  defaultSort: string,
+  defaultSecondaryField: string | undefined,
+  row: Record<string, any>
+): string | undefined => {
+  const field = sort && sort !== defaultSort ? sort : defaultSecondaryField;
+  return field ? labelColumnValue(columns, field, row) : undefined;
+};

--- a/src/components/List/gridColumnAdapters.ts
+++ b/src/components/List/gridColumnAdapters.ts
@@ -20,11 +20,12 @@ import { DateTime } from 'luxon';
  * **Known limitation (intentional, not silent):** the grid additionally applies
  * filter-operator–specific conversions via `getAsApiInput` (e.g. date
  * after/before ranges). The mobile drawer does NOT replicate those, so columns
- * that depend on them are excluded — date columns are skipped here, and any new
- * column needing custom API mapping must express it via `serverFilter` (which
- * both the grid and these adapters honor). The `as any` casts below are confined
- * to invoking the column value pipeline without a grid `apiRef` (try/catch
- * guarded); column shape contracts are locked by gridColumnAdapters.test.ts.
+ * that depend on them are excluded — date/dateTime columns are skipped here,
+ * and any new column needing custom API mapping must express it via
+ * `serverFilter` (which both the grid and these adapters honor). The `as any`
+ * casts below are confined to invoking the column value pipeline without a grid
+ * `apiRef` (try/catch guarded); column shape contracts are locked by
+ * gridColumnAdapters.test.ts.
  */
 
 export interface EnumOption {
@@ -92,7 +93,12 @@ export const columnsToFilterControls = (
 ): FilterControl[] =>
   columns.flatMap((column): FilterControl[] => {
     const col = column as any;
-    if (col.filterable === false || !col.field || col.type === 'date') {
+    if (
+      col.filterable === false ||
+      !col.field ||
+      col.type === 'date' ||
+      col.type === 'dateTime'
+    ) {
       return [];
     }
     const field: string = col.field;

--- a/src/components/List/index.ts
+++ b/src/components/List/index.ts
@@ -1,2 +1,7 @@
 export * from './useListQuery';
+export * from './usePagedListQuery';
 export * from './List';
+export * from './EntityListItem';
+export * from './EntityList';
+export * from './gridColumnAdapters';
+export * from './MobileFilters';

--- a/src/components/List/usePagedListQuery.test.tsx
+++ b/src/components/List/usePagedListQuery.test.tsx
@@ -36,14 +36,17 @@ const wrapperWith = (mocks: readonly MockedResponse[]) =>
     return <MockedProvider mocks={mocks}>{children}</MockedProvider>;
   };
 
-const renderPaged = (mocks: readonly MockedResponse[]) =>
+const renderPaged = (
+  mocks: readonly MockedResponse[],
+  variables: Record<string, any> = { input: {} }
+) =>
   renderHook(
-    () =>
+    ({ variables }) =>
       usePagedListQuery(TestListDocument, {
         listAt: (data: any) => data.things,
-        variables: { input: {} },
+        variables,
       }),
-    { wrapper: wrapperWith(mocks) }
+    { initialProps: { variables }, wrapper: wrapperWith(mocks) }
   );
 
 describe('usePagedListQuery', () => {
@@ -110,5 +113,50 @@ describe('usePagedListQuery', () => {
 
     await waitFor(() => expect(result.current.data?.items).toHaveLength(4));
     expect(page2Fetches).toBe(1);
+  });
+
+  it('resets accumulated pages when variables change away and back', async () => {
+    const variablesA = { input: { filter: { name: 'A' } } };
+    const variablesB = { input: { filter: { name: 'B' } } };
+    const { result, rerender } = renderPaged(
+      [
+        {
+          request: { query: TestListDocument, variables: variablesA },
+          result: { data: page([1, 2], true) },
+        },
+        {
+          request: {
+            query: TestListDocument,
+            variables: { input: { filter: { name: 'A' }, page: 2 } },
+          },
+          result: { data: page([3, 4], false) },
+        },
+        {
+          request: { query: TestListDocument, variables: variablesB },
+          result: { data: page([10, 11], false) },
+        },
+      ],
+      variablesA
+    );
+
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(2));
+    act(() => {
+      result.current.loadMore();
+    });
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(4));
+
+    rerender({ variables: variablesB });
+    await waitFor(() =>
+      expect(
+        result.current.data?.items.map((item: { id: string }) => item.id)
+      ).toEqual(['10', '11'])
+    );
+
+    rerender({ variables: variablesA });
+    await waitFor(() =>
+      expect(
+        result.current.data?.items.map((item: { id: string }) => item.id)
+      ).toEqual(['1', '2'])
+    );
   });
 });

--- a/src/components/List/usePagedListQuery.test.tsx
+++ b/src/components/List/usePagedListQuery.test.tsx
@@ -1,0 +1,114 @@
+import { gql } from '@apollo/client';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { usePagedListQuery } from './usePagedListQuery';
+
+const TestListDocument = gql`
+  query TestList($input: TestListInput) {
+    things(input: $input) {
+      total
+      hasMore
+      items {
+        id
+        name
+      }
+    }
+  }
+` as TypedDocumentNode<any, any>;
+
+const page = (ids: number[], hasMore: boolean) => ({
+  things: {
+    __typename: 'TestList',
+    total: 4,
+    hasMore,
+    items: ids.map((id) => ({
+      __typename: 'Thing',
+      id: `${id}`,
+      name: `Thing ${id}`,
+    })),
+  },
+});
+
+const wrapperWith = (mocks: readonly MockedResponse[]) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <MockedProvider mocks={mocks}>{children}</MockedProvider>;
+  };
+
+const renderPaged = (mocks: readonly MockedResponse[]) =>
+  renderHook(
+    () =>
+      usePagedListQuery(TestListDocument, {
+        listAt: (data: any) => data.things,
+        variables: { input: {} },
+      }),
+    { wrapper: wrapperWith(mocks) }
+  );
+
+describe('usePagedListQuery', () => {
+  it('loads the first page', async () => {
+    const { result } = renderPaged([
+      {
+        request: { query: TestListDocument, variables: { input: {} } },
+        result: { data: page([1, 2], true) },
+      },
+    ]);
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(2));
+    expect(result.current.data?.hasMore).toBe(true);
+  });
+
+  it('appends the next page on loadMore', async () => {
+    const { result } = renderPaged([
+      {
+        request: { query: TestListDocument, variables: { input: {} } },
+        result: { data: page([1, 2], true) },
+      },
+      {
+        request: { query: TestListDocument, variables: { input: { page: 2 } } },
+        result: { data: page([3, 4], false) },
+      },
+    ]);
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(2));
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(4));
+    expect(result.current.data?.items.map((i: { id: string }) => i.id)).toEqual(
+      ['1', '2', '3', '4']
+    );
+    expect(result.current.data?.hasMore).toBe(false);
+  });
+
+  it('guards against concurrent loadMore — a double tap fetches the page once', async () => {
+    let page2Fetches = 0;
+    const mocks: MockedResponse[] = [
+      {
+        request: { query: TestListDocument, variables: { input: {} } },
+        result: { data: page([1, 2], true) },
+      },
+      // Two page-2 mocks are provided so that an unguarded double-fire would
+      // succeed (and bump the counter to 2) rather than erroring — making the
+      // guard the only thing keeping it at 1.
+      ...[0, 1].map(() => ({
+        request: { query: TestListDocument, variables: { input: { page: 2 } } },
+        result: () => {
+          page2Fetches++;
+          return { data: page([3, 4], false) };
+        },
+      })),
+    ];
+    const { result } = renderPaged(mocks);
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(2));
+
+    act(() => {
+      result.current.loadMore();
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.data?.items).toHaveLength(4));
+    expect(page2Fetches).toBe(1);
+  });
+});

--- a/src/components/List/usePagedListQuery.ts
+++ b/src/components/List/usePagedListQuery.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client';
 import { QueryHookOptions } from '@apollo/client/react/types/types';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { uniqBy } from 'lodash';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { InputArg, PaginatedListInput, PaginatedListOutput } from '../../api';
 import { ListQueryResult } from './useListQuery';
 
@@ -58,6 +58,9 @@ export const usePagedListQuery = <
     pages: [],
     page: 1,
   });
+  useEffect(() => {
+    setAcc((curr) => (curr.key === key ? curr : { key, pages: [], page: 1 }));
+  }, [key]);
   // Ignore (and effectively reset) accumulation when the base variables change.
   const active: Accumulated<Item> = useMemo(
     () => (acc.key === key ? acc : { key, pages: [], page: 1 }),
@@ -124,6 +127,7 @@ export const usePagedListQuery = <
           };
         });
       })
+      .catch(() => undefined)
       .finally(() => {
         loadingMoreRef.current = false;
       });

--- a/src/components/List/usePagedListQuery.ts
+++ b/src/components/List/usePagedListQuery.ts
@@ -1,0 +1,140 @@
+import { useQuery } from '@apollo/client';
+import { QueryHookOptions } from '@apollo/client/react/types/types';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
+import { uniqBy } from 'lodash';
+import { useMemo, useRef, useState } from 'react';
+import { InputArg, PaginatedListInput, PaginatedListOutput } from '../../api';
+import { ListQueryResult } from './useListQuery';
+
+type Options<
+  Data,
+  Variables extends InputArg<PaginatedListInput>,
+  List extends PaginatedListOutput<Item>,
+  Item
+> = QueryHookOptions<Data, Variables> & {
+  /** Where in the query result is the list? */
+  listAt: (data: Data) => List;
+};
+
+interface Accumulated<Item> {
+  /** Identifies the base query variables; accumulation resets when they change. */
+  key: string;
+  pages: ReadonlyArray<readonly Item[]>;
+  page: number;
+  hasMore?: boolean;
+  total?: number;
+}
+
+/**
+ * Page-based list query that accumulates pages in React state rather than relying
+ * on an Apollo field `merge` policy. Needed for the data-grid–backed list fields
+ * (`projects`, `partners`, `users`, `languages`, `engagements`), which intentionally
+ * have no merge policy (the grid manages their cache itself), so the normal
+ * {@link useListQuery} "Load More" — which depends on that policy — never appends.
+ */
+export const usePagedListQuery = <
+  Data,
+  Variables extends InputArg<PaginatedListInput>,
+  Item extends { id: string },
+  List extends PaginatedListOutput<Item>
+>(
+  doc: TypedDocumentNode<Data, Variables>,
+  options: Options<Data, Variables, List, Item>
+): ListQueryResult<Item, List, Data> => {
+  const { listAt, ...opts } = options;
+  const result = useQuery(doc, {
+    ...opts,
+    notifyOnNetworkStatusChange: true,
+  });
+  const { fetchMore } = result;
+  // Keep the previous results visible while a new variable set (e.g. a changed
+  // sort or filter) is in flight, instead of flashing skeletons. The list simply
+  // re-orders/updates once the new data lands.
+  const res = result.data ?? result.previousData;
+
+  const key = JSON.stringify(options.variables ?? {});
+  const [acc, setAcc] = useState<Accumulated<Item>>({
+    key,
+    pages: [],
+    page: 1,
+  });
+  // Ignore (and effectively reset) accumulation when the base variables change.
+  const active: Accumulated<Item> = useMemo(
+    () => (acc.key === key ? acc : { key, pages: [], page: 1 }),
+    [acc, key]
+  );
+
+  const firstList = res ? listAt(res) : undefined;
+
+  const data = useMemo(() => {
+    if (!firstList) {
+      return undefined;
+    }
+    const loadedExtra = active.pages.length > 0;
+    const items = uniqBy(
+      [...firstList.items, ...active.pages.flat()],
+      (item) => item.id
+    );
+    return {
+      ...firstList,
+      items,
+      hasMore: loadedExtra ? !!active.hasMore : firstList.hasMore,
+      total: loadedExtra ? active.total ?? firstList.total : firstList.total,
+    };
+  }, [firstList, active]);
+
+  // Guards against concurrent "Load More" requests for the same page — a fast
+  // double-tap would otherwise fetch the next page twice (uniqBy only hides the
+  // duplicate rows, not the wasted request).
+  const loadingMoreRef = useRef(false);
+  const loadMore = () => {
+    if (!firstList || loadingMoreRef.current) {
+      return;
+    }
+    loadingMoreRef.current = true;
+    const nextPage = active.page + 1;
+    void fetchMore({
+      variables: {
+        ...options.variables,
+        input: { ...options.variables?.input, page: nextPage },
+      },
+      // We accumulate from the resolved result below; keep the watched query as-is
+      // (and avoid Apollo's missing-merge warning for these un-merged fields).
+      updateQuery: (prev) => prev,
+    })
+      .then(({ data: more }) => {
+        const moreList = listAt(more);
+        setAcc((curr) => {
+          const base =
+            curr.key === key
+              ? curr
+              : {
+                  key,
+                  pages: [],
+                  page: 1,
+                  hasMore: undefined,
+                  total: undefined,
+                };
+          return {
+            key,
+            pages: [...base.pages, moreList.items],
+            page: nextPage,
+            hasMore: moreList.hasMore,
+            total: moreList.total,
+          };
+        });
+      })
+      .finally(() => {
+        loadingMoreRef.current = false;
+      });
+  };
+
+  return {
+    loading: result.loading,
+    data: data as List | undefined,
+    error: result.error,
+    networkStatus: result.networkStatus,
+    loadMore,
+    root: res,
+  };
+};

--- a/src/components/PartnersDataGrid/renderPartnerRow.tsx
+++ b/src/components/PartnersDataGrid/renderPartnerRow.tsx
@@ -1,0 +1,38 @@
+import { EntityListItem, rowSecondary } from '../List';
+import { PartnerColumns } from './PartnerColumns';
+import { PartnerDataGridRowFragment as Partner } from './partnerDataGridRow.graphql';
+
+const SORT_DEFAULT = 'organization.name';
+
+/**
+ * Renders a partner as a mobile {@link EntityListItem}: the primary is the acronym
+ * (falling back to the full name), so on the default sort the labeled name is
+ * only shown as the secondary when an acronym occupies the primary — otherwise
+ * it would just repeat the name. Used by the partner list and the user→partners
+ * tab via {@link EntityList}'s `renderItem`.
+ */
+export const renderPartnerRow = (
+  partner: Partner,
+  sort: string | undefined
+) => {
+  const org = partner.organization.value;
+  const acronym = org?.acronym.value;
+  const name = org?.name.value;
+  return (
+    <EntityListItem
+      to={`/partners/${partner.id}`}
+      primary={acronym ?? name}
+      secondary={
+        sort !== SORT_DEFAULT || acronym
+          ? rowSecondary(
+              PartnerColumns,
+              sort,
+              SORT_DEFAULT,
+              SORT_DEFAULT,
+              partner
+            )
+          : undefined
+      }
+    />
+  );
+};

--- a/src/components/PartnersDataGrid/renderPartnerRow.tsx
+++ b/src/components/PartnersDataGrid/renderPartnerRow.tsx
@@ -16,7 +16,7 @@ export const renderPartnerRow = (
   sort: string | undefined
 ) => {
   const org = partner.organization.value;
-  const acronym = org?.acronym.value;
+  const acronym = org?.acronym.value?.trim() || undefined;
   const name = org?.name.value;
   return (
     <EntityListItem

--- a/src/components/PnpValidation/ProblemsWithSheetsAsTabs.tsx
+++ b/src/components/PnpValidation/ProblemsWithSheetsAsTabs.tsx
@@ -1,7 +1,8 @@
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Tab } from '@mui/material';
 import { groupToMapBy } from '@seedcompany/common';
 import { memo, ReactNode, useState } from 'react';
+import { TabList } from '../Tabs';
 import { ProblemTreeProps } from './PnPExtractionProblems';
 
 export const ProblemsWithSheetsAsTabs = memo(function ProblemsWithSheetsAsTabs({

--- a/src/components/Tabs/TabList.test.tsx
+++ b/src/components/Tabs/TabList.test.tsx
@@ -1,0 +1,56 @@
+import { TabContext } from '@mui/lab';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { useIsMobile } from '~/common';
+import { TabList } from './TabList';
+
+jest.mock('~/common', () => ({
+  ...jest.requireActual('~/common'),
+  useIsMobile: jest.fn(),
+}));
+const mockUseIsMobile = useIsMobile as jest.Mock;
+
+// TabList reads value/label/to off its children's props (it doesn't render them
+// in mobile mode), so a props-only stand-in is sufficient.
+const Tab = (_: { value: string; label: string; to?: string }) => null;
+
+const LocationProbe = () => {
+  const { pathname } = useLocation();
+  return <div data-testid="pathname">{pathname}</div>;
+};
+
+const renderTabs = () =>
+  render(
+    <MemoryRouter initialEntries={['/projects']}>
+      <TabContext value="/projects">
+        <TabList aria-label="tabs">
+          <Tab value="/projects" label="Projects" to="/projects" />
+          <Tab value="/engagements" label="Engagements" to="/engagements" />
+        </TabList>
+      </TabContext>
+      <LocationProbe />
+    </MemoryRouter>
+  );
+
+describe('TabList (mobile)', () => {
+  beforeEach(() => mockUseIsMobile.mockReturnValue(true));
+
+  it('renders a select instead of tabs', async () => {
+    renderTabs();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    // current tab shown
+    expect(await screen.findByText('Projects')).toBeInTheDocument();
+  });
+
+  it('navigates when a route-based tab is selected', async () => {
+    renderTabs();
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/projects');
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('option', { name: 'Engagements' }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/engagements')
+    );
+  });
+});

--- a/src/components/Tabs/TabList.tsx
+++ b/src/components/Tabs/TabList.tsx
@@ -1,0 +1,77 @@
+import { TabList as MuiTabList, TabListProps } from '@mui/lab';
+// `useTabContext` isn't re-exported from the `@mui/lab` barrel in a way the build
+// can resolve, so import it from its subpath.
+// eslint-disable-next-line @seedcompany/no-restricted-imports
+import { useTabContext } from '@mui/lab/TabContext';
+import { MenuItem, TextField } from '@mui/material';
+import {
+  Children,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  SyntheticEvent,
+} from 'react';
+import { To, useNavigate } from 'react-router-dom';
+import { useIsMobile } from '~/common';
+
+interface TabChildProps {
+  value: string;
+  label?: ReactNode;
+  /** Present on route-based tabs (`TabLink`); selecting navigates here. */
+  to?: To;
+}
+
+/**
+ * MUI Lab `TabList` that collapses into a dropdown select on mobile, so tabbed
+ * detail pages stay usable on small screens. Drop-in replacement for `@mui/lab`'s
+ * `TabList` for the `value`/`onChange` pattern — it reads each tab's `value` and
+ * `label` from the `<Tab>` children and drives the same `onChange`.
+ */
+export const TabList = ({ children, onChange, ...props }: TabListProps) => {
+  const isMobile = useIsMobile();
+  const context = useTabContext();
+  const navigate = useNavigate();
+
+  if (!isMobile) {
+    return (
+      <MuiTabList onChange={onChange} {...props}>
+        {children}
+      </MuiTabList>
+    );
+  }
+
+  const tabs = Children.toArray(children).filter(
+    (child): child is ReactElement<TabChildProps> => isValidElement(child)
+  );
+  const ariaLabel = (props as { 'aria-label'?: string })['aria-label'];
+
+  return (
+    <TextField
+      select
+      // Outlined (not the theme's default filled) so the value is vertically
+      // centered — filled reserves top space for a label this field doesn't have.
+      variant="outlined"
+      size="small"
+      fullWidth
+      value={context?.value ?? ''}
+      onChange={(event) => {
+        const value = event.target.value;
+        const selected = tabs.find((tab) => tab.props.value === value);
+        // Route-based tabs (TabLink) navigate; value-based tabs drive onChange.
+        if (selected?.props.to != null) {
+          navigate(selected.props.to);
+        } else {
+          onChange?.(event as unknown as SyntheticEvent, value);
+        }
+      }}
+      SelectProps={{ 'aria-label': ariaLabel }}
+      sx={{ mb: 2 }}
+    >
+      {tabs.map((tab) => (
+        <MenuItem key={tab.props.value} value={tab.props.value}>
+          {tab.props.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,3 +1,4 @@
 export * from './Tab';
+export * from './TabList';
 export * from './TabsContainer';
 export * from './TabPanelContent';

--- a/src/components/Widgets/WidgetGrid.tsx
+++ b/src/components/Widgets/WidgetGrid.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/material';
 import { many, Many } from '@seedcompany/common';
 import { ReactElement } from 'react';
-import { extendSx, StyleProps } from '~/common';
+import { extendSx, StyleProps, useIsMobile } from '~/common';
 
 export type WidgetGridProps = {
   gap?: number;
@@ -17,18 +17,33 @@ export const WidgetGrid = ({
   children,
   sx,
 }: WidgetGridProps) => {
+  const isMobile = useIsMobile();
   return (
     <Box
       sx={[
-        {
-          flex: 1,
-          display: 'grid',
-          gridGap: gap * 8,
-          gridTemplateRows: `repeat(${rows * many(children).length}, minmax(${
-            Math.floor((1 / rows) * 100) - 0.6 // 0.6 fixes height, punting on the permenant fix for now
-          }%, 1fr));`,
-          gridTemplateColumns: `repeat(${cols}, 1fr);`,
-        },
+        isMobile
+          ? {
+              // Stack widgets full-width on mobile. Each needs a definite height
+              // (the desktop grid's `gridRow` span is a no-op in a flex column)
+              // so its grid fills the card and scrolls — sideways for columns,
+              // down for rows.
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: `${gap * 8}px`,
+              '& > *': { height: '70dvh' },
+            }
+          : {
+              flex: 1,
+              display: 'grid',
+              gridGap: gap * 8,
+              gridTemplateRows: `repeat(${
+                rows * many(children).length
+              }, minmax(${
+                Math.floor((1 / rows) * 100) - 0.6 // 0.6 fixes height, punting on the permanent fix for now
+              }%, 1fr));`,
+              gridTemplateColumns: `repeat(${cols}, 1fr);`,
+            },
         ...extendSx(sx),
       ]}
     >

--- a/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
+++ b/src/scenes/Engagement/InternshipEngagement/InternshipEngagementDetail.tsx
@@ -41,6 +41,9 @@ const useStyles = makeStyles()(({ spacing, breakpoints, palette }) => ({
     flex: 1,
     overflowY: 'auto',
     padding: spacing(4),
+    [breakpoints.down('md')]: {
+      padding: spacing(2),
+    },
   },
   main: {
     maxWidth: breakpoints.values.md,
@@ -223,7 +226,7 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                 <EngagementDescription engagement={engagement} />
               </Grid>
               <Grid item container spacing={3}>
-                <Grid item xs={6}>
+                <Grid item xs={12} md={6}>
                   <FieldOverviewCard
                     title="Growth Plan Complete Date"
                     data={{
@@ -236,7 +239,7 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                     onButtonClick={() => show('completeDate')}
                   />
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={12} md={6}>
                   <FieldOverviewCard
                     title="Disbursement Complete Date"
                     data={{
@@ -252,11 +255,11 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                   />
                 </Grid>
                 <Grid item container spacing={3} alignItems="center">
-                  <Grid item xs={6}>
+                  <Grid item xs={12}>
                     <Typography variant="h4">Growth Plan</Typography>
                   </Grid>
                 </Grid>
-                <Grid item xs={6}>
+                <Grid item xs={12} md={6}>
                   <MethodologiesCard
                     onClick={() => show('methodologies')}
                     data={engagement.methodologies}
@@ -264,13 +267,13 @@ export const InternshipEngagementDetail = ({ engagement }: EngagementQuery) => {
                 </Grid>
               </Grid>
               <Grid item container spacing={3}>
-                <Grid item xs={6}>
+                <Grid item xs={12} md={6}>
                   <CeremonyCard {...engagement.ceremony} />
                 </Grid>
                 <MentorCard
                   data={engagement.mentor}
                   wrap={(node) => (
-                    <Grid item xs={6}>
+                    <Grid item xs={12} md={6}>
                       {node}
                     </Grid>
                   )}

--- a/src/scenes/FieldRegions/Detail/FieldRegionDetail.tsx
+++ b/src/scenes/FieldRegions/Detail/FieldRegionDetail.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -13,7 +13,7 @@ import {
 } from '~/components/DisplaySimpleProperty';
 import { EditFieldRegion } from '~/components/FieldRegion';
 import { Link } from '~/components/Routing';
-import { Tab, TabsContainer } from '~/components/Tabs';
+import { Tab, TabList, TabsContainer } from '~/components/Tabs';
 import { useDetailTabs } from '~/hooks';
 import { Error } from '../../../components/Error';
 import { IconButton } from '../../../components/IconButton';

--- a/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjectsPanel.tsx
+++ b/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjectsPanel.tsx
@@ -40,7 +40,7 @@ export const FieldRegionProjectsPanel = () => {
       avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
     />
   ) : (
-    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    // ai edge-case The grid (and its `useDataGridSource`) must only mount on desktop.
     <FieldRegionProjectsGrid />
   );
 };

--- a/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjectsPanel.tsx
+++ b/src/scenes/FieldRegions/Detail/Tabs/Projects/FieldRegionProjectsPanel.tsx
@@ -1,5 +1,6 @@
 import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
+import { useIsMobile } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
@@ -8,12 +9,14 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as FieldRegionsProjectsList } from '~/components/List';
 import {
   ProjectDataGridRowFragment as Project,
   ProjectColumns,
   ProjectInitialState,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import {
   type FieldRegionProjectDataGridRowFragment as FieldRegionProject,
@@ -21,6 +24,28 @@ import {
 } from './FieldRegionProjects.graphql';
 
 export const FieldRegionProjectsPanel = () => {
+  const { fieldRegionId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <FieldRegionsProjectsList
+      query={FieldRegionProjectsDocument}
+      listAt={(data) => data.fieldRegion.projects}
+      variables={{ fieldRegionId }}
+      columns={ProjectColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="primaryLocation.name"
+      primary={(project) => project.name.value}
+      to={(project) => `/projects/${project.id}`}
+      avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <FieldRegionProjectsGrid />
+  );
+};
+
+const FieldRegionProjectsGrid = () => {
   const { fieldRegionId = '' } = useParams();
 
   const [dataGridProps] = useDataGridSource({

--- a/src/scenes/FieldZones/Detail/FieldZoneDetail.tsx
+++ b/src/scenes/FieldZones/Detail/FieldZoneDetail.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -12,7 +12,7 @@ import {
   DisplaySimplePropertyProps,
 } from '~/components/DisplaySimpleProperty';
 import { Link } from '~/components/Routing';
-import { Tab, TabsContainer } from '~/components/Tabs';
+import { Tab, TabList, TabsContainer } from '~/components/Tabs';
 import { useDetailTabs } from '~/hooks';
 import { Error } from '../../../components/Error';
 import { EditFieldZone } from '../../../components/FieldZone';

--- a/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjectsPanel.tsx
+++ b/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjectsPanel.tsx
@@ -1,5 +1,6 @@
 import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
+import { useIsMobile } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
@@ -8,12 +9,14 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as FieldZonesProjectsList } from '~/components/List';
 import {
   ProjectDataGridRowFragment as Project,
   ProjectColumns,
   ProjectInitialState,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import {
   type FieldZoneProjectDataGridRowFragment as FieldZoneProject,
@@ -21,6 +24,28 @@ import {
 } from './FieldZoneProjects.graphql';
 
 export const FieldZoneProjectsPanel = () => {
+  const { fieldZoneId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <FieldZonesProjectsList
+      query={FieldZoneProjectsDocument}
+      listAt={(data) => data.fieldZone.projects}
+      variables={{ fieldZoneId }}
+      columns={ProjectColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="primaryLocation.name"
+      primary={(project) => project.name.value}
+      to={(project) => `/projects/${project.id}`}
+      avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <FieldZoneProjectsGrid />
+  );
+};
+
+const FieldZoneProjectsGrid = () => {
   const { fieldZoneId = '' } = useParams();
 
   const [dataGridProps] = useDataGridSource({

--- a/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjectsPanel.tsx
+++ b/src/scenes/FieldZones/Detail/Tabs/Projects/FieldZoneProjectsPanel.tsx
@@ -40,7 +40,7 @@ export const FieldZoneProjectsPanel = () => {
       avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
     />
   ) : (
-    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    // ai edge-case The grid (and its `useDataGridSource`) must only mount on desktop.
     <FieldZoneProjectsGrid />
   );
 };

--- a/src/scenes/Languages/Detail/LanguageDetail.tsx
+++ b/src/scenes/Languages/Detail/LanguageDetail.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -10,7 +10,7 @@ import { canEditAny } from '~/common';
 import { BooleanProperty } from '~/components/BooleanProperty';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
 import { Sensitivity } from '~/components/Sensitivity';
-import { Tab, TabsContainer } from '~/components/Tabs';
+import { Tab, TabList, TabsContainer } from '~/components/Tabs';
 import { useDetailTabs } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
 import { useDialog } from '../../../components/Dialog';

--- a/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Locations/LanguageDetailLocations.tsx
@@ -1,22 +1,20 @@
 import { useMutation } from '@apollo/client';
 import { Delete as DeleteIcon } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-  GridColDef,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
+import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useMemo } from 'react';
+import { useIsMobile } from '~/common';
 import { useDialog } from '~/components/Dialog';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
 import { createAddItemFooter } from '~/components/Grid/createAddItemFooter';
+import { EntityList as LanguagesLocationsList } from '~/components/List';
 import {
   LocationColumns,
   LocationInitialState,
@@ -38,6 +36,26 @@ interface LanguageDetailLocationProps {
 export const LanguageDetailLocations = ({
   language,
 }: LanguageDetailLocationProps) => {
+  const isMobile = useIsMobile();
+  return isMobile ? (
+    <LanguagesLocationsList
+      query={LanguageLocationsDocument}
+      listAt={(data) => data.language.locations}
+      variables={{ languageId: language.id }}
+      columns={LocationColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="type"
+      primary={(location) => location.name.value}
+      to={(location) => `/locations/${location.id}`}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop — that
+    // hook drives a `GridApiPro` ref and would crash if run without a grid.
+    <LanguageLocationsGrid language={language} />
+  );
+};
+
+const LanguageLocationsGrid = ({ language }: LanguageDetailLocationProps) => {
   const { id, locations } = language;
   const [locationFormState, addLocation] = useDialog();
 
@@ -92,19 +110,9 @@ export const LanguageDetailLocations = ({
     [addLocation]
   );
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, props.slots, {
-        toolbar: LocationToolbar,
-        footer: LocationFooter,
-      } satisfies DataGridProps['slots']),
-    [props.slots, LocationFooter]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
-    [props.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(props, {
+    slots: { toolbar: LocationToolbar, footer: LocationFooter },
+  });
 
   return (
     <TabPanelContent>

--- a/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
@@ -1,22 +1,21 @@
-import {
-  DataGridPro as DataGrid,
-  DataGridProProps as DataGridProps,
-} from '@mui/x-data-grid-pro';
-import { merge } from 'lodash';
-import { useMemo } from 'react';
+import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
+import { useIsMobile } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
   noFooter,
   noHeaderFilterButtons,
+  useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as LanguagesProjectsList } from '~/components/List';
 import {
   ProjectColumns,
   ProjectInitialState,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import {
   type LanguageProjectDataGridRowFragment as LanguageProject,
@@ -24,6 +23,28 @@ import {
 } from './LanguageProjects.graphql';
 
 export const LanguageDetailProjects = () => {
+  const { languageId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <LanguagesProjectsList
+      query={LanguageProjectsDocument}
+      listAt={(data) => data.language.projects}
+      variables={{ languageId }}
+      columns={ProjectColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="primaryLocation.name"
+      primary={(project) => project.name.value}
+      to={(project) => `/projects/${project.id}`}
+      avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <LanguageProjectsGrid />
+  );
+};
+
+const LanguageProjectsGrid = () => {
   const { languageId = '' } = useParams();
 
   const [props] = useDataGridSource({
@@ -35,18 +56,9 @@ export const LanguageDetailProjects = () => {
     },
   });
 
-  const slots = useMemo(
-    () =>
-      merge({}, DefaultDataGridStyles.slots, props.slots, {
-        toolbar: ProjectToolbar,
-      } satisfies DataGridProps['slots']),
-    [props.slots]
-  );
-
-  const slotProps = useMemo(
-    () => merge({}, DefaultDataGridStyles.slotProps, props.slotProps),
-    [props.slotProps]
-  );
+  const { slots, slotProps } = useDataGridSlots(props, {
+    slots: { toolbar: ProjectToolbar },
+  });
 
   return (
     <TabPanelContent>

--- a/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
+++ b/src/scenes/Languages/Detail/Tabs/Projects/LanguageDetailProjects.tsx
@@ -39,7 +39,7 @@ export const LanguageDetailProjects = () => {
       avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
     />
   ) : (
-    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    // ai edge-case The grid (and its `useDataGridSource`) must only mount on desktop.
     <LanguageProjectsGrid />
   );
 };

--- a/src/scenes/Languages/List/LanguageList.tsx
+++ b/src/scenes/Languages/List/LanguageList.tsx
@@ -33,7 +33,7 @@ export const LanguageList = () => {
             )}
           />
         ) : (
-          // The grid (and its `useDataGridSource`) must only mount on desktop.
+          // ai edge-case The grid (and its `useDataGridSource`) must only mount on desktop.
           <Stack sx={{ flex: 1, containerType: 'size' }}>
             <Paper
               sx={{

--- a/src/scenes/Languages/List/LanguageList.tsx
+++ b/src/scenes/Languages/List/LanguageList.tsx
@@ -1,28 +1,53 @@
 import { Paper, Stack, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
+import { useIsMobile } from '~/common';
+import { LanguageColumns } from '~/components/LanguageDataGrid';
+import { EntityList as LanguagesList } from '~/components/List';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { LanguageGrid } from './LanguageGrid';
+import { LanguagesDocument } from './languages.graphql';
 
 export const LanguageList = () => {
+  const isMobile = useIsMobile();
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 2, md: 4 }, pt: 2 }}>
       <Helmet title="Languages" />
       <Stack component="main" sx={{ flex: 1 }}>
         <Typography variant="h2" paragraph>
           Languages
         </Typography>
-        <Stack sx={{ flex: 1, containerType: 'size' }}>
-          <Paper
-            sx={{
-              flex: 1,
-              minHeight: 375,
-              maxHeight: '100cqh',
-              width: 'min-content',
-              maxWidth: '100cqw',
+        {isMobile ? (
+          <LanguagesList
+            query={LanguagesDocument}
+            listAt={(data) => data.languages}
+            columns={LanguageColumns}
+            sortDefault={{
+              field: LanguageColumns[0]!.field,
+              direction: 'ASC',
             }}
-          >
-            <LanguageGrid />
-          </Paper>
-        </Stack>
+            defaultSecondaryField="ethnologue.code"
+            primary={(language) => language.displayName.value}
+            to={(language) => `/languages/${language.id}`}
+            avatar={(language) => (
+              <SensitivityIcon value={language.sensitivity} />
+            )}
+          />
+        ) : (
+          // The grid (and its `useDataGridSource`) must only mount on desktop.
+          <Stack sx={{ flex: 1, containerType: 'size' }}>
+            <Paper
+              sx={{
+                flex: 1,
+                minHeight: 375,
+                maxHeight: '100cqh',
+                width: 'min-content',
+                maxWidth: '100cqw',
+              }}
+            >
+              <LanguageGrid />
+            </Paper>
+          </Stack>
+        )}
       </Stack>
     </Stack>
   );

--- a/src/scenes/Partners/Detail/PartnerDetail.tsx
+++ b/src/scenes/Partners/Detail/PartnerDetail.tsx
@@ -5,7 +5,7 @@ import {
   Person as PersonIcon,
   Timeline as TimelineIcon,
 } from '@mui/icons-material';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Stack, Tooltip, Typography } from '@mui/material';
 import { Many, Nil } from '@seedcompany/common';
 import { Helmet } from 'react-helmet-async';
@@ -18,7 +18,7 @@ import { Error } from '~/components/Error';
 import { FormattedDate, FormattedDateTime } from '~/components/Formatters';
 import { IconButton } from '~/components/IconButton';
 import { InactiveStatusIcon } from '~/components/Icons/InactiveStatusIcon';
-import { Tab, TabsContainer } from '~/components/Tabs';
+import { Tab, TabList, TabsContainer } from '~/components/Tabs';
 import { TogglePinButton } from '~/components/TogglePinButton';
 import { useDetailTabs } from '~/hooks';
 import { useComments } from '../../../components/Comments/CommentsContext';
@@ -64,7 +64,7 @@ export const PartnerDetail = () => {
       component="main"
       sx={{
         flex: 1,
-        p: 4,
+        p: { xs: 2, md: 4 },
         overflowY: 'auto',
       }}
     >
@@ -102,13 +102,18 @@ const PartnerHeader = ({
   return (
     <>
       <Helmet title={acronym ?? name ?? undefined} />
-      <Stack direction="row" gap={1}>
+      <Stack direction="row" gap={1} flexWrap="wrap" alignItems="center">
         {!partner && (
           <Skeleton width={300}>
             <Typography variant="h2" lineHeight="inherit" mr={1} />
           </Skeleton>
         )}
-        <Typography variant="h2" lineHeight="inherit" mr={1}>
+        <Typography
+          variant="h2"
+          lineHeight="inherit"
+          mr={1}
+          sx={{ minWidth: 0 }}
+        >
           {acronym ?? name}
         </Typography>
         <Tooltip title="Edit Partner">
@@ -162,7 +167,7 @@ const PartnerDataButtons = ({
   partner,
   editPartner: edit,
 }: PartnerViewEditProps) => (
-  <Box mt={3} mb={2} display="flex" gap={2}>
+  <Box mt={3} mb={2} display="flex" gap={2} flexWrap="wrap">
     <DataButton
       label="Status"
       onClick={() => edit('partner.active')}

--- a/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Engagements/PartnerDetailEngagements.tsx
@@ -1,9 +1,11 @@
 import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
+import { useIsMobile } from '~/common';
 import {
   EngagementDataGridRowFragment as Engagement,
   EngagementColumns,
   EngagementInitialState,
+  engagementName,
   EngagementToolbar,
   useProcessEngagementUpdate,
 } from '~/components/EngagementDataGrid';
@@ -15,10 +17,36 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as PartnersEngagementsList } from '~/components/List';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import { PartnerDetailEngagementsDocument } from './PartnerDetailEngagements.graphql';
 
 export const PartnerDetailEngagements = () => {
+  const { partnerId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <PartnersEngagementsList
+      query={PartnerDetailEngagementsDocument}
+      listAt={(data) => data.partner.engagements}
+      variables={{ id: partnerId }}
+      columns={EngagementColumns}
+      sortDefault={{ field: EngagementColumns[0]!.field, direction: 'ASC' }}
+      defaultSecondaryField="project.name"
+      primary={engagementName}
+      to={(engagement) => `/engagements/${engagement.id}`}
+      avatar={(engagement) => (
+        <SensitivityIcon value={engagement.project.sensitivity} />
+      )}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <PartnerEngagementsGrid />
+  );
+};
+
+const PartnerEngagementsGrid = () => {
   const { partnerId = '' } = useParams();
 
   const [props] = useDataGridSource({
@@ -34,7 +62,7 @@ export const PartnerDetailEngagements = () => {
     slots: { toolbar: EngagementToolbar },
   });
 
-  const processEngagementUpdate = useProcessEngagementUpdate();
+  const processRowUpdate = useProcessEngagementUpdate();
 
   return (
     <TabPanelContent>
@@ -45,7 +73,7 @@ export const PartnerDetailEngagements = () => {
         slotProps={slotProps}
         columns={EngagementColumns}
         initialState={EngagementInitialState}
-        processRowUpdate={processEngagementUpdate}
+        processRowUpdate={processRowUpdate}
         headerFilters
         hideFooter
         sx={[flexLayout, noHeaderFilterButtons, noFooter]}

--- a/src/scenes/Partners/Detail/Tabs/People/PartnerDetailPeople.tsx
+++ b/src/scenes/Partners/Detail/Tabs/People/PartnerDetailPeople.tsx
@@ -5,6 +5,7 @@ import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { removeItemFromList } from '~/api';
+import { useIsMobile } from '~/common';
 import { useDialog } from '~/components/Dialog';
 import {
   booleanColumn,
@@ -16,6 +17,7 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as PartnersPeopleList } from '~/components/List';
 import { TabPanelContent } from '~/components/Tabs';
 import {
   UserColumns,
@@ -35,6 +37,27 @@ interface Props {
 }
 
 export const PartnerDetailPeople = ({ partner }: Props) => {
+  const { partnerId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <PartnersPeopleList
+      query={PartnerPeopleDocument}
+      listAt={(data) => data.partner.people}
+      variables={{ id: partnerId }}
+      columns={UserColumns}
+      sortDefault={{ field: 'fullName', direction: 'ASC' }}
+      defaultSecondaryField="title"
+      primary={(user) => user.fullName}
+      to={(user) => `/users/${user.id}`}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <PartnerPeopleGrid partner={partner} />
+  );
+};
+
+const PartnerPeopleGrid = ({ partner }: Props) => {
   const { partnerId = '' } = useParams();
   const orgId = partner?.organization.value?.id;
   const pocId = partner?.pointOfContact.value?.id;

--- a/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
+++ b/src/scenes/Partners/Detail/Tabs/Projects/PartnerDetailProjects.tsx
@@ -1,7 +1,7 @@
 import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
 import { PartnerTypeLabels, PartnerTypeList } from '~/api/schema.graphql';
-import { unmatchedIndexThrow } from '~/common';
+import { useIsMobile } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
@@ -11,12 +11,15 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as PartnersProjectsList } from '~/components/List';
 import {
+  insertProjectColumnAfterField,
   ProjectDataGridRowFragment as Project,
   ProjectColumns,
   ProjectInitialState,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import {
   PartnerProjectDataGridRowFragment as PartnerProject,
@@ -24,6 +27,28 @@ import {
 } from './PartnerProjects.graphql';
 
 export const PartnerDetailProjects = () => {
+  const { partnerId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <PartnersProjectsList
+      query={PartnerProjectsDocument}
+      listAt={(data) => data.partner.projects}
+      variables={{ partnerId }}
+      columns={PartnerProjectColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="primaryLocation.name"
+      primary={(project) => project.name.value}
+      to={(project) => `/projects/${project.id}`}
+      avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <PartnerProjectsGrid />
+  );
+};
+
+const PartnerProjectsGrid = () => {
   const { partnerId = '' } = useParams();
 
   const [props] = useDataGridSource({
@@ -64,18 +89,13 @@ const PartnershipTypesColumn: GridColDef<PartnerProject> = {
   valueGetter: (_, { partnership }) => partnership.types.value,
 };
 
-const indexAfterStatus =
-  unmatchedIndexThrow(ProjectColumns.findIndex((c) => c.field === 'status')) +
-  1;
-
-const PartnerProjectColumns =
-  // Avoid contravariance constraint on `row` parameter of `valueGetter`.
-  // This function is called for us, and we just want to enforce that
-  // the `row` is _at least_ a `Project`.
-  // The actual enforcement below.
-  (ProjectColumns as Array<GridColDef<PartnerProject>>)
-    // Add types' column after status
-    .toSpliced(indexAfterStatus, 0, PartnershipTypesColumn);
+const PartnerProjectColumns = insertProjectColumnAfterField(
+  // The helper only requires `row` to be _at least_ a `Project`; the superset
+  // constraint is enforced below.
+  ProjectColumns as Array<GridColDef<PartnerProject>>,
+  'status',
+  PartnershipTypesColumn
+);
 
 // Actually enforce superset constraint here, since we're ignoring above.
 const _EnforcePartnerProjectIsSupersetOfProject: Project =

--- a/src/scenes/Partners/List/PartnerList.tsx
+++ b/src/scenes/Partners/List/PartnerList.tsx
@@ -1,28 +1,45 @@
 import { Paper, Stack, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
+import { useIsMobile } from '~/common';
+import { EntityList as PartnersList } from '~/components/List';
+import { PartnerColumns } from '~/components/PartnersDataGrid/PartnerColumns';
+import { renderPartnerRow } from '~/components/PartnersDataGrid/renderPartnerRow';
 import { PartnerGrid } from './PartnerGrid';
+import { PartnersDocument } from './PartnerList.graphql';
 
 export const PartnerList = () => {
+  const isMobile = useIsMobile();
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 2, md: 4 }, pt: 2 }}>
       <Helmet title="Partners" />
       <Stack component="main" sx={{ flex: 1 }}>
         <Typography variant="h2" paragraph>
           Partners
         </Typography>
-        <Stack sx={{ flex: 1, containerType: 'size' }}>
-          <Paper
-            sx={{
-              flex: 1,
-              minHeight: 375,
-              maxHeight: '100cqh',
-              width: 'min-content',
-              maxWidth: '100cqw',
-            }}
-          >
-            <PartnerGrid />
-          </Paper>
-        </Stack>
+        {isMobile ? (
+          <PartnersList
+            query={PartnersDocument}
+            listAt={(data) => data.partners}
+            columns={PartnerColumns}
+            sortDefault={{ field: 'organization.name', direction: 'ASC' }}
+            renderItem={renderPartnerRow}
+          />
+        ) : (
+          // The grid (and its `useDataGridSource`) must only mount on desktop.
+          <Stack sx={{ flex: 1, containerType: 'size' }}>
+            <Paper
+              sx={{
+                flex: 1,
+                minHeight: 375,
+                maxHeight: '100cqh',
+                width: 'min-content',
+                maxWidth: '100cqw',
+              }}
+            >
+              <PartnerGrid />
+            </Paper>
+          </Stack>
+        )}
       </Stack>
     </Stack>
   );

--- a/src/scenes/ProgressReports/EditForm/ProgressReportDrawer.tsx
+++ b/src/scenes/ProgressReports/EditForm/ProgressReportDrawer.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from '@apollo/client';
+import { ArrowBack } from '@mui/icons-material';
 import { Box, Drawer } from '@mui/material';
 import { useMatch } from 'react-router-dom';
 import { ChildrenProp, flexColumn } from '~/common';
-import { useNavigate } from '~/components/Routing';
+import { ButtonLink, useNavigate } from '~/components/Routing';
 import { ProgressReportContextProvider } from './ProgressReportContext';
 import { ProgressReportDrawerHeader } from './ProgressReportDrawerHeader';
 import { ProgressReportEditDocument } from './ProgressReportEdit.graphql';
@@ -72,17 +73,41 @@ const EditLayout = ({ report }: ReportProp) => {
   }
 
   return (
-    <Box sx={{ m: 4, mt: 2, display: 'flex', gap: 4 }}>
-      <Box css={flexColumn} sx={{ flex: 1, gap: 2 }}>
+    <Box
+      sx={{
+        m: { xs: 2, md: 4 },
+        mt: 2,
+        display: 'flex',
+        // Stack into one column on mobile; the sidebar can't sit beside the
+        // content on a narrow screen without squeezing/overflowing it.
+        flexDirection: { xs: 'column', md: 'row' },
+        gap: { xs: 2, md: 4 },
+      }}
+    >
+      {/* Mobile only: the header's own "Back" sits in the content column, which
+          stacks below the sidebar on mobile — so surface a back link up top. */}
+      <ButtonLink
+        to=".."
+        color="secondary"
+        startIcon={<ArrowBack />}
+        sx={{ order: 0, alignSelf: 'start', display: { md: 'none' } }}
+      >
+        Back To Overview
+      </ButtonLink>
+      <Box css={flexColumn} sx={{ flex: 1, gap: 2, order: { xs: 2, md: 1 } }}>
         <ProgressReportDrawerHeader report={report} />
         <StepContainer report={report} />
       </Box>
       <ProgressReportSidebar
         report={report}
         sx={(theme) => ({
-          top: theme.spacing(2), // matches mt above
-          position: 'sticky',
-          alignSelf: 'start',
+          // Nav/status first on mobile (above the form), beside it on desktop.
+          order: { xs: 1, md: 2 },
+          [theme.breakpoints.up('md')]: {
+            top: theme.spacing(2), // matches mt above
+            position: 'sticky',
+            alignSelf: 'start',
+          },
         })}
       />
     </Box>

--- a/src/scenes/ProgressReports/EditForm/ProgressReportDrawerHeader.tsx
+++ b/src/scenes/ProgressReports/EditForm/ProgressReportDrawerHeader.tsx
@@ -18,11 +18,13 @@ export const ProgressReportDrawerHeader = ({ report }: ReportProp) => {
 
   return (
     <Box css={flexColumn}>
+      {/* Hidden on mobile — surfaced at the top of the layout instead, since
+          this header stacks below the step sidebar on a narrow screen. */}
       <ButtonLink
         to=".."
         color="secondary"
         startIcon={<ArrowBack />}
-        sx={{ alignSelf: 'start' }}
+        sx={{ alignSelf: 'start', display: { xs: 'none', md: 'inline-flex' } }}
       >
         Back To Overview
       </ButtonLink>

--- a/src/scenes/Projects/Files/ProjectFilesList.tsx
+++ b/src/scenes/Projects/Files/ProjectFilesList.tsx
@@ -15,10 +15,12 @@ import {
   GridToolbarContainer,
   GridToolbarProps,
 } from '@mui/x-data-grid-pro';
+import { useMemo } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 import { makeStyles } from 'tss-react/mui';
+import { useResponsiveColumnVisibility } from '~/components/Grid';
 import { useDialog } from '../../../components/Dialog';
 import { Error } from '../../../components/Error';
 import {
@@ -131,79 +133,89 @@ const ProjectFilesListWrapped = () => {
     isFileVersion(item) ? [] : { ...item, parent: data!.directory }
   );
 
-  const columns: Array<GridColDef<FileRow>> = [
-    {
-      headerName: 'Name',
-      field: 'name',
-      flex: 1,
-      renderCell: ({ row, value }) => {
-        const { Icon } = isDirectory(row)
-          ? getDirectoryComponents()
-          : getFileComponents(row.mimeType);
-        return (
-          <span className={classes.fileName}>
-            <Icon className={classes.fileIcon} />
-            {parseFileNameAndExtension(value).displayName}
-          </span>
-        );
+  const columns = useMemo<Array<GridColDef<FileRow>>>(
+    () => [
+      {
+        headerName: 'Name',
+        field: 'name',
+        flex: 1,
+        renderCell: ({ row, value }) => {
+          const { Icon } = isDirectory(row)
+            ? getDirectoryComponents()
+            : getFileComponents(row.mimeType);
+          return (
+            <span className={classes.fileName}>
+              <Icon className={classes.fileIcon} />
+              {parseFileNameAndExtension(value).displayName}
+            </span>
+          );
+        },
       },
-    },
-    {
-      headerName: 'Modified',
-      field: 'modifiedAt',
-      width: 150,
-      valueGetter: (_, row) =>
-        row.__typename === 'File' ? row.modifiedAt : row.createdAt,
-      renderCell: ({ value }) => <FormattedDateTime date={value} />,
-    },
-    {
-      headerName: 'Modified By',
-      field: 'modifiedBy',
-      width: 150,
-      valueGetter: (_, row) =>
-        row.__typename === 'File'
-          ? row.modifiedBy.fullName
-          : row.createdBy.fullName,
-    },
-    {
-      headerName: 'File Size',
-      field: 'size',
-      valueGetter: (_, row) => (isDirectory(row) ? undefined : row.size),
-      renderCell: ({ row: { type }, value: size }) =>
-        type === 'Directory' ? '–' : formatFileSize(size),
-    },
-    {
-      headerName: '',
-      field: 'item',
-      width: 55,
-      align: 'center',
-      renderCell: ({ row }) => {
-        const permittedActions = getPermittedFileActions(
-          !!canReadRootDirectory,
-          !!canReadRootDirectory
-        );
-        const directoryActions = permittedActions.filter(
-          (action) =>
-            action === FileAction.Rename || action === FileAction.Delete
-        );
-        return (
-          <ActionsMenu
-            IconButtonProps={{ size: 'small' }}
-            actions={isDirectory(row) ? directoryActions : permittedActions}
-            item={row}
-            onVersionUpload={(files) =>
-              uploadProjectFiles({
-                action: 'version',
-                files,
-                parentId: row.id,
-              })
-            }
-          />
-        );
+      {
+        headerName: 'Modified',
+        field: 'modifiedAt',
+        width: 150,
+        mobileHidden: true,
+        valueGetter: (_, row) =>
+          row.__typename === 'File' ? row.modifiedAt : row.createdAt,
+        renderCell: ({ value }) => <FormattedDateTime date={value} />,
       },
-      sortable: false,
-    },
-  ];
+      {
+        headerName: 'Modified By',
+        field: 'modifiedBy',
+        width: 150,
+        mobileHidden: true,
+        valueGetter: (_, row) =>
+          row.__typename === 'File'
+            ? row.modifiedBy.fullName
+            : row.createdBy.fullName,
+      },
+      {
+        headerName: 'File Size',
+        field: 'size',
+        mobileHidden: true,
+        valueGetter: (_, row) => (isDirectory(row) ? undefined : row.size),
+        renderCell: ({ row: { type }, value: size }) =>
+          type === 'Directory' ? '–' : formatFileSize(size),
+      },
+      {
+        headerName: '',
+        field: 'item',
+        width: 55,
+        align: 'center',
+        renderCell: ({ row }) => {
+          const permittedActions = getPermittedFileActions(
+            !!canReadRootDirectory,
+            !!canReadRootDirectory
+          );
+          const directoryActions = permittedActions.filter(
+            (action) =>
+              action === FileAction.Rename || action === FileAction.Delete
+          );
+          return (
+            <ActionsMenu
+              IconButtonProps={{ size: 'small' }}
+              actions={isDirectory(row) ? directoryActions : permittedActions}
+              item={row}
+              onVersionUpload={(files) =>
+                uploadProjectFiles({
+                  action: 'version',
+                  files,
+                  parentId: row.id,
+                })
+              }
+            />
+          );
+        },
+        sortable: false,
+      },
+    ],
+    [classes, canReadRootDirectory, uploadProjectFiles]
+  );
+
+  const initialState = useResponsiveColumnVisibility(columns, undefined, {
+    pinnedLeft: ['name'],
+  });
 
   const handleRowClick = ({ row }: GridRowParams<FileRow>) => {
     if (isDirectory(row)) {
@@ -276,6 +288,7 @@ const ProjectFilesListWrapped = () => {
                   loading={loading}
                   rows={rowData}
                   columns={columns}
+                  initialState={initialState}
                   onRowClick={handleRowClick}
                   slots={{
                     row: FileRowComponent,

--- a/src/scenes/Projects/List/EngagementList.graphql
+++ b/src/scenes/Projects/List/EngagementList.graphql
@@ -3,6 +3,6 @@ query EngagementList($input: EngagementListInput) {
     items {
       ...engagementDataGridRow
     }
-    total
+    ...Pagination
   }
 }

--- a/src/scenes/Projects/List/EngagementsPanel.tsx
+++ b/src/scenes/Projects/List/EngagementsPanel.tsx
@@ -30,7 +30,7 @@ export const EngagementsPanel = () => {
     slots: { toolbar: EngagementToolbar },
   });
 
-  const processEngagementUpdate = useProcessEngagementUpdate();
+  const processRowUpdate = useProcessEngagementUpdate();
 
   return (
     <DataGrid<Engagement>
@@ -40,7 +40,7 @@ export const EngagementsPanel = () => {
       slotProps={slotProps}
       columns={EngagementColumns}
       initialState={EngagementInitialState}
-      processRowUpdate={processEngagementUpdate}
+      processRowUpdate={processRowUpdate}
       headerFilters
       hideFooter
       sx={[flexLayout, noHeaderFilterButtons, noFooter]}

--- a/src/scenes/Projects/List/ProjectList.graphql
+++ b/src/scenes/Projects/List/ProjectList.graphql
@@ -3,6 +3,6 @@ query ProjectList($input: ProjectListInput) {
     items {
       ...projectDataGridRow
     }
-    total
+    ...Pagination
   }
 }

--- a/src/scenes/Projects/List/ProjectList.tsx
+++ b/src/scenes/Projects/List/ProjectList.tsx
@@ -1,17 +1,36 @@
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Stack } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
+import { useIsMobile } from '~/common';
+import {
+  EngagementColumns,
+  engagementName,
+} from '~/components/EngagementDataGrid';
 import { ContentContainer } from '~/components/Layout';
-import { TabLink, TabPanelContent, TabsContainer } from '~/components/Tabs';
+import {
+  EntityList as EngagementsList,
+  EntityList as ProjectsList,
+} from '~/components/List';
+import { ProjectColumns } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
+import {
+  TabLink,
+  TabList,
+  TabPanelContent,
+  TabsContainer,
+} from '~/components/Tabs';
+import { EngagementListDocument } from './EngagementList.graphql';
 import { EngagementsPanel } from './EngagementsPanel';
+import { ProjectListDocument } from './ProjectList.graphql';
 import { ProjectsPanel } from './ProjectsPanel';
 
 export const ProjectList = () => {
   const { pathname } = useLocation();
+  const isMobile = useIsMobile();
 
   return (
-    <ContentContainer sx={{ p: 4, pt: 2, overflow: 'initial' }}>
+    <ContentContainer sx={{ p: { xs: 2, md: 4 }, pt: 2, overflow: 'initial' }}>
       <Helmet title={pathname === '/projects' ? 'Projects' : 'Engagements'} />
       <Stack component="main" sx={{ flex: 1 }}>
         <TabsContainer>
@@ -25,14 +44,49 @@ export const ProjectList = () => {
               />
             </TabList>
             <TabPanel value="/projects">
-              <TabPanelContent>
-                <ProjectsPanel />
-              </TabPanelContent>
+              {isMobile ? (
+                <ProjectsList
+                  query={ProjectListDocument}
+                  listAt={(data) => data.projects}
+                  columns={ProjectColumns}
+                  sortDefault={{ field: 'name', direction: 'ASC' }}
+                  defaultSecondaryField="primaryLocation.name"
+                  primary={(project) => project.name.value}
+                  to={(project) => `/projects/${project.id}`}
+                  avatar={(project) => (
+                    <SensitivityIcon value={project.sensitivity} />
+                  )}
+                />
+              ) : (
+                // The grid (and its `useDataGridSource`) only mounts on desktop.
+                <TabPanelContent>
+                  <ProjectsPanel />
+                </TabPanelContent>
+              )}
             </TabPanel>
             <TabPanel value="/engagements">
-              <TabPanelContent>
-                <EngagementsPanel />
-              </TabPanelContent>
+              {isMobile ? (
+                <EngagementsList
+                  query={EngagementListDocument}
+                  listAt={(data) => data.engagements}
+                  columns={EngagementColumns}
+                  sortDefault={{
+                    field: EngagementColumns[0]!.field,
+                    direction: 'ASC',
+                  }}
+                  defaultSecondaryField="project.name"
+                  primary={engagementName}
+                  to={(engagement) => `/engagements/${engagement.id}`}
+                  avatar={(engagement) => (
+                    <SensitivityIcon value={engagement.project.sensitivity} />
+                  )}
+                />
+              ) : (
+                // The grid (and its `useDataGridSource`) only mounts on desktop.
+                <TabPanelContent>
+                  <EngagementsPanel />
+                </TabPanelContent>
+              )}
             </TabPanel>
           </TabContext>
         </TabsContainer>

--- a/src/scenes/Projects/List/ProjectList.tsx
+++ b/src/scenes/Projects/List/ProjectList.tsx
@@ -58,7 +58,7 @@ export const ProjectList = () => {
                   )}
                 />
               ) : (
-                // The grid (and its `useDataGridSource`) only mounts on desktop.
+                // ai edge-case The grid (and its `useDataGridSource`) only mounts on desktop.
                 <TabPanelContent>
                   <ProjectsPanel />
                 </TabPanelContent>
@@ -82,7 +82,7 @@ export const ProjectList = () => {
                   )}
                 />
               ) : (
-                // The grid (and its `useDataGridSource`) only mounts on desktop.
+                // ai edge-case The grid (and its `useDataGridSource`) only mounts on desktop.
                 <TabPanelContent>
                   <EngagementsPanel />
                 </TabPanelContent>

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -147,7 +147,10 @@ export const ProjectOverview = () => {
     : CreateInternshipEngagement;
 
   return (
-    <Box component="main" sx={{ flex: 1, overflowY: 'auto', padding: 4 }}>
+    <Box
+      component="main"
+      sx={{ flex: 1, overflowY: 'auto', padding: { xs: 2, md: 4 } }}
+    >
       <Helmet title={project?.name.value ?? undefined} />
       <Error error={error}>
         {{
@@ -159,6 +162,9 @@ export const ProjectOverview = () => {
         <Box
           sx={(theme) => ({
             maxWidth: theme.breakpoints.values.md,
+            // Guard against minor horizontal overhang (negative grid gutters,
+            // card shadows) causing a stray horizontal scroll on mobile.
+            overflowX: 'clip',
             '& > *:not(:last-child)': {
               mb: 3,
             },
@@ -167,81 +173,88 @@ export const ProjectOverview = () => {
           <Box
             component="header"
             sx={{
-              flex: 1,
               display: 'flex',
-              gap: 1,
-              alignItems: 'center',
+              gap: 2,
+              alignItems: 'flex-start',
             }}
           >
-            <Typography
-              variant="h2"
+            {/* Name + type chip stack vertically, so the action icons stay
+                pinned top-right, in line with the project name. */}
+            <Box
               sx={{
-                mr: 2, // a little extra between text and buttons
-                // centers text with buttons better
-                lineHeight: 'inherit',
-                alignSelf: 'flex-start',
-                ...(project
-                  ? {}
-                  : {
-                      width: '30%',
-                      alignSelf: 'initial',
-                    }),
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+                gap: 1,
               }}
             >
-              {!project ? (
-                <Skeleton width="100%" />
-              ) : project.name.canRead ? (
-                <ChangesetPropertyBadge current={project} prop="name">
-                  {project.name.value}
-                </ChangesetPropertyBadge>
-              ) : (
-                <Redacted
-                  info="You do not have permission to view project's name"
-                  width="50%"
+              <Typography
+                variant="h2"
+                sx={{
+                  lineHeight: 'inherit',
+                  minWidth: 0, // allow the title to shrink/wrap instead of forcing width
+                  ...(project ? {} : { width: '30%' }),
+                }}
+              >
+                {!project ? (
+                  <Skeleton width="100%" />
+                ) : project.name.canRead ? (
+                  <ChangesetPropertyBadge current={project} prop="name">
+                    {project.name.value}
+                  </ChangesetPropertyBadge>
+                ) : (
+                  <Redacted
+                    info="You do not have permission to view project's name"
+                    width="50%"
+                  />
+                )}
+              </Typography>
+              {project && (
+                <Chip
+                  label={labelFrom(ProjectTypeLabels)(project.type)}
+                  variant="outlined"
                 />
               )}
-            </Typography>
-            {project && (
-              <Chip
-                label={labelFrom(ProjectTypeLabels)(project.type)}
-                variant="outlined"
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+              {(!project || project.name.canEdit) && (
+                <Tooltip title="Edit Project Name">
+                  <IconButton
+                    aria-label="edit project name"
+                    onClick={() =>
+                      editField([
+                        'name',
+                        'departmentId',
+                        ...(project?.__typename === 'MomentumTranslationProject'
+                          ? ['usesRev79' as const]
+                          : []),
+                      ])
+                    }
+                    loading={!project}
+                  >
+                    <Edit />
+                  </IconButton>
+                </Tooltip>
+              )}
+              <TogglePinButton
+                object={project}
+                label="Project"
+                listId="projects"
+                listFilter={(args: PartialDeep<ProjectListQueryVariables>) =>
+                  args.input?.filter?.pinned ?? false
+                }
               />
-            )}
-            {(!project || project.name.canEdit) && (
-              <Tooltip title="Edit Project Name">
-                <IconButton
-                  aria-label="edit project name"
-                  onClick={() =>
-                    editField([
-                      'name',
-                      'departmentId',
-                      ...(project?.__typename === 'MomentumTranslationProject'
-                        ? ['usesRev79' as const]
-                        : []),
-                    ])
-                  }
+              <ToggleCommentsButton loading={!project} />
+              {project && <DeleteProject project={project} />}
+              {project && (
+                <WorkflowEventsIcon
+                  onClick={openWorkflowEvents}
                   loading={!project}
-                >
-                  <Edit />
-                </IconButton>
-              </Tooltip>
-            )}
-            <TogglePinButton
-              object={project}
-              label="Project"
-              listId="projects"
-              listFilter={(args: PartialDeep<ProjectListQueryVariables>) =>
-                args.input?.filter?.pinned ?? false
-              }
-            />
-            <ToggleCommentsButton loading={!project} />
-            {project && <DeleteProject project={project} />}
-            {project && (
-              <WorkflowEventsIcon
-                onClick={openWorkflowEvents}
-                loading={!project}
-              />
-            )}
+                />
+              )}
+            </Box>
           </Box>
 
           <Box

--- a/src/scenes/Root/Header/Header.tsx
+++ b/src/scenes/Root/Header/Header.tsx
@@ -1,12 +1,33 @@
+import { Menu as MenuIcon } from '@mui/icons-material';
 import { AppBar, Toolbar } from '@mui/material';
+import { useIsMobile } from '~/common';
+import { IconButton } from '~/components/IconButton';
+import { MobileFilterButton } from '~/components/List';
 import { HeaderSearch } from './HeaderSearch';
 import { ProfileToolbar } from './ProfileToolbar';
 
-export const Header = () => (
-  <AppBar position="static" color="inherit" sx={{ zIndex: 1 }}>
-    <Toolbar sx={{ gap: 3, justifyContent: 'space-between' }}>
-      <HeaderSearch sx={{ flex: 1, maxWidth: 500 }} />
-      <ProfileToolbar />
-    </Toolbar>
-  </AppBar>
-);
+export interface HeaderProps {
+  onMenuClick?: () => void;
+}
+
+export const Header = ({ onMenuClick }: HeaderProps) => {
+  const isMobile = useIsMobile();
+  return (
+    <AppBar position="static" color="inherit" sx={{ zIndex: 1 }}>
+      <Toolbar sx={{ gap: 3, justifyContent: 'space-between' }}>
+        {isMobile && (
+          <IconButton
+            edge="start"
+            aria-label="Open navigation menu"
+            onClick={onMenuClick}
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
+        <HeaderSearch sx={{ flex: 1, maxWidth: 500 }} />
+        {isMobile && <MobileFilterButton />}
+        <ProfileToolbar />
+      </Toolbar>
+    </AppBar>
+  );
+};

--- a/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
+++ b/src/scenes/Root/Header/HeaderSearch/HeaderSearch.tsx
@@ -1,8 +1,10 @@
 import { Search } from '@mui/icons-material';
 import { Box, InputAdornment } from '@mui/material';
+import { useState } from 'react';
 import { Form } from 'react-final-form';
 import { useNavigate } from 'react-router-dom';
-import { StyleProps } from '~/common';
+import { StyleProps, useIsMobile } from '~/common';
+import { IconButton } from '~/components/IconButton';
 import { TextField } from '../../../../components/form';
 import { makeQueryHandler, StringParam } from '../../../../hooks';
 
@@ -13,6 +15,22 @@ export const useSearch = makeQueryHandler({
 export const HeaderSearch = (props: StyleProps) => {
   const [{ q: search = '' }] = useSearch();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  // On mobile the field is collapsed to an icon to free up the cramped toolbar;
+  // tapping it expands the full search field.
+  const [expanded, setExpanded] = useState(false);
+
+  if (isMobile && !expanded) {
+    return (
+      <IconButton
+        aria-label="Search"
+        edge="start"
+        onClick={() => setExpanded(true)}
+      >
+        <Search />
+      </IconButton>
+    );
+  }
 
   return (
     <Form
@@ -21,16 +39,25 @@ export const HeaderSearch = (props: StyleProps) => {
         if (search) {
           navigate(`/search?q=${search}`);
         }
+        // Collapse the mobile search back to its icon after submitting.
+        setExpanded(false);
       }}
     >
       {({ handleSubmit }) => (
-        <Box component="form" onSubmit={handleSubmit} {...props}>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          // Collapse back to the icon when focus leaves the mobile search.
+          onBlur={() => isMobile && setExpanded(false)}
+          {...props}
+        >
           <TextField
             name="search"
             variant="outlined"
             placeholder="Search"
             size="small"
             helperText={false}
+            autoFocus={isMobile}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start" disablePointerEvents>

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
@@ -1,10 +1,13 @@
-import { Box, Divider, Menu, MenuProps, Typography } from '@mui/material';
+import { Box, Divider, Menu, Typography } from '@mui/material';
+import type { MenuProps } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { UIEvent, useContext } from 'react';
+import type { UIEvent } from 'react';
+import { useContext } from 'react';
 import { ImpersonationContext } from '~/api/client/ImpersonationContext';
-import { MenuItemLink } from '../../../../components/Routing';
-import { useSession } from '../../../../components/Session';
-import { NotificationList, UseNotifications } from '../../Notifications';
+import { MenuItemLink } from '~/components/Routing';
+import { useSession } from '~/components/Session';
+import { NotificationList } from '../../Notifications';
+import type { UseNotifications } from '../../Notifications';
 import { ChangePasswordMenuItem } from './ChangePasswordMenuItem';
 import { ImpersonationMenuItem } from './ImpersonationDialog';
 import { ToggleUploadManagerMenuItem } from './ToggleUploadManagerMenuItem';

--- a/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
+++ b/src/scenes/Root/Header/ProfileMenu/ProfileMenu.tsx
@@ -1,18 +1,20 @@
-import { Divider, Menu, MenuProps, Typography } from '@mui/material';
+import { Box, Divider, Menu, MenuProps, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { UIEvent, useContext } from 'react';
 import { ImpersonationContext } from '~/api/client/ImpersonationContext';
 import { MenuItemLink } from '../../../../components/Routing';
 import { useSession } from '../../../../components/Session';
+import { NotificationList, UseNotifications } from '../../Notifications';
 import { ChangePasswordMenuItem } from './ChangePasswordMenuItem';
 import { ImpersonationMenuItem } from './ImpersonationDialog';
 import { ToggleUploadManagerMenuItem } from './ToggleUploadManagerMenuItem';
 
-// Menu looks for disabled prop to skip over when choosing
-// which item to auto focus first.
-const skipAutoFocus: any = { disabled: true };
+export interface ProfileMenuProps extends Partial<MenuProps> {
+  /** When provided (mobile), the menu shows the username header + notifications. */
+  notifications?: UseNotifications;
+}
 
-export const ProfileMenu = (props: Partial<MenuProps>) => {
+export const ProfileMenu = ({ notifications, ...props }: ProfileMenuProps) => {
   const { spacing } = useTheme();
   const { session } = useSession();
   const impersonation = useContext(ImpersonationContext);
@@ -33,14 +35,32 @@ export const ProfileMenu = (props: Partial<MenuProps>) => {
         horizontal: 'right',
       }}
       slotProps={{
-        paper: { sx: { minWidth: 200 } },
+        paper: { sx: { minWidth: notifications ? 'min(360px, 90vw)' : 200 } },
       }}
+      // The header rows below (title/divider/notifications) aren't menu items;
+      // don't auto-focus into the list so focus opens on the menu itself.
+      MenuListProps={{ autoFocusItem: false }}
       {...props}
     >
-      <Typography variant="h4" pt={1} p={2} {...skipAutoFocus}>
-        Profile Info
+      <Typography variant="h4" pt={1} p={2}>
+        {notifications && session?.fullName ? session.fullName : 'Profile Info'}
       </Typography>
-      <Divider {...skipAutoFocus} />
+      <Divider />
+      {notifications?.enabled && (
+        <Box>
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ display: 'block', px: 2, pt: 1 }}
+          >
+            Notifications
+          </Typography>
+          <Box sx={{ maxHeight: 320, overflowY: 'auto' }}>
+            <NotificationList notifications={notifications} />
+          </Box>
+          <Divider />
+        </Box>
+      )}
       {userId && (
         <MenuItemLink to={`/users/${userId}`}>View Profile</MenuItemLink>
       )}

--- a/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
+++ b/src/scenes/Root/Header/ProfileToolbar/ProfileToolbar.tsx
@@ -1,14 +1,17 @@
 import { AccountCircle, SupervisedUserCircle } from '@mui/icons-material';
-import { IconButton, MenuProps, Stack, Typography } from '@mui/material';
-import { useContext, useState } from 'react';
+import { Badge, IconButton, MenuProps, Stack, Typography } from '@mui/material';
+import { MouseEvent, useContext, useState } from 'react';
 import { ImpersonationContext } from '~/api/client/ImpersonationContext';
+import { useIsMobile } from '~/common';
 import { useSession } from '~/components/Session';
-import { Notifications } from '../../Notifications';
+import { Notifications, useNotifications } from '../../Notifications';
 import { ProfileMenu } from '../ProfileMenu';
 
-export const ProfileToolbar = () => {
+export const ProfileToolbar = () =>
+  useIsMobile() ? <MobileProfileToolbar /> : <DesktopProfileToolbar />;
+
+const DesktopProfileToolbar = () => {
   const { session } = useSession();
-  const impersonation = useContext(ImpersonationContext);
   const [profileAnchor, setProfileAnchor] = useState<MenuProps['anchorEl']>();
 
   return (
@@ -18,19 +21,73 @@ export const ProfileToolbar = () => {
         <Typography color="primary" sx={{ fontWeight: 'medium' }}>
           {session?.fullName}
         </Typography>
-        <IconButton
-          color="secondary"
-          aria-controls="profile-menu"
-          aria-haspopup="true"
-          onClick={(e) => setProfileAnchor(e.currentTarget)}
-        >
-          {impersonation.enabled ? <SupervisedUserCircle /> : <AccountCircle />}
-        </IconButton>
+        <ProfileButton onClick={(e) => setProfileAnchor(e.currentTarget)} />
       </Stack>
       <ProfileMenu
         anchorEl={profileAnchor}
         onClose={() => setProfileAnchor(null)}
       />
     </>
+  );
+};
+
+/**
+ * Mobile: the notification bell and username collapse into the avatar — the
+ * unread count rides as a badge on the avatar, and the username + notifications
+ * move into the profile menu.
+ */
+const MobileProfileToolbar = () => {
+  const [profileAnchor, setProfileAnchor] = useState<MenuProps['anchorEl']>();
+  const notifications = useNotifications();
+
+  return (
+    <>
+      <ProfileButton
+        onClick={(e) => setProfileAnchor(e.currentTarget)}
+        unread={notifications.totalUnread}
+      />
+      <ProfileMenu
+        anchorEl={profileAnchor}
+        onClose={() => setProfileAnchor(null)}
+        notifications={notifications}
+      />
+    </>
+  );
+};
+
+const ProfileButton = ({
+  onClick,
+  unread,
+}: {
+  onClick: (e: MouseEvent<HTMLElement>) => void;
+  /** Mobile only: unread notification count shown as a badge over the avatar. */
+  unread?: number;
+}) => {
+  const impersonation = useContext(ImpersonationContext);
+  const icon = impersonation.enabled ? (
+    <SupervisedUserCircle />
+  ) : (
+    <AccountCircle />
+  );
+  return (
+    <IconButton
+      color="secondary"
+      aria-label={
+        unread ? `Profile, ${unread} unread notifications` : 'Profile'
+      }
+      aria-controls="profile-menu"
+      aria-haspopup="true"
+      onClick={onClick}
+    >
+      {/*
+        Default (rectangular) badge placement so this matches the header's
+        filter badge exactly — both ride at the icon's top-right corner.
+        `badgeContent={0}` renders nothing (showZero is off), so this is inert
+        on desktop where `unread` is undefined.
+      */}
+      <Badge color="primary" badgeContent={unread ?? 0}>
+        {icon}
+      </Badge>
+    </IconButton>
   );
 };

--- a/src/scenes/Root/MainLayout.tsx
+++ b/src/scenes/Root/MainLayout.tsx
@@ -1,7 +1,10 @@
 import { Box } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { Outlet } from 'react-router-dom';
+// eslint-disable-next-line @seedcompany/no-restricted-imports
+import { Outlet, useLocation } from 'react-router-dom';
 import { CommentsBar } from '~/components/Comments/CommentsBar';
+import { MobileFilterProvider } from '~/components/List';
 import { Error } from '../../components/Error';
 import { useAuthRequired } from '../Authentication';
 import { CreateDialogProviders } from './Creates';
@@ -11,31 +14,40 @@ import { Sidebar } from './Sidebar';
 export const MainLayout = () => {
   useAuthRequired();
 
+  const [navOpen, setNavOpen] = useState(false);
+
+  // Close the mobile nav drawer whenever the route changes.
+  const { pathname } = useLocation();
+  useEffect(() => setNavOpen(false), [pathname]);
+
   return (
-    <Box
-      sx={{
-        flex: 1,
-        display: 'flex',
-        height: '100vh',
-        bgcolor: 'background.default',
-      }}
-    >
-      <CreateDialogProviders>
-        <Sidebar />
-      </CreateDialogProviders>
+    <MobileFilterProvider>
       <Box
         sx={{
           flex: 1,
           display: 'flex',
-          flexDirection: 'column',
+          height: '100vh',
+          bgcolor: 'background.default',
         }}
       >
-        <Header />
-        <ErrorBoundary fallback={<Error show page />}>
-          <Outlet />
-        </ErrorBoundary>
+        <CreateDialogProviders>
+          <Sidebar open={navOpen} onClose={() => setNavOpen(false)} />
+        </CreateDialogProviders>
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: 0,
+          }}
+        >
+          <Header onMenuClick={() => setNavOpen(true)} />
+          <ErrorBoundary fallback={<Error show page />}>
+            <Outlet />
+          </ErrorBoundary>
+        </Box>
+        <CommentsBar />
       </Box>
-      <CommentsBar />
-    </Box>
+    </MobileFilterProvider>
   );
 };

--- a/src/scenes/Root/Notifications/NotificationList.tsx
+++ b/src/scenes/Root/Notifications/NotificationList.tsx
@@ -1,0 +1,47 @@
+import { Divider, Stack, Typography } from '@mui/material';
+import { extendSx, StyleProps } from '~/common';
+import { ProgressButton } from '~/components/ProgressButton';
+import { Notification } from './Notification';
+import { UseNotifications } from './useNotifications';
+import { BaseView } from './Views/Base';
+
+export interface NotificationListProps extends StyleProps {
+  notifications: UseNotifications;
+}
+
+/** The notification rows (skeletons, items, empty state, load more). */
+export const NotificationList = ({
+  notifications,
+  sx,
+}: NotificationListProps) => {
+  const { data, loading, loadMore, onReadToggle } = notifications;
+  return (
+    <Stack
+      divider={<Divider />}
+      sx={[{ p: 1, pt: 0.5, gap: 0.5 }, ...extendSx(sx)]}
+    >
+      {loading && !data
+        ? Array.from({ length: 5 }).map((_, i) => (
+            <BaseView key={i} notification="loading" />
+          ))
+        : null}
+      {data?.items.map((notification) => (
+        <Notification
+          key={notification.id}
+          notification={notification}
+          onReadToggle={onReadToggle(notification)}
+        />
+      ))}
+      {data && data.items.length === 0 && (
+        <Typography align="center" color="text.secondary" my={3}>
+          None yet!
+        </Typography>
+      )}
+      {data?.hasMore && (
+        <ProgressButton progress={loading} onClick={() => loadMore()}>
+          Load more
+        </ProgressButton>
+      )}
+    </Stack>
+  );
+};

--- a/src/scenes/Root/Notifications/Notifications.tsx
+++ b/src/scenes/Root/Notifications/Notifications.tsx
@@ -1,4 +1,3 @@
-import { useMutation, useSubscription } from '@apollo/client';
 import { NotificationsNone } from '@mui/icons-material';
 import {
   Badge,
@@ -6,91 +5,20 @@ import {
   Divider,
   IconButton,
   Popover,
-  Stack,
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { useState } from 'react';
-import {
-  useFeatureEnabled,
-  VisibilityAndClickTracker,
-} from '~/components/Feature';
-import { useListQuery } from '~/components/List';
-import { ProgressButton } from '~/components/ProgressButton';
-import { Notification } from './Notification';
-import { NotificationAddedDocument } from './NotificationAdded.graphql';
-import { NotificationListDocument } from './NotificationList.graphql';
-import { ReadNotificationDocument } from './ReadNotification.graphql';
-import { NotificationFragment } from './Views';
-import { BaseView } from './Views/Base';
+import { VisibilityAndClickTracker } from '~/components/Feature';
+import { NotificationList } from './NotificationList';
+import { useNotifications } from './useNotifications';
 
 export const Notifications = () => {
-  const enabled = useFeatureEnabled('notifications');
-
   const { spacing } = useTheme();
-
-  const { data, loadMore, loading } = useListQuery(NotificationListDocument, {
-    listAt: (data) => data.notifications,
-    skip: !enabled,
-  });
-  useSubscription(NotificationAddedDocument, {
-    skip: !enabled,
-    onData: ({ data, client }) => {
-      const added = data.data?.notificationAdded;
-      if (!added) {
-        return;
-      }
-      client.cache.updateQuery(
-        {
-          query: NotificationListDocument,
-        },
-        (prev) => {
-          if (!prev) {
-            return;
-          }
-          return {
-            notifications: {
-              ...prev.notifications,
-              total: prev.notifications.total + 1,
-              totalUnread: prev.notifications.totalUnread + 1,
-              items: [added.notification, ...prev.notifications.items],
-            },
-          };
-        }
-      );
-    },
-  });
-
-  const [markAsRead] = useMutation(ReadNotificationDocument, {
-    update: (cache, { data: updated }) => {
-      cache.updateQuery(
-        {
-          query: NotificationListDocument,
-        },
-        (prev) => ({
-          notifications: {
-            ...prev!.notifications,
-            totalUnread:
-              prev!.notifications.totalUnread +
-              (updated!.readNotification.unread ? 1 : -1),
-          },
-        })
-      );
-    },
-  });
-  const onReadToggle = (notification: NotificationFragment) => () => {
-    const next = !notification.unread;
-    void markAsRead({
-      variables: { id: notification.id, unread: next },
-      optimisticResponse: {
-        readNotification: { ...notification, unread: next },
-      },
-    });
-  };
-
+  const notifications = useNotifications();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  if (!enabled) {
+  if (!notifications.enabled) {
     return null;
   }
 
@@ -101,7 +29,7 @@ export const Notifications = () => {
           aria-label="notifications"
           onClick={(event) => setAnchorEl(event.currentTarget)}
         >
-          <Badge color="primary" badgeContent={data?.totalUnread ?? 0}>
+          <Badge color="primary" badgeContent={notifications.totalUnread}>
             <NotificationsNone />
           </Badge>
         </IconButton>
@@ -140,30 +68,7 @@ export const Notifications = () => {
           </Typography>
           <Divider sx={{ mx: 1 }} />
         </Box>
-        <Stack divider={<Divider />} sx={{ p: 1, pt: 0.5, gap: 0.5 }}>
-          {loading && !data
-            ? Array.from({ length: 5 }).map((_, i) => (
-                <BaseView key={i} notification="loading" />
-              ))
-            : null}
-          {data?.items.map((notification) => (
-            <Notification
-              key={notification.id}
-              notification={notification}
-              onReadToggle={onReadToggle(notification)}
-            />
-          ))}
-          {data && data.items.length === 0 && (
-            <Typography align="center" color="text.secondary" my={3}>
-              None yet!
-            </Typography>
-          )}
-          {data?.hasMore && (
-            <ProgressButton progress={loading} onClick={() => loadMore()}>
-              Load more
-            </ProgressButton>
-          )}
-        </Stack>
+        <NotificationList notifications={notifications} />
       </Popover>
     </>
   );

--- a/src/scenes/Root/Notifications/index.ts
+++ b/src/scenes/Root/Notifications/index.ts
@@ -1,1 +1,3 @@
 export * from './Notifications';
+export * from './NotificationList';
+export * from './useNotifications';

--- a/src/scenes/Root/Notifications/useNotifications.ts
+++ b/src/scenes/Root/Notifications/useNotifications.ts
@@ -1,0 +1,85 @@
+import { useMutation, useSubscription } from '@apollo/client';
+import { useFeatureEnabled } from '~/components/Feature';
+import { useListQuery } from '~/components/List';
+import { NotificationAddedDocument } from './NotificationAdded.graphql';
+import { NotificationListDocument } from './NotificationList.graphql';
+import { ReadNotificationDocument } from './ReadNotification.graphql';
+import { NotificationFragment } from './Views';
+
+/**
+ * Notifications data + actions, shared by the desktop bell ({@link Notifications})
+ * and the mobile profile menu. Owns the live subscription, so it should be mounted
+ * once at a time per surface.
+ */
+export const useNotifications = () => {
+  const enabled = useFeatureEnabled('notifications');
+
+  const { data, loadMore, loading } = useListQuery(NotificationListDocument, {
+    listAt: (data) => data.notifications,
+    skip: !enabled,
+  });
+
+  useSubscription(NotificationAddedDocument, {
+    skip: !enabled,
+    onData: ({ data, client }) => {
+      const added = data.data?.notificationAdded;
+      if (!added) {
+        return;
+      }
+      client.cache.updateQuery({ query: NotificationListDocument }, (prev) => {
+        if (!prev) {
+          return;
+        }
+        // Idempotent: ignore a notification we've already inserted (a duplicate
+        // subscription event, or a second mounted surface) so counts don't double.
+        if (
+          prev.notifications.items.some((n) => n.id === added.notification.id)
+        ) {
+          return prev;
+        }
+        return {
+          notifications: {
+            ...prev.notifications,
+            total: prev.notifications.total + 1,
+            totalUnread: prev.notifications.totalUnread + 1,
+            items: [added.notification, ...prev.notifications.items],
+          },
+        };
+      });
+    },
+  });
+
+  const [markAsRead] = useMutation(ReadNotificationDocument, {
+    update: (cache, { data: updated }) => {
+      cache.updateQuery({ query: NotificationListDocument }, (prev) => ({
+        notifications: {
+          ...prev!.notifications,
+          totalUnread:
+            prev!.notifications.totalUnread +
+            (updated!.readNotification.unread ? 1 : -1),
+        },
+      }));
+    },
+  });
+
+  const onReadToggle = (notification: NotificationFragment) => () => {
+    const next = !notification.unread;
+    void markAsRead({
+      variables: { id: notification.id, unread: next },
+      optimisticResponse: {
+        readNotification: { ...notification, unread: next },
+      },
+    });
+  };
+
+  return {
+    enabled,
+    data,
+    loading,
+    loadMore,
+    onReadToggle,
+    totalUnread: data?.totalUnread ?? 0,
+  };
+};
+
+export type UseNotifications = ReturnType<typeof useNotifications>;

--- a/src/scenes/Root/Notifications/useNotifications.ts
+++ b/src/scenes/Root/Notifications/useNotifications.ts
@@ -4,7 +4,7 @@ import { useListQuery } from '~/components/List';
 import { NotificationAddedDocument } from './NotificationAdded.graphql';
 import { NotificationListDocument } from './NotificationList.graphql';
 import { ReadNotificationDocument } from './ReadNotification.graphql';
-import { NotificationFragment } from './Views';
+import type { NotificationFragment } from './Views';
 
 /**
  * Notifications data + actions, shared by the desktop bell ({@link Notifications})
@@ -51,14 +51,19 @@ export const useNotifications = () => {
 
   const [markAsRead] = useMutation(ReadNotificationDocument, {
     update: (cache, { data: updated }) => {
-      cache.updateQuery({ query: NotificationListDocument }, (prev) => ({
-        notifications: {
-          ...prev!.notifications,
-          totalUnread:
-            prev!.notifications.totalUnread +
-            (updated!.readNotification.unread ? 1 : -1),
-        },
-      }));
+      cache.updateQuery({ query: NotificationListDocument }, (prev) => {
+        if (!prev || !updated?.readNotification) {
+          return;
+        }
+        return {
+          notifications: {
+            ...prev.notifications,
+            totalUnread:
+              prev.notifications.totalUnread +
+              (updated.readNotification.unread ? 1 : -1),
+          },
+        };
+      });
     },
   });
 

--- a/src/scenes/Root/Sidebar/Sidebar.tsx
+++ b/src/scenes/Root/Sidebar/Sidebar.tsx
@@ -1,15 +1,16 @@
-import { Dashboard, FolderOpen, Language, Person } from '@mui/icons-material';
+import { Dashboard, FolderOpen, Person, Translate } from '@mui/icons-material';
 import {
+  Drawer,
   List,
   ListItemIcon,
   ListItemText,
-  ListSubheader,
   Paper,
   SvgIconProps,
 } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { ComponentType } from 'react';
 import { makeStyles } from 'tss-react/mui';
+import { useIsMobile } from '~/common';
 import { PeopleJoinedIcon } from '../../../components/Icons';
 import { ListItemLink, ListItemLinkProps } from '../../../components/Routing';
 import { CreateButtonMenu } from '../Creates';
@@ -31,43 +32,71 @@ const useStyles = makeStyles()(({ spacing }) => ({
   },
 }));
 
-export const Sidebar = () => {
-  const { classes } = useStyles();
+export interface SidebarProps {
+  /** Mobile only: whether the temporary drawer is open. */
+  open?: boolean;
+  /** Mobile only: called to close the temporary drawer. */
+  onClose?: () => void;
+}
 
-  const navList = (
-    <List
-      component="nav"
-      aria-label="sidebar"
-      subheader={<ListSubheader component="div">MENU</ListSubheader>}
-    >
-      <NavItem to="/dashboard" label="My Dashboard" icon={Dashboard} />
-      <NavItem
-        to="/projects"
-        label="Projects"
-        icon={FolderOpen}
-        active={[
-          { path: '/projects', end: false },
-          { path: '/engagements', end: false },
-        ]}
-      />
-      <NavItem to="/languages" label="Languages" icon={Language} />
-      <NavItem to="/users" label="People" icon={Person} />
-      <NavItem to="/partners" label="Partners" icon={PeopleJoinedIcon} />
-    </List>
-  );
+export const Sidebar = ({ open = false, onClose }: SidebarProps) => {
+  const { classes } = useStyles();
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      // ThemeProvider must wrap the whole Drawer so its Paper surface picks up
+      // the dark sidebar background (not just the content inside it).
+      <ThemeProvider theme={sidebarTheme}>
+        <Drawer
+          variant="temporary"
+          open={open}
+          onClose={onClose}
+          ModalProps={{ keepMounted: true }}
+          PaperProps={{ className: classes.root }}
+        >
+          <SidebarContent classes={classes} />
+        </Drawer>
+      </ThemeProvider>
+    );
+  }
 
   return (
     <ThemeProvider theme={sidebarTheme}>
       <Paper elevation={0} square className={classes.root}>
-        <SidebarHeader />
-        <div className={classes.content}>
-          <CreateButtonMenu fullWidth className={classes.createNewItem} />
-          {navList}
-        </div>
+        <SidebarContent classes={classes} />
       </Paper>
     </ThemeProvider>
   );
 };
+
+const SidebarContent = ({
+  classes,
+}: {
+  classes: ReturnType<typeof useStyles>['classes'];
+}) => (
+  <>
+    <SidebarHeader />
+    <div className={classes.content}>
+      <CreateButtonMenu fullWidth className={classes.createNewItem} />
+      <List component="nav" aria-label="sidebar">
+        <NavItem to="/dashboard" label="My Dashboard" icon={Dashboard} />
+        <NavItem
+          to="/projects"
+          label="Projects"
+          icon={FolderOpen}
+          active={[
+            { path: '/projects', end: false },
+            { path: '/engagements', end: false },
+          ]}
+        />
+        <NavItem to="/languages" label="Languages" icon={Translate} />
+        <NavItem to="/users" label="People" icon={Person} />
+        <NavItem to="/partners" label="Partners" icon={PeopleJoinedIcon} />
+      </List>
+    </div>
+  </>
+);
 
 const NavItem = ({
   icon: Icon,

--- a/src/scenes/SearchResults/SearchResults.tsx
+++ b/src/scenes/SearchResults/SearchResults.tsx
@@ -1,18 +1,23 @@
 import { useQuery } from '@apollo/client';
-import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
+import {
+  Build,
+  FolderOpen,
+  MenuBook,
+  Movie,
+  Palette,
+  Person,
+  Public,
+  Search,
+  Translate,
+} from '@mui/icons-material';
+import { Box, List, Stack } from '@mui/material';
 import { startCase } from 'lodash';
 import { ReactElement } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { FieldRegionCard } from '~/components/FieldRegionCard';
-import { FieldZoneCard } from '~/components/FieldZoneCard';
-import { ToolListItemCard } from '~/components/ToolListItemCard';
+import { PeopleJoinedIcon } from '~/components/Icons';
+import { EntityListItem } from '~/components/List';
 import { Error } from '../../components/Error';
-import { LanguageListItemCard } from '../../components/LanguageListItemCard';
-import { LocationCard } from '../../components/LocationCard';
-import { PartnerListItemCard } from '../../components/PartnerListItemCard';
-import { ProjectListItemCard } from '../../components/ProjectListItemCard';
 import { Navigate } from '../../components/Routing';
-import { UserListItemCardLandscape } from '../../components/UserListItemCard';
 import { useSearch } from '../Root/Header/HeaderSearch';
 import {
   SearchDocument,
@@ -47,42 +52,37 @@ export const SearchResults = () => {
       sx={(theme) => ({
         flex: 1,
         overflowY: 'auto',
-        padding: theme.spacing(4),
+        padding: { xs: theme.spacing(2), md: theme.spacing(4) },
       })}
     >
       <Helmet title={`${query} - Search`} />
       <Stack
         component="main"
         sx={{
-          gap: 2,
           maxWidth: 600,
         }}
       >
         {error ? (
           <Error error={error}>Error loading search results</Error>
-        ) : loading ? (
-          <>
-            <ProjectListItemCard />
-            <UserListItemCardLandscape />
-            <PartnerListItemCard />
-            <ToolListItemCard />
-            <ProjectListItemCard />
-            <PartnerListItemCard />
-            <UserListItemCardLandscape />
-            <FieldRegionCard />
-            <FieldZoneCard />
-          </>
-        ) : data && data.search.items.length > 0 ? (
-          data.search.items.map((item, _, list) => {
-            const res = displayItem(item);
-            return Array.isArray(res)
-              ? list.length === 1
-                ? res[0]
-                : res[1]
-              : res;
-          })
         ) : (
-          <Error show>No results found</Error>
+          <List disablePadding component="div">
+            {loading ? (
+              Array.from({ length: 8 }).map((_, index) => (
+                <EntityListItem key={index} loading icon={<Search />} />
+              ))
+            ) : data && data.search.items.length > 0 ? (
+              data.search.items.map((item, _, list) => {
+                const res = displayItem(item);
+                return Array.isArray(res)
+                  ? list.length === 1
+                    ? res[0]
+                    : res[1]
+                  : res;
+              })
+            ) : (
+              <Error show>No results found</Error>
+            )}
+          </List>
         )}
       </Stack>
     </Box>
@@ -91,7 +91,7 @@ export const SearchResults = () => {
 
 const displayItem = (
   item: SearchResult
-): [exact: string | ReactElement, card: ReactElement] | ReactElement | null => {
+): [exact: string | ReactElement, row: ReactElement] | ReactElement | null => {
   /* eslint-disable react/jsx-key -- type is tuple not array */
   switch (item.__typename) {
     case 'MomentumTranslationProject':
@@ -99,63 +99,122 @@ const displayItem = (
     case 'InternshipProject':
       return [
         <Navigate replace to={`/projects/${item.id}`} />,
-        <ProjectListItemCard key={item.id} project={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/projects/${item.id}`}
+          icon={<FolderOpen />}
+          primary={item.name.value}
+          secondary={item.primaryLocation.value?.name.value}
+        />,
       ];
     case 'Language':
       return [
         <Navigate replace to={`/languages/${item.id}`} />,
-        <LanguageListItemCard key={item.id} language={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/languages/${item.id}`}
+          icon={<Translate />}
+          primary={item.displayName.value}
+          secondary={item.ethnologue.code.value}
+        />,
       ];
     case 'User':
       return [
         <Navigate replace to={`/users/${item.id}`} />,
-        <UserListItemCardLandscape key={item.id} user={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/users/${item.id}`}
+          icon={<Person />}
+          primary={[item.displayFirstName.value, item.displayLastName.value]
+            .filter(Boolean)
+            .join(' ')}
+          secondary={item.title.value}
+        />,
       ];
     case 'Partner':
       return [
         <Navigate replace to={`/partners/${item.id}`} />,
-        <PartnerListItemCard key={item.id} partner={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/partners/${item.id}`}
+          icon={<PeopleJoinedIcon />}
+          primary={
+            item.organization.value?.acronym.value ??
+            item.organization.value?.name.value
+          }
+          secondary={
+            item.organization.value?.acronym.value
+              ? item.organization.value.name.value
+              : undefined
+          }
+        />,
       ];
     case 'Location':
       return [
         <Navigate replace to={`/locations/${item.id}`} />,
-        <LocationCard key={item.id} location={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/locations/${item.id}`}
+          icon={<Public />}
+          primary={item.name.value}
+          secondary={item.locationType.value}
+        />,
       ];
     case 'FieldRegion':
       return [
         <Navigate replace to={`/field-regions/${item.id}`} />,
-        <FieldRegionCard key={item.id} fieldRegion={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/field-regions/${item.id}`}
+          icon={<Public />}
+          primary={item.name.value}
+          secondary={item.director.value?.fullName}
+        />,
       ];
     case 'FieldZone':
       return [
         <Navigate replace to={`/field-zones/${item.id}`} />,
-        <FieldZoneCard key={item.id} fieldZone={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/field-zones/${item.id}`}
+          icon={<Public />}
+          primary={item.name.value}
+          secondary={item.director.value?.fullName}
+        />,
       ];
     case 'Tool':
       return [
         <Navigate replace to={`/tools/${item.id}`} />,
-        <ToolListItemCard key={item.id} tool={item} />,
+        <EntityListItem
+          key={item.id}
+          to={`/tools/${item.id}`}
+          icon={<Build />}
+          primary={item.name.value}
+          secondary={item.description.value}
+        />,
       ];
     case 'Film':
     case 'Story':
     case 'EthnoArt':
-      return <PlaceholderCard key={item.id} item={item} />;
+      return (
+        <EntityListItem
+          key={item.id}
+          icon={
+            item.__typename === 'Film' ? (
+              <Movie />
+            ) : item.__typename === 'Story' ? (
+              <MenuBook />
+            ) : (
+              <Palette />
+            )
+          }
+          primary={item.name.value}
+          secondary={startCase(item.__typename)}
+        />
+      );
     default:
       console.error(`Unknown type ${item.__typename} returned from search`);
       return null;
   }
   /* eslint-enable react/jsx-key */
 };
-
-const PlaceholderCard = ({
-  item,
-}: {
-  item: Extract<SearchResult, { name: unknown }>;
-}) => (
-  <Card>
-    <CardContent>
-      <Typography variant="h4">{startCase(item.__typename)}</Typography>
-      <Typography>{item.name.value}</Typography>
-    </CardContent>
-  </Card>
-);

--- a/src/scenes/SearchResults/SearchResults.tsx
+++ b/src/scenes/SearchResults/SearchResults.tsx
@@ -98,7 +98,7 @@ const displayItem = (
     case 'MultiplicationTranslationProject':
     case 'InternshipProject':
       return [
-        <Navigate replace to={`/projects/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/projects/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/projects/${item.id}`}
@@ -109,7 +109,7 @@ const displayItem = (
       ];
     case 'Language':
       return [
-        <Navigate replace to={`/languages/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/languages/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/languages/${item.id}`}
@@ -120,7 +120,7 @@ const displayItem = (
       ];
     case 'User':
       return [
-        <Navigate replace to={`/users/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/users/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/users/${item.id}`}
@@ -133,7 +133,7 @@ const displayItem = (
       ];
     case 'Partner':
       return [
-        <Navigate replace to={`/partners/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/partners/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/partners/${item.id}`}
@@ -151,7 +151,7 @@ const displayItem = (
       ];
     case 'Location':
       return [
-        <Navigate replace to={`/locations/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/locations/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/locations/${item.id}`}
@@ -162,7 +162,7 @@ const displayItem = (
       ];
     case 'FieldRegion':
       return [
-        <Navigate replace to={`/field-regions/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/field-regions/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/field-regions/${item.id}`}
@@ -173,7 +173,7 @@ const displayItem = (
       ];
     case 'FieldZone':
       return [
-        <Navigate replace to={`/field-zones/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/field-zones/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/field-zones/${item.id}`}
@@ -184,7 +184,7 @@ const displayItem = (
       ];
     case 'Tool':
       return [
-        <Navigate replace to={`/tools/${item.id}`} />,
+        <Navigate key={item.id} replace to={`/tools/${item.id}`} />,
         <EntityListItem
           key={item.id}
           to={`/tools/${item.id}`}

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/EngagementPanel.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/EngagementPanel.tsx
@@ -1,9 +1,11 @@
 import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { EngagementListInput } from '~/api/schema.graphql';
+import { useIsMobile } from '~/common';
 import {
   EngagementDataGridRowFragment as Engagement,
   EngagementColumns,
   EngagementInitialState,
+  engagementName,
   EngagementToolbar,
   useProcessEngagementUpdate,
 } from '~/components/EngagementDataGrid';
@@ -15,6 +17,8 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as ToolsEngagementsList } from '~/components/List';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import { EngagementListDocument } from '../../../../../Projects/List/EngagementList.graphql';
 
@@ -22,15 +26,36 @@ interface EngagementPanelProps {
   toolId: string;
 }
 
+const engagementFilter = (toolId: string) =>
+  ({ filter: { tool: { id: toolId } } } satisfies EngagementListInput);
+
 export const EngagementPanel = ({ toolId }: EngagementPanelProps) => {
+  const isMobile = useIsMobile();
+  return isMobile ? (
+    <ToolsEngagementsList
+      query={EngagementListDocument}
+      listAt={(data) => data.engagements}
+      variables={{ input: engagementFilter(toolId) }}
+      columns={EngagementColumns}
+      sortDefault={{ field: EngagementColumns[0]!.field, direction: 'ASC' }}
+      defaultSecondaryField="project.name"
+      primary={engagementName}
+      to={(engagement) => `/engagements/${engagement.id}`}
+      avatar={(engagement) => (
+        <SensitivityIcon value={engagement.project.sensitivity} />
+      )}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <EngagementPanelGrid toolId={toolId} />
+  );
+};
+
+const EngagementPanelGrid = ({ toolId }: EngagementPanelProps) => {
   const [dataGridProps] = useDataGridSource({
     query: EngagementListDocument,
     variables: {
-      input: {
-        filter: {
-          tool: { id: toolId },
-        },
-      } satisfies EngagementListInput,
+      input: engagementFilter(toolId),
     },
     listAt: 'engagements',
     initialInput: {

--- a/src/scenes/Tools/Detail/Tabs/Usages/Panels/ProjectPanel.tsx
+++ b/src/scenes/Tools/Detail/Tabs/Usages/Panels/ProjectPanel.tsx
@@ -1,5 +1,6 @@
 import { DataGridPro as DataGrid } from '@mui/x-data-grid-pro';
 import { ProjectListInput } from '~/api/schema.graphql';
+import { useIsMobile } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
@@ -8,12 +9,14 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as ToolsProjectsList } from '~/components/List';
 import {
   ProjectDataGridRowFragment as Project,
   ProjectColumns,
   ProjectInitialState,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
 import { TabPanelContent } from '~/components/Tabs';
 import { ProjectListDocument } from '../../../../../Projects/List/ProjectList.graphql';
 
@@ -21,15 +24,34 @@ interface ProjectPanelProps {
   toolId: string;
 }
 
+const projectFilter = (toolId: string) =>
+  ({ filter: { tool: { id: toolId } } } satisfies ProjectListInput);
+
 export const ProjectPanel = ({ toolId }: ProjectPanelProps) => {
+  const isMobile = useIsMobile();
+  return isMobile ? (
+    <ToolsProjectsList
+      query={ProjectListDocument}
+      listAt={(data) => data.projects}
+      variables={{ input: projectFilter(toolId) }}
+      columns={ProjectColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="primaryLocation.name"
+      primary={(project) => project.name.value}
+      to={(project) => `/projects/${project.id}`}
+      avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <ProjectPanelGrid toolId={toolId} />
+  );
+};
+
+const ProjectPanelGrid = ({ toolId }: ProjectPanelProps) => {
   const [dataGridProps] = useDataGridSource({
     query: ProjectListDocument,
     variables: {
-      input: {
-        filter: {
-          tool: { id: toolId },
-        },
-      } satisfies ProjectListInput,
+      input: projectFilter(toolId),
     },
     listAt: 'projects',
     initialInput: {

--- a/src/scenes/Tools/Detail/ToolDetail.tsx
+++ b/src/scenes/Tools/Detail/ToolDetail.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
 import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -10,7 +10,7 @@ import { useDialog } from '~/components/Dialog';
 import { Error } from '~/components/Error';
 import { IconButton } from '~/components/IconButton';
 import { Redacted } from '~/components/Redacted';
-import { Tab, TabsContainer } from '~/components/Tabs';
+import { Tab, TabList, TabsContainer } from '~/components/Tabs';
 import { EditTool } from '~/components/Tool';
 import { useDetailTabs } from '~/hooks';
 import { ToolDetailProfile } from './Tabs/Profile/ToolDetailProfile';

--- a/src/scenes/Users/Detail/Tabs/Partners/UserDetailPartners.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserDetailPartners.tsx
@@ -1,14 +1,11 @@
-import { TabPanelContent } from '~/components/Tabs';
 import { UserPartnersPanel } from './UserPartnerPanel/UserPartnersPanel';
 
 interface UserDetailPartnersProps {
   canCreate: boolean;
 }
 
-export const UserDetailPartners = ({ canCreate }: UserDetailPartnersProps) => {
-  return (
-    <TabPanelContent>
-      <UserPartnersPanel canCreate={canCreate} />
-    </TabPanelContent>
-  );
-};
+// The Paper (TabPanelContent) lives in the panel's desktop grid branch so the
+// mobile row list renders bare.
+export const UserDetailPartners = ({ canCreate }: UserDetailPartnersProps) => (
+  <UserPartnersPanel canCreate={canCreate} />
+);

--- a/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Partners/UserPartnerPanel/UserPartnersPanel.tsx
@@ -4,6 +4,7 @@ import { IconButton, Tooltip } from '@mui/material';
 import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { useIsMobile } from '~/common';
 import { useDialog } from '~/components/Dialog';
 import {
   createAddItemFooter,
@@ -14,12 +15,15 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as UsersPartnersList } from '~/components/List';
 import {
   PartnerColumns,
   PartnerInitialState,
   PartnerToolbar,
 } from '~/components/PartnersDataGrid/PartnerColumns';
 import type { PartnerDataGridRowFragment as UserPartner } from '~/components/PartnersDataGrid/partnerDataGridRow.graphql';
+import { renderPartnerRow } from '~/components/PartnersDataGrid/renderPartnerRow';
+import { TabPanelContent } from '~/components/Tabs';
 import { AddOrganizationToUserForm } from '../AddOrganizationToUserForm';
 import {
   RemoveOrganizationFromUserDocument,
@@ -31,6 +35,25 @@ interface UserPartnersPanelProps {
 }
 
 export const UserPartnersPanel = ({ canCreate }: UserPartnersPanelProps) => {
+  const { userId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <UsersPartnersList
+      query={UserPartnersDocument}
+      listAt={(data) => data.user.partners}
+      variables={{ userId }}
+      columns={PartnerColumns}
+      sortDefault={{ field: 'organization.name', direction: 'ASC' }}
+      renderItem={renderPartnerRow}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <UserPartnersGrid canCreate={canCreate} />
+  );
+};
+
+const UserPartnersGrid = ({ canCreate }: UserPartnersPanelProps) => {
   const { userId = '' } = useParams();
   const [addPartnerState, openAddPartner] = useDialog();
 
@@ -94,7 +117,7 @@ export const UserPartnersPanel = ({ canCreate }: UserPartnersPanelProps) => {
   });
 
   return (
-    <>
+    <TabPanelContent>
       <DataGrid<UserPartner>
         {...DefaultDataGridStyles}
         {...dataGridProps}
@@ -109,6 +132,6 @@ export const UserPartnersPanel = ({ canCreate }: UserPartnersPanelProps) => {
       {canCreate && (
         <AddOrganizationToUserForm userId={userId} {...addPartnerState} />
       )}
-    </>
+    </TabPanelContent>
   );
 };

--- a/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
+++ b/src/scenes/Users/Detail/Tabs/Profile/UserDetailProfile.tsx
@@ -19,7 +19,8 @@ export const UserDetailProfile = ({ user }: UserDetailProfileProps) => {
     <Box
       component={Paper}
       sx={(theme) => ({
-        width: theme.breakpoints.values.md,
+        width: '100%',
+        maxWidth: theme.breakpoints.values.md,
       })}
     >
       <Stack

--- a/src/scenes/Users/Detail/Tabs/Projects/UserDetailProjects.tsx
+++ b/src/scenes/Users/Detail/Tabs/Projects/UserDetailProjects.tsx
@@ -1,10 +1,5 @@
-import { TabPanelContent } from '~/components/Tabs';
 import { UserProjectsPanel } from './UserProjectPanel/UserProjectsPanel';
 
-export const UserDetailProjects = () => {
-  return (
-    <TabPanelContent>
-      <UserProjectsPanel />
-    </TabPanelContent>
-  );
-};
+// The Paper (TabPanelContent) lives in the panel's desktop grid branch so the
+// mobile row list renders bare.
+export const UserDetailProjects = () => <UserProjectsPanel />;

--- a/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectsPanel.tsx
+++ b/src/scenes/Users/Detail/Tabs/Projects/UserProjectPanel/UserProjectsPanel.tsx
@@ -1,6 +1,7 @@
 import { DataGridPro as DataGrid, GridColDef } from '@mui/x-data-grid-pro';
 import { useParams } from 'react-router-dom';
 import { RoleLabels, RoleList } from '~/api/schema.graphql';
+import { useIsMobile } from '~/common';
 import {
   DefaultDataGridStyles,
   flexLayout,
@@ -10,6 +11,7 @@ import {
   useDataGridSlots,
   useDataGridSource,
 } from '~/components/Grid';
+import { EntityList as UsersProjectsList } from '~/components/List';
 import {
   insertProjectColumnAfterField,
   ProjectDataGridRowFragment as Project,
@@ -18,12 +20,36 @@ import {
   ProjectNameField,
   ProjectToolbar,
 } from '~/components/ProjectDataGrid';
+import { SensitivityIcon } from '~/components/Sensitivity';
+import { TabPanelContent } from '~/components/Tabs';
 import {
   UserProjectDataGridRowFragment as UserProject,
   UserProjectsDocument,
 } from './UserProjectList.graphql';
 
 export const UserProjectsPanel = () => {
+  const { userId = '' } = useParams();
+  const isMobile = useIsMobile();
+
+  return isMobile ? (
+    <UsersProjectsList
+      query={UserProjectsDocument}
+      listAt={(data) => data.user.projects}
+      variables={{ userId }}
+      columns={UserProjectColumns}
+      sortDefault={{ field: 'name', direction: 'ASC' }}
+      defaultSecondaryField="primaryLocation.name"
+      primary={(project) => project.name.value}
+      to={(project) => `/projects/${project.id}`}
+      avatar={(project) => <SensitivityIcon value={project.sensitivity} />}
+    />
+  ) : (
+    // The grid (and its `useDataGridSource`) must only mount on desktop.
+    <UserProjectsGrid />
+  );
+};
+
+const UserProjectsGrid = () => {
   const { userId = '' } = useParams();
 
   const [dataGridProps] = useDataGridSource({
@@ -40,17 +66,19 @@ export const UserProjectsPanel = () => {
   });
 
   return (
-    <DataGrid<UserProject>
-      {...DefaultDataGridStyles}
-      {...dataGridProps}
-      slots={slots}
-      slotProps={slotProps}
-      columns={UserProjectColumns}
-      initialState={ProjectInitialState}
-      headerFilters
-      hideFooter
-      sx={[flexLayout, noHeaderFilterButtons, noFooter]}
-    />
+    <TabPanelContent>
+      <DataGrid<UserProject>
+        {...DefaultDataGridStyles}
+        {...dataGridProps}
+        slots={slots}
+        slotProps={slotProps}
+        columns={UserProjectColumns}
+        initialState={ProjectInitialState}
+        headerFilters
+        hideFooter
+        sx={[flexLayout, noHeaderFilterButtons, noFooter]}
+      />
+    </TabPanelContent>
   );
 };
 

--- a/src/scenes/Users/Detail/UserDetail.tsx
+++ b/src/scenes/Users/Detail/UserDetail.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@apollo/client';
 import { Edit } from '@mui/icons-material';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabPanel } from '@mui/lab';
 import { Box, Skeleton, Stack, Tooltip, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
@@ -11,7 +11,7 @@ import { useDialog } from '~/components/Dialog';
 import { Error } from '~/components/Error';
 import { IconButton } from '~/components/IconButton';
 import { Redacted } from '~/components/Redacted';
-import { Tab, TabsContainer } from '~/components/Tabs';
+import { Tab, TabList, TabsContainer } from '~/components/Tabs';
 import { TogglePinButton } from '~/components/TogglePinButton';
 import { UserPhoto } from '~/components/UserPhoto';
 import { useDetailTabs } from '~/hooks';
@@ -44,7 +44,7 @@ export const UserDetail = () => {
       component="main"
       sx={{
         overflowY: 'auto',
-        p: 4,
+        p: { xs: 2, md: 4 },
         gap: 3,
         flex: 1,
         maxWidth: (theme) => theme.breakpoints.values.xl,
@@ -63,6 +63,8 @@ export const UserDetail = () => {
           <Box
             sx={{
               display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
               gap: 1,
             }}
           >
@@ -71,6 +73,7 @@ export const UserDetail = () => {
               sx={{
                 mr: 2,
                 lineHeight: 'inherit',
+                minWidth: 0,
               }}
             >
               {!user ? (

--- a/src/scenes/Users/List/UserList.tsx
+++ b/src/scenes/Users/List/UserList.tsx
@@ -1,28 +1,46 @@
 import { Paper, Stack, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
+import { useIsMobile } from '~/common';
+import { EntityList as UsersList } from '~/components/List';
+import { UserColumns } from '~/components/UserDataGrid/UserColumns';
 import { UserGrid } from './UserGrid';
+import { UsersDocument } from './users.graphql';
 
 export const UserList = () => {
+  const isMobile = useIsMobile();
   return (
-    <Stack sx={{ flex: 1, padding: 4, pt: 2 }}>
+    <Stack sx={{ flex: 1, padding: { xs: 2, md: 4 }, pt: 2 }}>
       <Helmet title="People" />
       <Stack component="main" sx={{ flex: 1 }}>
         <Typography variant="h2" paragraph>
           People
         </Typography>
-        <Stack sx={{ flex: 1, containerType: 'size' }}>
-          <Paper
-            sx={{
-              flex: 1,
-              minHeight: 375,
-              maxHeight: '100cqh',
-              width: 'min-content',
-              maxWidth: '100cqw',
-            }}
-          >
-            <UserGrid />
-          </Paper>
-        </Stack>
+        {isMobile ? (
+          <UsersList
+            query={UsersDocument}
+            listAt={(data) => data.users}
+            columns={UserColumns}
+            sortDefault={{ field: 'fullName', direction: 'ASC' }}
+            defaultSecondaryField="title"
+            primary={(user) => user.fullName}
+            to={(user) => `/users/${user.id}`}
+          />
+        ) : (
+          // The grid (and its `useDataGridSource`) must only mount on desktop.
+          <Stack sx={{ flex: 1, containerType: 'size' }}>
+            <Paper
+              sx={{
+                flex: 1,
+                minHeight: 375,
+                maxHeight: '100cqh',
+                width: 'min-content',
+                maxWidth: '100cqw',
+              }}
+            >
+              <UserGrid />
+            </Paper>
+          </Stack>
+        )}
       </Stack>
     </Stack>
   );

--- a/src/theme/createTheme.ts
+++ b/src/theme/createTheme.ts
@@ -1,6 +1,7 @@
 import {
   createTheme as createMuiTheme,
   Theme as MuiTheme,
+  responsiveFontSizes,
 } from '@mui/material/styles';
 import { appComponents } from './overrides';
 import { createPalette } from './palette';
@@ -19,7 +20,9 @@ export const createTheme = ({ dark }: { dark?: boolean } = {}) => {
     components: appComponents(theme),
   });
 
-  return theme;
+  // Scale down large headings on smaller viewports so they don't dominate
+  // the screen on mobile (h1 44px / h2 32px are sized for desktop).
+  return responsiveFontSizes(theme);
 };
 
 // Communicate emotion's theme is MUI theme, which <ThemeProvider> does

--- a/src/theme/overrides.ts
+++ b/src/theme/overrides.ts
@@ -53,6 +53,24 @@ export const appComponents = ({
         },
       },
     },
+    MuiIconButton: {
+      styleOverrides: {
+        // Ensure comfortable tap targets on touch devices without enlarging
+        // the intentionally-dense `size="small"` buttons.
+        sizeMedium: {
+          '@media (pointer: coarse)': {
+            minWidth: 44,
+            minHeight: 44,
+          },
+        },
+        sizeLarge: {
+          '@media (pointer: coarse)': {
+            minWidth: 48,
+            minHeight: 48,
+          },
+        },
+      },
+    },
     MuiFab: {
       defaultProps: {
         size: 'small',


### PR DESCRIPTION
## Summary
This PR makes the app usable below the `md` breakpoint (< 900px) end to end.

Everything is **additive and gated behind a single `useIsMobile()` hook** — the
desktop render path is unchanged, so there's no behavior change ≥ 900px.

## How it works

- **`useIsMobile()`** (`md`, `noSsr`) is the one breakpoint check; scenes swap
  desktop ↔ mobile with an inline `isMobile ? … : …` ternary (no wrapper).
- Data grids become a reusable dense list (**`EntityList`** / **`EntityListItem`**)
  whose filter/sort drawer + labeled secondary line are **derived from the grid's
  own column defs**, so they stay in sync with the grid for free.
- Tabbed pages use a responsive **`TabList`** (the MUI tabs on desktop, a dropdown
  `Select` on mobile).

## What's included (reviewable commit-by-commit)

1. **`useIsMobile` + reusable mobile list engine** — the hook plus `EntityList`,
   `ListItemRow`, the column→filter/sort/secondary adapters, `usePagedListQuery`,
   and grid column-hiding helpers (+ unit tests).
2. **Responsive Tabs** — `TabList` dropdown on mobile, rolled out to every tabbed
   detail page.
3. **Responsive app shell** — sidebar → drawer w/ hamburger, header, notifications
   collapsed into the avatar, theme touch-targets + responsive headings.
4. **Grids → dense row lists** — across Partners/Projects/Engagements/Languages/
   Users lists and every detail-page tab.
5. **Dialogs/comments/search/dashboard** — full-screen `DialogForm`, overlay
   `CommentsBar`, `SearchResults` rows, dashboard widget stacking.
6. **Detail-page polish** — intern engagement page (stacked cards) and the
   progress report edit form (single-column collapse + top "Back To Overview").

## Reviewing notes

- The 6 commits are dependency-ordered and **each type-checks in isolation**, so
  the PR can be reviewed (and bisected) one commit at a time.
- No changes to the desktop layout — diffs are mostly new mobile branches.