### PR TITLE
Fix: show final notes on progress report status card

### DIFF
--- a/src/components/RichText/RichTextField.tsx
+++ b/src/components/RichText/RichTextField.tsx
@@ -358,7 +358,7 @@ const isEditorEmpty = (ref: RefObject<HTMLElement>) =>
   // If not the default block, then assume there are more actions the remaining block could take.
   !!ref.current.querySelector('.codex-editor .ce-block .ce-paragraph');
 
-const isDataEmpty = (value: Nullable<RichTextData>) =>
+export const isDataEmpty = (value: Nullable<RichTextData>) =>
   !value || value.blocks.length === 0;
 
 const isRichTextEqual = (

--- a/src/scenes/ProgressReports/Detail/WorkflowCard.tsx
+++ b/src/scenes/ProgressReports/Detail/WorkflowCard.tsx
@@ -6,7 +6,7 @@ import {
   Typography,
 } from '@mui/material';
 import { RelativeDateTime } from '~/components/Formatters';
-import { RichTextView } from '~/components/RichText';
+import { isDataEmpty, RichTextView } from '~/components/RichText';
 import { ButtonLink } from '~/components/Routing';
 import { ProgressReportDetailFragment } from './ProgressReportDetail.graphql';
 import { StatusStepper } from './StatusStepper';
@@ -22,7 +22,7 @@ export const WorkflowCard = ({ report, ...rest }: WorkflowCardProps) => {
   const lastNotes = report?.workflowEvents
     .slice()
     .reverse()
-    .find((e) => e.notes.value)?.notes.value;
+    .find((e) => !isDataEmpty(e.notes.value))?.notes.value;
   return (
     <Card {...rest}>
       <Typography variant="h3" sx={{ pl: 2, pt: 2 }}>

--- a/src/scenes/ProgressReports/Detail/WorkflowCard.tsx
+++ b/src/scenes/ProgressReports/Detail/WorkflowCard.tsx
@@ -1,5 +1,12 @@
-import { Card, CardActions, CardProps, Typography } from '@mui/material';
+import {
+  Card,
+  CardActions,
+  CardContent,
+  CardProps,
+  Typography,
+} from '@mui/material';
 import { RelativeDateTime } from '~/components/Formatters';
+import { RichTextView } from '~/components/RichText';
 import { ButtonLink } from '~/components/Routing';
 import { ProgressReportDetailFragment } from './ProgressReportDetail.graphql';
 import { StatusStepper } from './StatusStepper';
@@ -12,12 +19,24 @@ export const WorkflowCard = ({ report, ...rest }: WorkflowCardProps) => {
   const lastWorkflowEvent = report?.workflowEvents.at(
     report.workflowEvents.length - 1
   );
+  const lastNotes = report?.workflowEvents
+    .slice()
+    .reverse()
+    .find((e) => e.notes.value)?.notes.value;
   return (
     <Card {...rest}>
       <Typography variant="h3" sx={{ pl: 2, pt: 2 }}>
         Status
       </Typography>
       <StatusStepper loading={!report} current={report?.status.value} />
+      {lastNotes && (
+        <CardContent>
+          <Typography variant="overline" color="text.secondary">
+            Final Notes
+          </Typography>
+          <RichTextView data={lastNotes} />
+        </CardContent>
+      )}
       {lastWorkflowEvent && (
         <CardActions
           sx={{


### PR DESCRIPTION
## Summary
- The "Final Notes" field on a progress report's status transition (entered on the Submit Report step) persisted to the backend but had no UI surface to display it.
- `WorkflowCard` now finds the most recent workflow event with notes and renders them in a "Final Notes" section below the status stepper.

Closes #1851

## Test plan
- [x] Submitted a report transition with text in "Final Notes"
- [x] Confirmed the note renders under the status stepper on the report detail page