### PR TITLE
Mobile fix: list filter/sort persistence, expanded-widget scroll, split overview cards

### DIFF
--- a/src/components/List/EntityList.tsx
+++ b/src/components/List/EntityList.tsx
@@ -1,9 +1,11 @@
+import { getOperationName } from '@apollo/client/utilities';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { Box, Typography } from '@mui/material';
 import { GridColDef } from '@mui/x-data-grid-pro';
 import { ReactNode, useMemo } from 'react';
 import { Entity, PaginatedListOutput } from '~/api';
 import { FormattedNumber } from '../Formatters';
+import { useSession } from '../Session/Session';
 import { EntityListItem } from './EntityListItem';
 import {
   columnsToFilterControls,
@@ -72,10 +74,20 @@ export function EntityList<Data, Item extends Entity>({
     [columns]
   );
   const sortOptions = useMemo(() => columnsToSortOptions(columns), [columns]);
-  const { filter, sort, order } = useRowListFilters(filterControls, {
-    options: sortOptions,
-    default: sortDefault,
-  });
+
+  // Persist filter/sort per user + list, mirroring the data grid's stored view.
+  const { session } = useSession();
+  const opName = useMemo(() => getOperationName(query), [query]);
+  const storageKey =
+    opName && session?.id
+      ? `${session.id}:${opName}-mobile-list-view`
+      : undefined;
+
+  const { filter, sort, order } = useRowListFilters(
+    filterControls,
+    { options: sortOptions, default: sortDefault },
+    storageKey
+  );
 
   // Merge the drawer's filter with any base scoping filter (e.g. a tool filter),
   // rather than overwriting it.

--- a/src/components/List/MobileFilters.tsx
+++ b/src/components/List/MobileFilters.tsx
@@ -13,7 +13,7 @@ import {
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
-import { useDebounce } from 'ahooks';
+import { useDebounce, useLatest, useLocalStorageState } from 'ahooks';
 import { mergeWith } from 'lodash';
 import {
   createContext,
@@ -35,6 +35,17 @@ import {
 
 type FilterValues = Record<string, unknown>;
 
+/**
+ * The persisted (localStorage) shape of a mobile list's view, mirroring the data
+ * grid's stored view. Free-text `search` filters are intentionally excluded on
+ * save (see {@link useRowListFilters}), matching the grid which only persists
+ * select/boolean columns.
+ */
+interface StoredMobileView {
+  values?: FilterValues;
+  sort?: SortState;
+}
+
 interface MobileFilterState {
   controls: readonly FilterControl[];
   values: FilterValues;
@@ -42,7 +53,8 @@ interface MobileFilterState {
   clearAll: () => void;
   register: (
     controls: readonly FilterControl[],
-    sort?: SortConfig & { key: string }
+    sort?: SortConfig & { key: string },
+    initial?: StoredMobileView
   ) => void;
   unregister: () => void;
   sortOptions: readonly SortOption[];
@@ -71,11 +83,13 @@ export const MobileFilterProvider = ({ children }: { children: ReactNode }) => {
   );
 
   const register = useCallback<MobileFilterState['register']>(
-    (next, sortCfg) => {
+    (next, sortCfg, initial) => {
       setControls(next);
-      setValues({});
+      // Seed from the persisted view (if any) so filters/sort survive navigation
+      // and reloads, falling back to empty / the list's default sort.
+      setValues(initial?.values ?? {});
       setSortOptions(sortCfg?.options ?? []);
-      setSort(sortCfg?.default);
+      setSort(initial?.sort ?? sortCfg?.default);
       setDefaultSort(sortCfg?.default);
       setSortKey(sortCfg?.key ?? '');
     },
@@ -162,15 +176,20 @@ const buildFilter = (
  * Mobile filtering for a dense row list. Registers `controls` with the app shell
  * (so the header filter button can drive them) and returns the merged API `filter`
  * for `useListQuery`. Returns `undefined` when nothing is selected.
+ *
+ * When a `storageKey` is supplied, the active filter values and sort persist to
+ * localStorage (mirroring the data grid's view persistence) so they survive
+ * navigation and reloads. Free-text `search` filters are NOT persisted, matching
+ * the grid, which only persists select/boolean columns.
  */
 export const useRowListFilters = (
   controls: readonly FilterControl[],
-  sort?: SortConfig
+  sort?: SortConfig,
+  storageKey?: string
 ) => {
   const ctx = useContext(MobileFilterContext);
   const register = ctx?.register;
   const unregister = ctx?.unregister;
-  const values = ctx?.values;
 
   const keysSig = controls.map((c) => c.key).join('|');
   const optionsSig = sort?.options.map((o) => o.field).join('|') ?? '';
@@ -180,24 +199,56 @@ export const useRowListFilters = (
     ? `${optionsSig}#${sort.default.field}:${sort.default.direction}`
     : '';
 
+  const persistEnabled = !!storageKey;
+  const [storedView, setStoredView] = useLocalStorageState<StoredMobileView>(
+    storageKey ?? 'mobile-list-view:unscoped',
+    { defaultValue: {} }
+  );
+  const stored = persistEnabled ? storedView : undefined;
+  // Read the persisted view at register time without re-registering on every save.
+  const storedRef = useLatest(stored);
+
   useEffect(() => {
-    register?.(controls, sort ? { ...sort, key: sortKey } : undefined);
+    register?.(
+      controls,
+      sort ? { ...sort, key: sortKey } : undefined,
+      storedRef.current
+    );
     return () => unregister?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- keysSig/sortKey capture the meaningful change
   }, [keysSig, sortKey, register, unregister]);
 
-  const filter = useMemo(
-    () => buildFilter(controls, values ?? {}),
+  // Persist filter/sort changes back to storage while THIS list is the active
+  // registration. `search` (free-text) values are stripped, matching the grid.
+  useEffect(() => {
+    if (!persistEnabled || ctx?.sortKey !== sortKey) {
+      return;
+    }
+    const persistable = Object.fromEntries(
+      Object.entries(ctx.values).filter(([key]) => {
+        const control = controls.find((c) => c.key === key);
+        return control && control.kind !== 'search';
+      })
+    );
+    setStoredView({ values: persistable, sort: ctx.sort });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- keysSig captures the meaningful change
-    [keysSig, values]
+  }, [persistEnabled, ctx?.values, ctx?.sort, ctx?.sortKey, sortKey, keysSig]);
+
+  // Use the shared state only when it belongs to THIS list (matching sortKey).
+  // On first render — before this list registers — the context still holds the
+  // previous list's state, so fall back to the persisted view (then our own
+  // default) and never query with stale/foreign filters or sort.
+  const isActive = ctx?.sortKey === sortKey;
+  const activeValues = isActive ? ctx.values : stored?.values;
+
+  const filter = useMemo(
+    () => buildFilter(controls, activeValues ?? {}),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keysSig captures the meaningful change
+    [keysSig, activeValues]
   );
 
-  // Use the shared sort only when it belongs to THIS list (matching sortKey).
-  // On first render — before this list registers — the context still holds the
-  // previous list's sort, so fall back to our own default and never query with a
-  // stale/foreign sort.
   const effectiveSort =
-    ctx?.sortKey === sortKey && ctx.sort ? ctx.sort : sort?.default;
+    isActive && ctx.sort ? ctx.sort : stored?.sort ?? sort?.default;
 
   return {
     filter,

--- a/src/scenes/Dashboard/Dashboard.tsx
+++ b/src/scenes/Dashboard/Dashboard.tsx
@@ -24,19 +24,29 @@ const MainDashboard = () => (
   </WidgetGrid>
 );
 
+// `minHeight: 0` lets the widget shrink to the available height (instead of its
+// default `min-height: auto` growing to content). That gives the widget — and so
+// its `containerType: size` table — a definite size, the same way the compact
+// grid cell does, so the expanded DataGrid scrolls internally (left/right and
+// up/down) rather than overflowing.
 const ExpandedProgressReports = () => (
-  <Stack sx={{ flex: 1 }}>
+  <Stack sx={{ flex: 1, minHeight: 0 }}>
     <ProgressReportsWidget
       colSpan={12}
       rowSpan={12}
       expanded
-      sx={{ flex: 1 }}
+      sx={{ flex: 1, minHeight: 0 }}
     />
   </Stack>
 );
 
 const ExpandedPnpProblems = () => (
-  <Stack sx={{ flex: 1 }}>
-    <PnpProblemsWidget colSpan={12} rowSpan={12} expanded sx={{ flex: 1 }} />
+  <Stack sx={{ flex: 1, minHeight: 0 }}>
+    <PnpProblemsWidget
+      colSpan={12}
+      rowSpan={12}
+      expanded
+      sx={{ flex: 1, minHeight: 0 }}
+    />
   </Stack>
 );

--- a/src/scenes/Projects/Overview/ProjectOverview.tsx
+++ b/src/scenes/Projects/Overview/ProjectOverview.tsx
@@ -10,7 +10,15 @@ import {
   Publish,
   Timeline as TimelineIcon,
 } from '@mui/icons-material';
-import { Box, Chip, Grid, Skeleton, Tooltip, Typography } from '@mui/material';
+import {
+  Box,
+  Card,
+  Chip,
+  Grid,
+  Skeleton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { Many } from '@seedcompany/common';
 import { useDropzone } from 'react-dropzone';
 import { Helmet } from 'react-helmet-async';
@@ -19,7 +27,6 @@ import { ProjectStepLabels, ProjectTypeLabels } from '~/api/schema.graphql';
 import { labelFrom } from '~/common';
 import { ToggleCommentsButton } from '~/components/Comments/ToggleCommentButton';
 import { BudgetOverviewCard } from '../../../components/BudgetOverviewCard';
-import { CardGroup } from '../../../components/CardGroup';
 import { ChangesetPropertyBadge } from '../../../components/Changeset';
 import { useComments } from '../../../components/Comments/CommentsContext';
 import { DataButton } from '../../../components/DataButton';
@@ -518,10 +525,18 @@ export const ProjectOverview = () => {
             </Grid>
           </Grid>
 
-          <CardGroup horizontal="mdUp">
-            <ProjectMembersSummary project={project} />
-            <PartnershipSummary partnerships={project?.partnerships} />
-          </CardGroup>
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
+              <Card sx={{ height: '100%' }}>
+                <ProjectMembersSummary project={project} />
+              </Card>
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <Card sx={{ height: '100%' }}>
+                <PartnershipSummary partnerships={project?.partnerships} />
+              </Card>
+            </Grid>
+          </Grid>
 
           {beta.has('projectChangeRequests') && (
             <Grid container spacing={3}>


### PR DESCRIPTION
## Changes

### Mobile lists now persist filter & sort (like the data grid)
The dense mobile lists discarded filter/sort on navigation, unlike the desktop
grid which persists them. `EntityList` now derives its operation name (via
Apollo's `getOperationName`) and scopes a `${userId}:${opName}-mobile-list-view`
localStorage key — the same per-user/per-operation scheme as the grid's
`useViewState`. `useRowListFilters` restores values + sort on register and writes
them back on change. Free-text `search` is intentionally not persisted, matching
the grid (which only persists select/boolean columns).

### Expanded dashboard widget scrolls horizontally
The compact widget scrolls left/right because its grid cell is definite-sized,
satisfying `TableWidget`'s `containerType: size`. Expanded, the widget was a
`flex: 1` child of a scrolling column with the default `min-height: auto`, so its
height was indefinite and the DataGrid couldn't scroll internally. Added
`minHeight: 0` to the expanded wrappers so it gets a definite size like the
compact cell.

### Team Members & Partnerships are now separate, responsive cards
Replaced the combined `CardGroup` on the Project Overview with two `Card`s in a
`Grid container` (`xs={12} md={6}`), matching the Budget/Files and report card
pairs — they stack on mobile and sit side-by-side on desktop. `MemberListSummary`
is unchanged (its contract is "content inside a consumer-provided Card").